### PR TITLE
Add helper scripts and update help messages

### DIFF
--- a/1_start_react.sh
+++ b/1_start_react.sh
@@ -1,0 +1,6 @@
+TOP="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $TOP
+
+npm install
+react-native start

--- a/2_start_android_app.sh
+++ b/2_start_android_app.sh
@@ -1,0 +1,6 @@
+TOP="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $TOP
+
+npx react-native run-android
+

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -168,9 +168,9 @@ echo
 echo "  Run Android Studio then:"
 echo "    * Select 'Configure > AVD Manager' at the bottom"
 echo "    * Create and run a virtula device, such as a Pixel 2"
+echo
 echo "  In a terminal run:"
-echo "    $ cd ~/mobileapp/"
-echo "    $ react-native start"
+echo "      $ ~/mobileapp/1_start_react.sh"
 echo "  In a second terminal:"
-echo "    $ cd ~/mobileapp/"
-echo "    $ npx react-native run-android"
+echo "      $ ~/mobileapp/2_start_android_app.sh"
+echo "  You can edit files and repeat step 2 again as necessary to debug."


### PR DESCRIPTION
Adds two scripts to make it easy to start the react system and (re)run
the application within the emulator.  Simply run:
  1_start_react.sh
To install packages and start the react ecosystem, then run
  2_start_android_app.sh
To launch the application within the Android emulator (launching the
emulator automatically if necessary).