### PR TITLE
Tweaking the Import functionality

### DIFF
--- a/app/helpers/GoogleData.js
+++ b/app/helpers/GoogleData.js
@@ -1,24 +1,24 @@
 /**
  * Import a Google JSon into the Database. 
  */
-import {GetStoreData, SetStoreData} from '../helpers/General';
+import { GetStoreData, SetStoreData } from '../helpers/General';
 
 function BuildLocalFormat(placeVisit) {
     return loc = {
-                latitude: (placeVisit.location.latitudeE7 * (10 ** -7) ),
-                longitude: (placeVisit.location.longitudeE7 * (10 ** -7) ),
-                time: placeVisit.duration.startTimestampMs 
-            };
+        latitude: (placeVisit.location.latitudeE7 * (10 ** -7)),
+        longitude: (placeVisit.location.longitudeE7 * (10 ** -7)),
+        time: placeVisit.duration.startTimestampMs
+    };
 }
 
 function LocationExists(localDataJSON, loc) {
     var wasImportedBefore = false;
 
-    for (var index = 0; index < locationData.length; ++index) {
-        var storedLoc = locationData[index];
-        if(storedLoc.latitude == loc.latitude
-        && storedLoc.longitude == loc.longitude
-        && storedLoc.time == loc.time){
+    for (var index = 0; index < localDataJSON.length; ++index) {
+        var storedLoc = localDataJSON[index];
+        if (storedLoc.latitude == loc.latitude &&
+            storedLoc.longitude == loc.longitude &&
+            storedLoc.time == loc.time) {
             wasImportedBefore = true;
             break;
         }
@@ -30,14 +30,14 @@ function LocationExists(localDataJSON, loc) {
 function InsertIfNew(localDataJSON, loc) {
     if (!LocationExists(localDataJSON, loc)) {
         console.log("Importing", loc);
-        locationData.push(loc);
+        localDataJSON.push(loc);
     } else {
-        console.log("Existing", loc, locationData.indexOf(loc));
+        console.log("Existing", loc, localDataJSON.indexOf(loc));
     }
 }
 
-function Merge(localDataJSON, googleDataJSON) { 
-    googleDataJSON.timelineObjects.map(function(data, index){ 
+function Merge(localDataJSON, googleDataJSON) {
+    googleDataJSON.timelineObjects.map(function (data, index) {
         // Only import visited places, not paths for now
         if (data.placeVisit) {
             var loc = BuildLocalFormat(data.placeVisit);
@@ -48,18 +48,18 @@ function Merge(localDataJSON, googleDataJSON) {
 
 export async function MergeJSONWithLocalData(googleDataJSON) {
     GetStoreData('LOCATION_DATA')
-    .then(locationArray => {
-        var locationData;
+        .then(locationArray => {
+            var locationData;
 
-        if (locationArray !== null) {
-            locationData = JSON.parse(locationArray);
-        } else {
-            locationData = [];
-        }
+            if (locationArray !== null) {
+                locationData = JSON.parse(locationArray);
+            } else {
+                locationData = [];
+            }
 
-        Merge(locationData, googleDataJSON);       
+            Merge(locationData, googleDataJSON);
 
-        console.log("Saving on array");
-        SetStoreData('LOCATION_DATA', locationData);
-    });
+            console.log("Saving on array");
+            SetStoreData('LOCATION_DATA', locationData);
+        });
 }


### PR DESCRIPTION
Fix several crashes due to renamed variable

It looks like the code got refactored and not all variables were renamed
during that, leading to some exceptions during import.  Just renamed vars
as appropriate.