### PR TITLE
Bugfix for v0.5

### DIFF
--- a/ios/PrivateKit.xcodeproj/project.pbxproj
+++ b/ios/PrivateKit.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 			baseConfigurationReference = 71D1C872DB0CCC3BBC3D907E /* Pods-PrivateKit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 5;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = A35W4MM59Y;
 				INFOPLIST_FILE = PrivateKit/Info.plist;
@@ -486,7 +486,7 @@
 			baseConfigurationReference = 9440D638E4331481079AE235 /* Pods-PrivateKit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = A35W4MM59Y;
 				INFOPLIST_FILE = PrivateKit/Info.plist;

--- a/ios/PrivateKit/Info.plist
+++ b/ios/PrivateKit/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "privatekit",
-  "version": "0.5",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
1. Package.json format must follow 0.0.0 version names. 
2. Version ID for the AppleStore and Android Stores are now the same. 