### PR TITLE
Add point count info, assists in debugging

### DIFF
--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -5,6 +5,7 @@ import {
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
 
 var instanceCount = 0
+var lastPointCount = 0;
 
 export default class LocationServices {
     static start() {
@@ -61,7 +62,8 @@ export default class LocationServices {
                     }
 
                     locationData.push(location);
-                    console.log('[GPS] Saving point:', locationData.length);
+                    lastPointCount = locationData.length;
+                    console.log('[GPS] Saving point:', lastPointCount);
 
                     SetStoreData('LOCATION_DATA', locationData);
                 });
@@ -100,14 +102,14 @@ export default class LocationServices {
                 // we need to set delay or otherwise alert may not be shown
                 setTimeout(() =>
                     Alert.alert('App requires location tracking permission', 'Would you like to open app settings?', [{
-                            text: 'Yes',
-                            onPress: () => BackgroundGeolocation.showAppSettings()
-                        },
-                        {
-                            text: 'No',
-                            onPress: () => console.log('No Pressed'),
-                            style: 'cancel'
-                        }
+                        text: 'Yes',
+                        onPress: () => BackgroundGeolocation.showAppSettings()
+                    },
+                    {
+                        text: 'No',
+                        onPress: () => console.log('No Pressed'),
+                        style: 'cancel'
+                    }
                     ]), 1000);
             }
         });
@@ -150,6 +152,11 @@ export default class LocationServices {
         // you can also just start without checking for status
         // BackgroundGeolocation.start();
     }
+
+    static getPointCount() {
+        return lastPointCount;
+    }
+
     static stop() {
         // unregister all event listeners
         BackgroundGeolocation.removeAllListeners();

--- a/app/views/Export.js
+++ b/app/views/Export.js
@@ -1,4 +1,6 @@
-import React, { Component } from 'react';
+import React, {
+    Component
+} from 'react';
 import {
     SafeAreaView,
     StyleSheet,
@@ -13,9 +15,12 @@ import {
 import colors from "../constants/colors";
 import WebView from 'react-native-webview';
 import Button from "../components/Button";
-import { GetStoreData } from '../helpers/General';
+import {
+    GetStoreData
+} from '../helpers/General';
 import Share from 'react-native-share';
 import RNFetchBlob from 'rn-fetch-blob';
+import LocationServices from '../services/LocationService';
 
 const base64 = RNFetchBlob.base64
 
@@ -29,18 +34,18 @@ class ExportScreen extends Component {
     }
 
     onShare = async () => {
-            try {
-                const locationArray = await GetStoreData('LOCATION_DATA');
-                var locationData;
+        try {
+            const locationArray = await GetStoreData('LOCATION_DATA');
+            var locationData;
 
-                if (locationArray !== null) {
-                    locationData = JSON.parse(locationArray);
-                } else {
-                    locationData = [];
-                }
+            if (locationArray !== null) {
+                locationData = JSON.parse(locationArray);
+            } else {
+                locationData = [];
+            }
 
-                b64Data = base64.encode(JSON.stringify(locationData));
-                Share.open({
+            b64Data = base64.encode(JSON.stringify(locationData));
+            Share.open({
                     url: "data:string/txt;base64," + b64Data
                 }).then(res => {
                     console.log(res);
@@ -48,14 +53,15 @@ class ExportScreen extends Component {
                 .catch(err => {
                     console.log(err.message, err.code);
                 })
-            } catch (error) {
-                console.log(error.message);
+        } catch (error) {
+            console.log(error.message);
         }
     };
 
     backToMain() {
         this.props.navigation.navigate('LocationTrackingScreen', {})
     }
+
 
     render() {
 
@@ -73,6 +79,7 @@ class ExportScreen extends Component {
                     <View style={styles.block}>
                         <Button onPress={this.onShare} title="Share" />
                     </View>
+                    <Text style={styles.mainText}>Points to be shared: { LocationServices.getPointCount() }</Text>
                 </View>
 
             </SafeAreaView>
@@ -116,6 +123,13 @@ const styles = StyleSheet.create({
     },
     mainText: {
         fontSize: 18,
+        lineHeight: 24,
+        fontWeight: '400',
+        textAlignVertical: 'center',
+        padding: 20,
+    },
+    smallText: {
+        fontSize: 10,
         lineHeight: 24,
         fontWeight: '400',
         textAlignVertical: 'center',


### PR DESCRIPTION
Now the Export screen shows a count of points to be exported.  This is
provides minimal information for debugging and to let the user understand
that something is happening in the background.

 ### Testing Notes ###
Go to the Export screen.  A count of saved data points should be visible.
If you wait 5 minutes and go back to Export, it should be one greater.

 ### Fixed Issues ###
Related to #4