### PR TITLE
Add 'yarn' support when found

### DIFF
--- a/1_start_react.sh
+++ b/1_start_react.sh
@@ -2,5 +2,16 @@ TOP="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $TOP
 
-npm install
+function found_exe() {
+    hash "$1" 2>/dev/null
+}
+
+if found_exe yarn ; then
+    yarn install
+elif found_exe npm ; then
+    npm install
+else
+    echo "Unable to find either 'npm' or 'yarn'"
+fi
+
 react-native start


### PR DESCRIPTION
Several people have said that 'yarn' works much better than 'npm' (especially
on a Mac), so I'm making it the default if found.  If not, the script will
still attempt to run 'npm.


 ### Testing Notes ###
Start the environments using the: `./1_start_react.sh` command