### PR TITLE
Add missing notifications for Location Services

### DIFF
--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -73,13 +73,13 @@ export default class LocationServices {
             locationProvider: BackgroundGeolocation.ACTIVITY_PROVIDER,
 
             // DEBUG: Use these to get a faster output
-            interval: 2000,
-            fastestInterval: 2000, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
-            activitiesInterval: 2000,
+                /*interval: 2000,
+                fastestInterval: 2000, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
+                activitiesInterval: 2000,*/
 
-            //interval: 20000,
-            //fastestInterval: 60000 * 5, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
-            //activitiesInterval: 20000,
+            interval: 20000,
+            fastestInterval: 60000 * 5, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
+            activitiesInterval: 20000,
 
             stopOnStillActivity: false,
             postTemplate: {

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -3,6 +3,7 @@ import {
     SetStoreData
 } from '../helpers/General';
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
+import { Alert } from 'react-native';
 
 var instanceCount = 0;
 var lastPointCount = 0;
@@ -64,21 +65,21 @@ export default class LocationServices {
             desiredAccuracy: BackgroundGeolocation.HIGH_ACCURACY,
             stationaryRadius: 50,
             distanceFilter: 50,
-            notificationTitle: 'PrivateKit Enabled',
-            notificationText: 'PrivateKit is recording path information on this device.',
+            notificationTitle: 'Private Kit Enabled',
+            notificationText: 'Private Kit is securely storing your GPS coordinates once every five minutes on this device.',
             debug: false,    // when true, it beeps every time a loc is read
             startOnBoot: false,
             stopOnTerminate: false,
             locationProvider: BackgroundGeolocation.ACTIVITY_PROVIDER,
 
             // DEBUG: Use these to get a faster output
-            //            interval: 2000,
-            //            fastestInterval: 2000, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
-            //            activitiesInterval: 2000,
+            interval: 2000,
+            fastestInterval: 2000, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
+            activitiesInterval: 2000,
 
-            interval: 20000,
-            fastestInterval: 60000 * 5, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
-            activitiesInterval: 20000,
+            //interval: 20000,
+            //fastestInterval: 60000 * 5, // Time (in milliseconds) between location information polls.  E.g. 60000*5 = 5 minutes
+            //activitiesInterval: 20000,
 
             stopOnStillActivity: false,
             postTemplate: {
@@ -120,7 +121,7 @@ export default class LocationServices {
         BackgroundGeolocation.on('stationary', (stationaryLocation) => {
             // handle stationary locations here
             // Actions.sendLocation(stationaryLocation);
-           BackgroundGeolocation.startTask(taskKey => {
+            BackgroundGeolocation.startTask(taskKey => {
                 // execute long running task
                 // eg. ajax post location
                 // IMPORTANT: task has to be ended by endTask
@@ -144,10 +145,11 @@ export default class LocationServices {
 
         BackgroundGeolocation.on('authorization', (status) => {
             console.log('[INFO] BackgroundGeolocation authorization status: ' + status);
+
             if (status !== BackgroundGeolocation.AUTHORIZED) {
                 // we need to set delay or otherwise alert may not be shown
                 setTimeout(() =>
-                    Alert.alert('App requires location tracking permission', 'Would you like to open app settings?', [{
+                    Alert.alert('Private Kit requires access to location information', 'Would you like to open app settings?', [{
                         text: 'Yes',
                         onPress: () => BackgroundGeolocation.showAppSettings()
                     },
@@ -157,6 +159,12 @@ export default class LocationServices {
                         style: 'cancel'
                     }
                     ]), 1000);
+            }
+            else {
+                BackgroundGeolocation.start(); //triggers start on start event
+
+                // TODO: We reach this point on Android when location services are toggled off/on.
+                //       When this fires, check if they are off and show a Notification in the tray
             }
         });
 
@@ -195,10 +203,39 @@ export default class LocationServices {
             console.log('[INFO] BackgroundGeolocation services enabled', status.locationServicesEnabled);
             console.log('[INFO] BackgroundGeolocation auth status: ' + status.authorization);
 
-            // you don't need to check status before start (this is just the example)
-            if (!status.isRunning) {
-                BackgroundGeolocation.start(); //triggers start on start event
+            BackgroundGeolocation.start(); //triggers start on start event
+
+            if (!status.locationServicesEnabled) {
+                // we need to set delay or otherwise alert may not be shown
+                setTimeout(() =>
+                    Alert.alert('Private Kit requires location services to be enabled', 'Would you like to open location settings?', [{
+                        text: 'Yes',
+                        onPress: () => BackgroundGeolocation.showLocationSettings()
+                    },
+                    {
+                        text: 'No',
+                        onPress: () => console.log('No Pressed'),
+                        style: 'cancel'
+                    }
+                    ]), 1000);
             }
+            else if (!status.authorization) {
+                // we need to set delay or otherwise alert may not be shown
+                setTimeout(() =>
+                    Alert.alert('Private Kit requires access to location information', 'Would you like to open app settings?', [{
+                        text: 'Yes',
+                        onPress: () => BackgroundGeolocation.showAppSettings()
+                    },
+                    {
+                        text: 'No',
+                        onPress: () => console.log('No Pressed'),
+                        style: 'cancel'
+                    }
+                    ]), 1000);
+            }
+            else if (!status.isRunning) {
+            }
+
         });
 
         // you can also just start without checking for status

--- a/app/views/Export.js
+++ b/app/views/Export.js
@@ -45,10 +45,10 @@ class ExportScreen extends Component {
 
             b64Data = base64.encode(JSON.stringify(locationData));
             Share.open({
-                    url: "data:string/txt;base64," + b64Data
-                }).then(res => {
-                    console.log(res);
-                })
+                url: "data:string/txt;base64," + b64Data
+            }).then(res => {
+                console.log(res);
+            })
                 .catch(err => {
                     console.log(err.message, err.code);
                 })
@@ -64,57 +64,24 @@ class ExportScreen extends Component {
 
     render() {
 
-        return ( <
-            SafeAreaView style = {
-                styles.container
-            } >
-            <
-            View style = {
-                styles.headerContainer
-            } >
-            <
-            Text onPress = {
-                () => this.backToMain()
-            }
-            style = {
-                styles.backArrow
-            } > & #8249; </Text>
-                    <Text style= {
-                styles.sectionDescription
-            } > Export < /Text> <
-            /View>
+        return (
+            <SafeAreaView style={styles.container}>
+                <View style={styles.headerContainer}>
+                    <Text onPress={() => this.backToMain()} style={styles.backArrow}> &#8249; </Text>
+                    <Text style={styles.sectionDescription}>Export</Text>
+                </View>
 
 
-            <
-            View style = {
-                styles.main
-            } >
-            <
-            Text style = {
-                styles.mainText
-            } > You can share you location trail with anyone using the Share button below.Once you press the button it will ask you with whom and how you want to share it. < /Text> <
-            Text style = {
-                styles.mainText
-            } > Location is shared as a simple list of times and coordinates, no other identifying information. < /Text> <
-            View style = {
-                styles.block
-            } >
-            <
-            Button onPress = {
-                this.onShare
-            }
-            title = "Share" / >
-            <
-            /View> <
-            Text style = {
-                styles.mainText
-            } > Points to be shared: {
-                LocationServices.getPointCount()
-            } < /Text> <
-            /View>
+                <View style={styles.main}>
+                    <Text style={styles.mainText}>You can share you location trail with anyone using the Share button below.  Once you press the button it will ask you with whom and how you want to share it.</Text>
+                    <Text style={styles.mainText}>Location is shared as a simple list of times and coordinates, no other identifying information.</Text>
+                    <View style={styles.block}>
+                        <Button onPress={this.onShare} title="Share" />
+                    </View>
+                    <Text style={styles.mainText}>Points to be shared: {LocationServices.getPointCount()}</Text>
+                </View>
 
-            <
-            /SafeAreaView>
+            </SafeAreaView>
         )
     }
 }

--- a/app/views/Export.js
+++ b/app/views/Export.js
@@ -8,7 +8,6 @@ import {
     Linking,
     View,
     Text,
-    Alert,
     Image
 } from 'react-native';
 
@@ -65,24 +64,57 @@ class ExportScreen extends Component {
 
     render() {
 
-        return (
-            <SafeAreaView style={styles.container}>
-                <View style={styles.headerContainer}>
-                    <Text onPress={() => this.backToMain()} style={styles.backArrow}> &#8249; </Text>
-                    <Text style={styles.sectionDescription}>Export</Text>
-                </View>
+        return ( <
+            SafeAreaView style = {
+                styles.container
+            } >
+            <
+            View style = {
+                styles.headerContainer
+            } >
+            <
+            Text onPress = {
+                () => this.backToMain()
+            }
+            style = {
+                styles.backArrow
+            } > & #8249; </Text>
+                    <Text style= {
+                styles.sectionDescription
+            } > Export < /Text> <
+            /View>
 
 
-                <View style={styles.main}>
-                    <Text style={styles.mainText}>You can share you location trail with anyone using the Share button below.  Once you press the button it will ask you with whom and how you want to share it.</Text>
-                    <Text style={styles.mainText}>Location is shared as a simple list of times and coordinates, no other identifying information.</Text>
-                    <View style={styles.block}>
-                        <Button onPress={this.onShare} title="Share" />
-                    </View>
-                    <Text style={styles.mainText}>Points to be shared: { LocationServices.getPointCount() }</Text>
-                </View>
+            <
+            View style = {
+                styles.main
+            } >
+            <
+            Text style = {
+                styles.mainText
+            } > You can share you location trail with anyone using the Share button below.Once you press the button it will ask you with whom and how you want to share it. < /Text> <
+            Text style = {
+                styles.mainText
+            } > Location is shared as a simple list of times and coordinates, no other identifying information. < /Text> <
+            View style = {
+                styles.block
+            } >
+            <
+            Button onPress = {
+                this.onShare
+            }
+            title = "Share" / >
+            <
+            /View> <
+            Text style = {
+                styles.mainText
+            } > Points to be shared: {
+                LocationServices.getPointCount()
+            } < /Text> <
+            /View>
 
-            </SafeAreaView>
+            <
+            /SafeAreaView>
         )
     }
 }

--- a/app/views/Import.js
+++ b/app/views/Import.js
@@ -30,7 +30,7 @@ class ImportScreen extends Component {
 
     }
 
-    componentWillUnmount() {}
+    componentWillUnmount() { }
 
     backToMain() {
         this.props.navigation.navigate('LocationTrackingScreen', {})
@@ -38,69 +38,26 @@ class ImportScreen extends Component {
 
 
     render() {
-        return ( <
-            SafeAreaView style = {
-                styles.container
-            } >
-            <
-            View style = {
-                styles.headerContainer
-            } >
-            <
-            Text onPress = {
-                () => this.backToMain()
-            }
-            style = {
-                styles.backArrow
-            } > & #8249; </Text>
-                    <Text style= {
-                styles.sectionDescription
-            } > Import Locations < /Text> <
-            /View>
+        return (
+            <SafeAreaView style={styles.container}>
+                <View style={styles.headerContainer}>
+                    <Text onPress={() => this.backToMain()} style={styles.backArrow}> &#8249; </Text>
+                    <Text style={styles.sectionDescription}>Import Locations</Text>
+                </View>
 
-            <
-            View style = {
-                styles.main
-            } >
-            <
-            View style = {
-                styles.subHeaderTitle
-            } >
-            <
-            Text style = {
-                styles.sectionDescription,
-                {
-                    fontSize: 18,
-                    marginTop: 8
-                }
-            } > 1. Login to your Google Account and Download your Location History < /Text> <
-            Text style = {
-                styles.sectionDescription,
-                {
-                    fontSize: 18,
-                    marginTop: 8
-                }
-            } > 2. After downloaded, open this screen again.The data will
-            import automatically. < /Text> <
-            /View> <
-            View style = {
-                styles.web
-            } >
-            <
-            WebView source = {
-                {
-                    uri: 'https://takeout.google.com/settings/takeout/custom/location_history'
-                }
-            }
-            style = {
-                {
-                    marginTop: 15
-                }
-            }
-            /> <
-            /View> <
-            /View> <
-            /SafeAreaView>
+                <View style={styles.main}>
+                    <View style={styles.subHeaderTitle}>
+                        <Text style={styles.sectionDescription, { fontSize: 18, marginTop: 8 }}>1. Login to your Google Account and Download your Location History</Text>
+                        <Text style={styles.sectionDescription, { fontSize: 18, marginTop: 8 }}>2. After downloaded, open this screen again. The data will import automatically.</Text>
+                    </View>
+                    <View style={styles.web}>
+                        <WebView
+                            source={{ uri: 'https://takeout.google.com/settings/takeout/custom/location_history' }}
+                            style={{ marginTop: 15 }}
+                        />
+                    </View>
+                </View>
+            </SafeAreaView>
         )
     }
 }

--- a/app/views/Import.js
+++ b/app/views/Import.js
@@ -7,15 +7,16 @@ import {
     ScrollView,
     Linking,
     View,
-    Text,
-    Alert
+    Text
 } from 'react-native';
 
 import colors from "../constants/colors";
 import WebView from 'react-native-webview';
 import Button from "../components/Button";
 
-import {SearchAndImport} from '../helpers/GoogleTakeOutAutoImport';
+import {
+    SearchAndImport
+} from '../helpers/GoogleTakeOutAutoImport';
 
 class ImportScreen extends Component {
     constructor(props) {
@@ -29,8 +30,7 @@ class ImportScreen extends Component {
 
     }
 
-    componentWillUnmount() {
-    }
+    componentWillUnmount() {}
 
     backToMain() {
         this.props.navigation.navigate('LocationTrackingScreen', {})
@@ -38,26 +38,69 @@ class ImportScreen extends Component {
 
 
     render() {
-        return (
-            <SafeAreaView style={styles.container}>
-                <View style={styles.headerContainer}>
-                    <Text onPress={() => this.backToMain()} style={styles.backArrow}> &#8249; </Text>
-                    <Text style={styles.sectionDescription}>Import Locations</Text>
-                </View>
+        return ( <
+            SafeAreaView style = {
+                styles.container
+            } >
+            <
+            View style = {
+                styles.headerContainer
+            } >
+            <
+            Text onPress = {
+                () => this.backToMain()
+            }
+            style = {
+                styles.backArrow
+            } > & #8249; </Text>
+                    <Text style= {
+                styles.sectionDescription
+            } > Import Locations < /Text> <
+            /View>
 
-                <View style={styles.main}>
-                    <View style={styles.subHeaderTitle}>
-                        <Text style={styles.sectionDescription, { fontSize: 18, marginTop: 8}}>1. Login to your Google Account and Download your Location History</Text>
-                        <Text style={styles.sectionDescription, { fontSize: 18, marginTop: 8}}>2. After downloaded, open this screen again. The data will import automatically.</Text>
-                    </View>
-                    <View style={styles.web}>
-                        <WebView
-                            source= {{ uri: 'https://takeout.google.com/settings/takeout/custom/location_history' }}
-                            style= {{ marginTop: 15 }}
-                        />
-                    </View>
-                </View>
-            </SafeAreaView>
+            <
+            View style = {
+                styles.main
+            } >
+            <
+            View style = {
+                styles.subHeaderTitle
+            } >
+            <
+            Text style = {
+                styles.sectionDescription,
+                {
+                    fontSize: 18,
+                    marginTop: 8
+                }
+            } > 1. Login to your Google Account and Download your Location History < /Text> <
+            Text style = {
+                styles.sectionDescription,
+                {
+                    fontSize: 18,
+                    marginTop: 8
+                }
+            } > 2. After downloaded, open this screen again.The data will
+            import automatically. < /Text> <
+            /View> <
+            View style = {
+                styles.web
+            } >
+            <
+            WebView source = {
+                {
+                    uri: 'https://takeout.google.com/settings/takeout/custom/location_history'
+                }
+            }
+            style = {
+                {
+                    marginTop: 15
+                }
+            }
+            /> <
+            /View> <
+            /View> <
+            /SafeAreaView>
         )
     }
 }

--- a/app/views/News.js
+++ b/app/views/News.js
@@ -27,37 +27,17 @@ class NewsScreen extends Component {
 
 
     render() {
-        return ( <
-            SafeAreaView style = {
-                styles.container
-            } >
-            <
-            View style = {
-                styles.headerContainer
-            } >
-            <
-            Text onPress = {
-                () => this.backToMain()
-            }
-            style = {
-                styles.backArrow
-            } > & #8249; </Text>
-                    <Text style= {
-                styles.sectionDescription
-            } > Latest News < /Text> <
-            /View> <
-            WebView source = {
-                {
-                    uri: 'https://privatekit.mit.edu/views'
-                }
-            }
-            style = {
-                {
-                    marginTop: 15
-                }
-            }
-            /> <
-            /SafeAreaView>
+        return (
+            <SafeAreaView style={styles.container}>
+                <View style={styles.headerContainer}>
+                    <Text onPress={() => this.backToMain()} style={styles.backArrow}> &#8249; </Text>
+                    <Text style={styles.sectionDescription}>Latest News</Text>
+                </View>
+                <WebView
+                    source={{ uri: 'https://privatekit.mit.edu/views' }}
+                    style={{ marginTop: 15 }}
+                />
+            </SafeAreaView>
         )
     }
 }

--- a/app/views/News.js
+++ b/app/views/News.js
@@ -7,8 +7,7 @@ import {
     ScrollView,
     Linking,
     View,
-    Text,
-    Alert
+    Text
 } from 'react-native';
 
 import colors from "../constants/colors";
@@ -28,17 +27,37 @@ class NewsScreen extends Component {
 
 
     render() {
-        return (
-            <SafeAreaView style={styles.container}>
-                <View style={styles.headerContainer}>
-                    <Text onPress={() => this.backToMain()} style={styles.backArrow}> &#8249; </Text>
-                    <Text style={styles.sectionDescription}>Latest News</Text>
-                </View>
-                <WebView
-                    source= {{ uri: 'https://privatekit.mit.edu/views' }}
-                    style= {{ marginTop: 15}}
-                />
-            </SafeAreaView>
+        return ( <
+            SafeAreaView style = {
+                styles.container
+            } >
+            <
+            View style = {
+                styles.headerContainer
+            } >
+            <
+            Text onPress = {
+                () => this.backToMain()
+            }
+            style = {
+                styles.backArrow
+            } > & #8249; </Text>
+                    <Text style= {
+                styles.sectionDescription
+            } > Latest News < /Text> <
+            /View> <
+            WebView source = {
+                {
+                    uri: 'https://privatekit.mit.edu/views'
+                }
+            }
+            style = {
+                {
+                    marginTop: 15
+                }
+            }
+            /> <
+            /SafeAreaView>
         )
     }
 }


### PR DESCRIPTION
Several conditions cause Private Kit to stop failing when it cannot access
GPS info.  We should notify the user when this has happened.  That includes:
* The app doesn't have proper permissions
* The permissions have been revoked
* The location service has been shut down

Still to do is a notification to show the user that the background service
is not doing anything when the user turns off location services.

 ### Testing Notes ###
Toggle permissions and location services, go in and out of the app.  There
should be notification within the app whenever it cannot access things.

 ### Fixed Issues ###
Resolves #23, #17

Leaving #50 open until we add a Notification that pops up