### PR TITLE
Check for background geo authorization before updating state

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -16,6 +16,7 @@ import {
 } from 'react-native';
 import colors from "../constants/colors";
 import LocationServices from '../services/LocationService';
+import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
 import exportImage from './../assets/images/export.png';
 import news from './../assets/images/newspaper.png';
 
@@ -77,9 +78,22 @@ class LocationTracking extends Component {
         SetStoreData('PARTICIPATE', 'true').then(() =>
             LocationServices.start()
         );
-        this.setState({
-            isLogging:true
-        })
+
+        // Check and see if they actually authorized in the system dialog.
+        // If not, stop services and set the state to !isLogging
+        // Fixes tripleblindmarket/private-kit#129
+        BackgroundGeolocation.checkStatus(({ authorization }) => {
+            if (authorization === BackgroundGeolocation.AUTHORIZED) {
+                this.setState({
+                    isLogging:true
+                })
+            } else if (authorization === BackgroundGeolocation.NOT_AUTHORIZED) {
+                LocationServices.stop(this.props.navigation)
+                this.setState({
+                    isLogging:false
+                })
+            }
+        });
     }
 
     setOptOut =()=>{


### PR DESCRIPTION
Per #129 if you denied permission in the system dialog, we'd still update the button as if you had started logging. This fix creates the desired behavior, setting the state back to the way it was before you requested permission.
