### PR TITLE
Fix formatting in languages json due to merge

### DIFF
--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -67,8 +67,7 @@ i18next.init({
       translation: {
         label: mrlabels
       }
-    }
-  }
+    },
     nl: {
       translation: {
         label: nllabels,


### PR DESCRIPTION
This fixes a formatting issue due to a merge. Languages were added in multiple PRs and they didn't get merged together correctly.