### PR TITLE
Enhancing the License screen

### DIFF
--- a/app/assets/LICENSE.json
+++ b/app/assets/LICENSE.json
@@ -1,0 +1,6 @@
+{
+    "licenses": [{
+        "name": "Private Kit",
+        "text": "MIT License\n\nCopyright (c) 2020 TripleBlind, Inc\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+    }, ]
+}

--- a/app/views/Licenses.js
+++ b/app/views/Licenses.js
@@ -4,15 +4,19 @@ import {
   StyleSheet,
   View,
   Text,
+  Platform,
   Image,
   Dimensions,
   TouchableOpacity,
   BackHandler,
 } from 'react-native';
+import { WebView } from 'react-native-webview';
+import packageJson from '../../package.json';
 
 import colors from '../constants/colors';
 import backArrow from './../assets/images/backArrow.png';
 import languages from './../locales/languages';
+import licenses from './../assets/LICENSE.json';
 
 const width = Dimensions.get('window').width;
 
@@ -38,6 +42,25 @@ class LicensesScreen extends Component {
     BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);
   }
 
+  getLicenses() {
+    var result = '<html>';
+    result +=
+      '<style>  html, body { font-size: 40px; margin: 0; padding: 0; } </style>';
+    result += '<body>';
+
+    for (var i = 0; i < licenses.licenses.length; i++) {
+      var element = licenses.licenses[i];
+
+      result += '<B>' + element.name + '</B><P>';
+      result += element.text.replace(/\n/g, '<br/>');
+      result += '<hr/>';
+    }
+    result += '</body></html>';
+    console.log('Here 2!:', result);
+
+    return result;
+  }
+
   render() {
     return (
       <SafeAreaView style={styles.container}>
@@ -51,10 +74,40 @@ class LicensesScreen extends Component {
         </View>
 
         <View style={styles.main}>
-          <Text style={styles.sectionDescription}>
-            {/* This screen is a placeholder for complete license content, or a link */}
-            {languages.t('label.license_placeholder')}
+          <Text style={styles.headerTitle}>
+            {languages.t('label.private_kit')}
           </Text>
+
+          <View style={styles.row}>
+            <Text style={styles.valueName}>Version: </Text>
+            <Text style={styles.value}>{packageJson.version}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.valueName}>OS: </Text>
+            <Text style={styles.value}>
+              {Platform.OS + ' v' + Platform.Version}
+            </Text>
+          </View>
+
+          <View style={styles.row}>
+            <Text style={styles.valueName}>Screen Resolution: </Text>
+            <Text style={styles.value}>
+              {' '}
+              {Math.trunc(Dimensions.get('screen').width) +
+                ' x ' +
+                Math.trunc(Dimensions.get('screen').height)}
+            </Text>
+          </View>
+        </View>
+
+        <View style={{ flex: 4, paddingLeft: 20, paddingRight: 15 }}>
+          <WebView
+            originWhitelist={['*']}
+            source={{
+              html: this.getLicenses(),
+            }}
+            style={{ marginTop: 15 }}
+          />
         </View>
       </SafeAreaView>
     );
@@ -69,12 +122,6 @@ const styles = StyleSheet.create({
     color: colors.PRIMARY_TEXT,
     backgroundColor: colors.WHITE,
   },
-  subHeaderTitle: {
-    textAlign: 'center',
-    fontWeight: 'bold',
-    fontSize: 22,
-    padding: 5,
-  },
   main: {
     flex: 1,
     flexDirection: 'column',
@@ -84,6 +131,21 @@ const styles = StyleSheet.create({
     width: '96%',
     alignSelf: 'center',
   },
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    color: colors.PRIMARY_TEXT,
+    backgroundColor: colors.WHITE,
+  },
+  valueName: {
+    fontSize: 20,
+    fontWeight: '800',
+  },
+  value: {
+    fontSize: 20,
+    fontWeight: '200',
+  },
+
   buttonTouchable: {
     borderRadius: 12,
     backgroundColor: '#665eff',
@@ -140,6 +202,7 @@ const styles = StyleSheet.create({
     fontSize: 16,
     lineHeight: 24,
     marginTop: 12,
+    overflow: 'scroll',
     fontFamily: 'OpenSans-Regular',
   },
 });

--- a/app/views/Licenses.js
+++ b/app/views/Licenses.js
@@ -56,7 +56,6 @@ class LicensesScreen extends Component {
       result += '<hr/>';
     }
     result += '</body></html>';
-    console.log('Here 2!:', result);
 
     return result;
   }


### PR DESCRIPTION
The kebab > License screen now is a combination of an About screen
and a license.  The top of the screen shows information about the current
app version, OS version on which it is running and screen resolution info.

Below that is license test.  It pulls from the new LICENSE.json in the
assets directory.  It will render an array of licenses, so later we can
add the licenses of components we use in addition to the main Private
Kit MIT license.

 ### Testing Notes ###
Go to kebab > Licenses.  You should see live info about your system.

 ### Environment Notes ###
This adds a asset/LICENSE.md, and it also imports the package.json.
I think this should build naturally, but need to test.