### PR TITLE
Add custom map styles to the Overlap map

### DIFF
--- a/app/views/Overlap.js
+++ b/app/views/Overlap.js
@@ -312,7 +312,8 @@ class OverlapScreen extends Component {
         <MapView
           provider={PROVIDER_GOOGLE}
           style={styles.main}
-          initialRegion={this.state.initialRegion}>
+          initialRegion={this.state.initialRegion}
+          customMapStyle={customMapStyles}>
           {this.state.markers.map(marker => (
             <Marker
               coordinate={marker.coordinate}
@@ -459,5 +460,107 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
   },
 });
+
+const customMapStyles = [
+  {
+    featureType: 'all',
+    elementType: 'all',
+    stylers: [
+      {
+        saturation: '32',
+      },
+      {
+        lightness: '-3',
+      },
+      {
+        visibility: 'on',
+      },
+      {
+        weight: '1.18',
+      },
+    ],
+  },
+  {
+    featureType: 'administrative',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'landscape',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'landscape.man_made',
+    elementType: 'all',
+    stylers: [
+      {
+        saturation: '-70',
+      },
+      {
+        lightness: '14',
+      },
+    ],
+  },
+  {
+    featureType: 'poi',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'road',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'transit',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'water',
+    elementType: 'all',
+    stylers: [
+      {
+        saturation: '100',
+      },
+      {
+        lightness: '-14',
+      },
+    ],
+  },
+  {
+    featureType: 'water',
+    elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+      {
+        lightness: '12',
+      },
+    ],
+  },
+];
 
 export default OverlapScreen;


### PR DESCRIPTION
The custom styles were taken from https://snazzymaps.com/style/127403/no-label-bright-colors
which was linked to in the issue #243

Closes #243