### PR TITLE
Cleanup react warnings on the Overlap screen

### DIFF
--- a/app/views/Overlap.js
+++ b/app/views/Overlap.js
@@ -96,12 +96,9 @@ class OverlapScreen extends Component {
   setMarkers = async () => {
     GetStoreData('LOCATION_DATA').then(locationArrayString => {
       var locationArray = JSON.parse(locationArrayString);
-      if (locationArray === null) {
-        console.log(locationArray);
-      } else {
+      if (locationArray !== null) {
         var markers = [];
         for (var i = 0; i < locationArray.length - 1; i += 1) {
-          console.log(i);
           const coord = locationArray[i];
           const marker = {
             coordinate: {
@@ -247,6 +244,8 @@ class OverlapScreen extends Component {
       const dist_threshold = 2000; //In KMs
       const latestLat = this.state.initialRegion.latitude;
       const latestLong = this.state.initialRegion.longitude;
+      const index = 0;
+
       for (const key in records) {
         const latitude = parseFloat(key.split('|')[0]);
         const longitude = parseFloat(key.split('|')[1]);
@@ -256,7 +255,8 @@ class OverlapScreen extends Component {
           !isNaN(longitude) &&
           distance(latestLat, latestLong, latitude, longitude) < dist_threshold
         ) {
-          var circle = {
+          const circle = {
+            key: `${index}-${latitude}-${longitude}-${count}`,
             center: {
               latitude: latitude,
               longitude: longitude,
@@ -264,14 +264,13 @@ class OverlapScreen extends Component {
             radius: 50 * count,
           };
           circles.push(circle);
-          console.log(count);
         }
+        index += 1;
       }
       console.log(circles.length, 'points found');
       this.setState({
-        circles: circles,
+        circles,
       });
-      console.log('done!');
     } catch (e) {
       console.log(e);
     }
@@ -311,11 +310,12 @@ class OverlapScreen extends Component {
         </View>
         <MapView
           provider={PROVIDER_GOOGLE}
-          style={styles.main}
+          style={styles.map}
           initialRegion={this.state.initialRegion}
           customMapStyle={customMapStyles}>
           {this.state.markers.map(marker => (
             <Marker
+              key={marker.key}
               coordinate={marker.coordinate}
               title={marker.title}
               description={marker.description}
@@ -324,6 +324,7 @@ class OverlapScreen extends Component {
           ))}
           {this.state.circles.map(circle => (
             <CustomCircle
+              key={circle.key}
               center={circle.center}
               radius={circle.radius}
               fillColor='rgba(163, 47, 163, 0.3)'
@@ -393,6 +394,13 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     textAlignVertical: 'top',
     // alignItems: 'center',
+    padding: 15,
+    width: '96%',
+    alignSelf: 'center',
+  },
+  map: {
+    flex: 1,
+    flexDirection: 'column',
     padding: 15,
     width: '96%',
     alignSelf: 'center',


### PR DESCRIPTION
There were some react warnings being thrown due to the key
prop not being set on some components. This sets the key prop
on the components that are added in a loop.

Fixes the style warning due to passing an invalid style property to
the map view.

### Screenshot of warnings

![image](https://user-images.githubusercontent.com/471801/77797817-bc24cb80-703f-11ea-8585-9c40b6ea6cf8.png)
