### PR TITLE
[Dev setup] Mac fixes, and clearer instructions

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -218,10 +218,10 @@ echo "Try this to get started:"
 echo
 echo "  Run Android Studio then:"
 echo "    * Select 'Configure > AVD Manager' at the bottom"
-echo "    * Create and run a virtula device, such as a Pixel 2"
+echo "    * Create and run a virtual device, such as a Pixel 2"
 echo
 echo "  In a terminal run:"
-echo "      $ ~/mobileapp/1_start_react.sh"
+echo "      $ ./1_start_react.sh"
 echo "  In a second terminal:"
-echo "      $ ~/mobileapp/2_start_android_app.sh"
+echo "      $ ./2_start_android_app.sh"
 echo "  You can edit files and repeat step 2 again as necessary to debug."

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -136,18 +136,13 @@ fi
 # Need Android Studio (interactive for now)
 if ! found_exe android-studio ; then
 
-    echo "Building for Android requires Android Studio.  Would you like to install it?"
+    echo "Building for Android requires Android Studio.  Would you like to see Android Studio instructions?"
     if get_YN "" "" "Skipping" ; then
 
         echo "${YELLOW}Install Android Studio from https://developer.android.com/studio/index.html${RESET}"
         echo "You can also use your software store to install."
         echo "${BLUE}Press RETURN after completing this step.${RESET}"
         read
-
-        if ! found_exe android-studio ; then
-            echo "Not able to find Android Studio still, aborting."
-            exit 1
-        fi
 
         # Need Android 9 (Pie) SDK
         echo "We need the Android 9 (Pie) SDK.  Please follow these steps:"
@@ -166,16 +161,23 @@ if ! found_exe android-studio ; then
         echo ""
         echo "${BLUE}Press RETURN after completing these steps.${RESET}"
 
-        echo "${BLUE}Adding environment variables via ~/.profile_mobileapp${RESET}"
+        echo "${BLUE}Adding environment variables to ${YELLOW}~/.profile_mobileapp${RESET}"
 
-        echo "# ==== Added by PrivateKit/mobileapp's dev_setup.sh ====" >> ~/.profile_mobileapp
-        echo "export ANDROID_HOME=\$HOME/Android/Sdk" >> ~/.profile_mobileapp
-        echo "export PATH=\$PATH:\$ANDROID_HOME/emulator" >> ~/.profile_mobileapp
-        echo "export PATH=\$PATH:\$ANDROID_HOME/tools" >> ~/.profile_mobileapp
-        echo "export PATH=\$PATH:\$ANDROID_HOME/tools/bin" >> ~/.profile_mobileapp
-        echo "export PATH=\$PATH:\$ANDROID_HOME/platform-tools" >> ~/.profile_mobileapp
+        echo "# ==== Added by PrivateKit/mobileapp's dev_setup.sh ====" > ~/.profile_mobileapp
+        if [[ "$OSTYPE" == "darwin"* ]] ; then
+            echo "export ANDROID_SDK_ROOT=\$HOME/Library/Android/sdk" >> ~/.profile_mobileapp
+        else
+            echo "export ANDROID_SDK_ROOT=\$HOME/Android/Sdk" >> ~/.profile_mobileapp
+        fi
+        echo "export PATH=\$PATH:\$ANDROID_SDK_ROOT/emulator" >> ~/.profile_mobileapp
+        echo "export PATH=\$PATH:\$ANDROID_SDK_ROOT/tools" >> ~/.profile_mobileapp
+        echo "export PATH=\$PATH:\$ANDROID_SDK_ROOT/tools/bin" >> ~/.profile_mobileapp
+        echo "export PATH=\$PATH:\$ANDROID_SDK_ROOT/platform-tools" >> ~/.profile_mobileapp
 
-        echo "source ~/.profile_mobileapp" >> ~/.profile
+        echo "Would you like to source environment variables in ${YELLOW}~/.profile${RESET}?"
+        if get_YN "" "" "Skipping" ; then
+            echo "source ~/.profile_mobileapp" >> ~/.profile
+        fi
 
         echo "${GREEN}Android Studio installed!${RESET}"
         echo "${YELLOW}You will need to start a new terminal session for this to apply.${RESET}"
@@ -215,6 +217,9 @@ echo
 echo "  Run Android Studio then:"
 echo "    * Select 'Configure > AVD Manager' at the bottom"
 echo "    * Create and run a virtual device, such as a Pixel 2"
+echo
+echo "  Configure Android environment in your ~/.bashrc (or equivalent):"
+echo "    source ~/.profile_mobileapp"
 echo
 echo "  In a terminal run:"
 echo "      $ ./1_start_react.sh"

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -88,13 +88,28 @@ function get_YN() {  # helper function for interactive questions
 ###############################################################################
 ## Main setup
 
+if [[ "$OSTYPE" == "darwin"* ]] ; then
+    if ! found_exe brew ; then
+        echo "${YELLOW}Homebrew is required to install dependencies: https://docs.brew.sh/Installation${RESET}"
+        exit 1
+    fi
+fi
+
 # Need Node.js (8.3 or newer)
 #TODO: Check nodejs version? (nodejs --version)
 if ! found_exe nodejs ; then
-    echo "${BLUE}Installing Node.js v13.x...${RESET}"
-    curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
-    sudo apt-get install -y nodejs
-    echo "${GREEN}Node.js installed!${RESET}"
+    if ! found_exe node ; then
+        echo "${BLUE}Installing Node.js v13.x...${RESET}"
+        if [[ "$OSTYPE" == "darwin"* ]] ; then
+            brew install node
+        else
+            sudo apt-get install -y nodejs
+            if ! found_exe nodejs ; then
+              curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+            fi
+        fi
+        echo "${GREEN}Node.js installed!${RESET}"
+    fi
 fi
 
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -169,38 +169,19 @@ fi
 
 
 # Need Watchman v4.9+ (watchman --version)
-if ! found_exe watchman ; then
-    echo "${BLUE}Installing Watchman, this is going to take a little bit...${RESET}"
-    echo "${YELLOW}TODO: Watchman setup...is it necessary?${RESET}"
+if [[ "$OSTYPE" == "darwin"* ]] ; then
+    if ! found_exe watchman ; then
+        echo "Updating homebrew..."
+        brew update && brew upgrade
+        echo "${BLUE}Installing Watchman, this is going to take a little bit...${RESET}"
+        brew install watchman
 
-#    if ! found_exe brew ; then
-#        # Use the linuxbrew system to install 'watchman'
-#        sudo apt-get install linuxbrew-wrapper
-#        export PATH="$HOME/.linuxbrew/bin:$PATH"
-#        export MANPATH="$HOME/.linuxbrew/share/man:$MANPATH"
-#        export INFOPATH="$HOME/.linuxbrew/share/info:$INFOPATH"
-#    fi
-#    brew update && brew upgrade
-#
-#    brew install --HEAD watchman
-#
-#    # Then increase the amount of inotify user instances, user watches and queued events
-#    echo fs.inotify.max_user_instances=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-#    echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-#    echo fs.inotify.max_queued_events=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-
-
-# SSP: This is the source-code version that didn't quite work
-#    pushd ~
-#    git clone https://github.com/facebook/watchman.git
-#    cd watchman/
-#    git checkout v4.9.0
-#    sudo apt-get install -y autoconf automake build-essential python-dev libtool m4
-#    ./autogen.sh
-#    ./configure --enable-lenient
-#    make
-#    sudo make install
-#    popd # Return to where we were
+        # TODO: Is this needed? on which environments?
+        # Then increase the amount of inotify user instances, user watches and queued events
+        # echo fs.inotify.max_user_instances=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+        # echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+        # echo fs.inotify.max_queued_events=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+    fi
 fi
 
 


### PR DESCRIPTION
* Enforce homebrew on Mac
* Install Node on mac, if not there
* Only try one method of installing node on linux
  * try apt-get install, if unsuccessful, use `curl | sh` method
* Remove `~/mobileapp` refs
* Don't bail out on android studio detection on mac, it's still important to create the environment vars
* Always create env vars file, use Linux and MacOS well known SDK paths
* Use `ANDROID_SDK_ROOT` over `ANDROID_HOME`, the latter is deprecated
* Add instructions on sourcing the env config file
* Install watchman on Mac, without it, it fails when booting up the Android app with `fsevents is not a constructor`: https://github.com/facebook/create-react-app/issues/7366