### PR TITLE
Reworking the UI for exposure notifications

### DIFF
--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -11,6 +11,8 @@ const colors = {
   VIOLET: '#6C3794',
   RED: '#e74c3c',
   ORANGE: '#e67e22',
+  BROWN: 'brown',
+  YELLOW: '#FFFF33',
 
   REG_BUTTON: '#428AF8',
   POS_BUTTON: '#32A852',

--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -9,10 +9,12 @@ const colors = {
   PRIMARY_TEXT: '#000',
   GREEN: '#32A852',
   VIOLET: '#6C3794',
-  RED: '#e74c3c',
-  ORANGE: '#e67e22',
-  BROWN: 'brown',
-  YELLOW: '#FFFF33',
+
+  // For notifications
+  HIGHEST_RISK: '#e74c3c',
+  MIDDLE_RISK: '#e67e22',
+  LOWER_RISK: '#FFFF33',
+  LOWEST_RISK: 'brown',
 
   REG_BUTTON: '#428AF8',
   POS_BUTTON: '#32A852',

--- a/app/locales/en/notification.json
+++ b/app/locales/en/notification.json
@@ -1,8 +1,14 @@
 {
-    "notification_main_text": "Check your Intersection day wise",
-    "notification_title": "Analyze your intersection",
-    "notification_data_not_available": "\n\nYou do not have any trails downloaded!\n\n",
-    "notification_warning_text": "You can press the following button to generate random intersections.\nWARNING: These are simulated intersections not real",
-    "notification_random_data_button": "Press this button to generate random data",
-    "notifications":"Notifications"
+    "notification_main_text": "Recent notifications:",
+    "notification_title": "2-Week Exposure Profile",
+    "notification_data_not_available": "No exposure data is available.",
+    "notification_warning_text": "If a Healthcare Authority exists in your area you can subscribe to obtain regular updates of exposure risks.",
+    "notification_random_data_button": "Select Healthcare Authority",
+    "notifications": "Notifications",
+    "notifications_exposure_format_today": "Today you crossed paths with someone infectious for {{exposureTime}} minutes.",
+    "notifications_exposure_format_yesterday": "Yesterday you crossed paths with someone infectious for {{exposureTime}} minutes.",
+    "notifications_exposure_format": "{{daysAgo}} days ago you crossed paths someone infectious for {{exposureTime}} minutes.",
+    "notification_today": "today",
+    "notification_2_weeks_ago": "2 weeks ago"
+
 }

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -234,15 +234,21 @@ class LocationTracking extends Component {
         <MenuOptions>
           <MenuOption
             onSelect={() => {
-              this.licenses();
-            }}>
-            <Text style={styles.menuOptionText}>Licenses</Text>
-          </MenuOption>
-          <MenuOption
-            onSelect={() => {
               this.notifications();
             }}>
             <Text style={styles.menuOptionText}>Notifications</Text>
+          </MenuOption>
+          <MenuOption
+            onSelect={() => {
+              this.settings();
+            }}>
+            <Text style={styles.menuOptionText}>Settings</Text>
+          </MenuOption>
+          <MenuOption
+            onSelect={() => {
+              this.licenses();
+            }}>
+            <Text style={styles.menuOptionText}>Licenses</Text>
           </MenuOption>
         </MenuOptions>
       </Menu>


### PR DESCRIPTION
Fix main menu (was missing Settings)

Notification screen cleanup
* Now only 14 days are shown
* Replaced "green" with "brown"
* Reworked the notifications and chart
* No longer lets you generate random data
* If no data, you are lead to the Settings page to select a Healthcare Authority

 ## Localization Notes ##

The Notification screen strings were all edited, several were added.  One is a
formatting string, so the {{daysAgo}} should NOT be translated.  Ask Steve if
you have questions.