### PR TITLE
Remove old "Check Overlap" functionality

### DIFF
--- a/app/locales/en/intro.json
+++ b/app/locales/en/intro.json
@@ -1,14 +1,14 @@
 {
-    "private_kit":"Private Kit",
-    "next":"NEXT",
-    "back":"BACK",
-    "start":"START",
-    "intro_subtitle":"We can fight COVID-19 together",
-    "intro_header_0":"Map where you go",
-    "intro_subheader_0":"The app saves your location every 5 minutes",
-    "intro_header_1":"Keep your privacy",
-    "intro_subheader_1":"Your data never leaves your phone without your consent",
-    "intro_header_2":"Stay informed of risk",
-    "intro_subheader_2":"Check if you crossed paths with a COVID-19 patient",
-    "intro_get_started":"I want to help!"
+    "private_kit": "COVID\nSafe Paths",
+    "next": "NEXT",
+    "back": "BACK",
+    "start": "START",
+    "intro_subtitle": "We can fight COVID-19 together",
+    "intro_header_0": "Map where you go",
+    "intro_subheader_0": "The app saves your location every 5 minutes",
+    "intro_header_1": "Keep your privacy",
+    "intro_subheader_1": "Your data never leaves your phone without your consent",
+    "intro_header_2": "Stay informed of risk",
+    "intro_subheader_2": "Check if you crossed paths with a COVID-19 patient",
+    "intro_get_started": "I want to help!"
 }

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -259,7 +259,7 @@ class LocationTracking extends Component {
             height: 164.4,
             alignSelf: 'center',
             marginTop: 15,
-            marginBottom: 15,
+            marginBottom: 25,
           }}
         />
         <ButtonWrapper
@@ -272,6 +272,7 @@ class LocationTracking extends Component {
           {languages.t('label.home_stop_tracking_description')}
         </Text>
 
+        {/* 
         <ButtonWrapper
           title={languages.t('label.home_check_risk')}
           onPress={() => this.overlap()}
@@ -281,6 +282,7 @@ class LocationTracking extends Component {
         <Text style={styles.sectionDescription}>
           {languages.t('label.home_check_risk_description')}
         </Text>
+        */}
       </>
     );
   };


### PR DESCRIPTION
Resolves #347

* Comment out the map functionality (button)
* Add extra padding for visual balance
* Renamed the Private Kit title to "COVID Safe Paths" so visual balance
  can be seen more clearly