### PR TITLE
Add unobtrusive locale selection dropdown to onboarding (WIP)

### DIFF
--- a/app/components/NativePicker.js
+++ b/app/components/NativePicker.js
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  TextInput,
+  TouchableWithoutFeedback,
+  Picker,
+  Modal,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+
+// Code for the language select dropdown, for nice native handling on both iOS and Android.
+// TODO: Move component to a separate file
+export default class NativePicker extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      modalVisible: false,
+    };
+  }
+
+  render() {
+    if (Platform.OS === 'android') {
+      return (
+        <Picker
+          selectedValue={this.props.value}
+          onValueChange={this.props.onValueChange}>
+          {this.props.items.map((i, index) => (
+            <Picker.Item key={index} label={i.label} value={i.value} />
+          ))}
+        </Picker>
+      );
+    } else {
+      const selectedItem = this.props.items.find(
+        i => i.value === this.props.value,
+      );
+      const selectedLabel = selectedItem ? selectedItem.label : '';
+
+      return (
+        <View style={styles.inputContainer}>
+          <TouchableOpacity
+            onPress={() => this.setState({ modalVisible: true })}>
+            <TextInput
+              style={styles.input}
+              editable={false}
+              placeholder='Select language'
+              onChangeText={searchString => {
+                this.setState({ searchString });
+              }}
+              value={selectedLabel}
+            />
+          </TouchableOpacity>
+          <Modal
+            animationType='slide'
+            transparent
+            visible={this.state.modalVisible}>
+            <TouchableWithoutFeedback
+              onPress={() => this.setState({ modalVisible: false })}>
+              <View style={styles.modalContainer}>
+                <View style={styles.modalContent}>
+                  <Text
+                    style={{ color: 'blue' }}
+                    onPress={() => this.setState({ modalVisible: false })}>
+                    Done
+                  </Text>
+                </View>
+                <View
+                  onStartShouldSetResponder={evt => true}
+                  onResponderReject={evt => {}}>
+                  <Picker
+                    selectedValue={this.props.value}
+                    onValueChange={this.props.onValueChange}>
+                    {this.props.items.map((i, index) => (
+                      <Picker.Item
+                        key={index}
+                        label={i.label}
+                        value={i.value}
+                      />
+                    ))}
+                  </Picker>
+                </View>
+              </View>
+            </TouchableWithoutFeedback>
+          </Modal>
+        </View>
+      );
+    }
+  }
+}
+
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  imageContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: '3%',
+  },
+  descriptionContainer: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  descriptionIconContainer: {
+    alignSelf: 'center',
+  },
+  descriptionIcon: {
+    width: 10,
+    height: 10,
+    resizeMode: 'contain',
+  },
+  descriptionTextContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    marginLeft: '5%',
+  },
+});

--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 import { getLanguages } from 'react-native-i18n';
+import { GetStoreData } from '../helpers/General';
 
 // Refer this for checking the codes and creating new folders https://developer.chrome.com/webstore/i18n
 // Step 1 - Create index.js files for each language we want to have, in this file you can import all the json files (Step 4) and export them
@@ -27,18 +28,38 @@ import gjlabels from './gj';
 import cslabels from './cs';
 
 // This will fetch the user's language
-let userLang = undefined;
-getLanguages().then(languages => {
-  userLang = languages[0].split('-')[0]; // ['en-US' will become 'en']
-  i18next.changeLanguage(userLang);
-});
+// Set up as a function so first onboarding screen can also update
+// ...from async language override setting
+export function findUserLang(callback) {
+  let userLang = undefined;
+  getLanguages().then(languages => {
+    userLang = languages[0].split('-')[0]; // ['en-US' will become 'en']
+
+    // If the user specified a language override, use it instead
+    GetStoreData('LANG_OVERRIDE').then(res => {
+      if (typeof res === 'string') {
+        console.log('Found user language override:');
+        console.log(res);
+        userLang = res;
+        i18next.changeLanguage(res);
+      } else {
+        i18next.changeLanguage(userLang);
+      }
+
+      // Run state updating callback to trigger rerender
+      callback(userLang);
+
+      return userLang;
+    });
+  });
+}
 
 i18next.init({
   interpolation: {
     // React already does escaping
     escapeValue: false,
   },
-  lng: userLang, // 'en' | 'es',
+  lng: 'en', // 'en' | 'es',
   fallbackLng: 'en', // If language detector fails
   resources: {
     en: {

--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -47,12 +47,14 @@ export function findUserLang(callback) {
       }
 
       // Run state updating callback to trigger rerender
-      callback(userLang);
+      typeof callback === 'function' ? callback(userLang) : null;
 
       return userLang;
     });
   });
 }
+
+findUserLang();
 
 i18next.init({
   interpolation: {

--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -45,81 +45,97 @@ i18next.init({
       translation: {
         label: enlabels,
       },
+      label: 'English',
     },
     de: {
       translation: {
         label: delabels,
       },
+      label: 'Deutsch',
     },
     hi: {
       translation: {
         label: hilabels,
       },
+      label: 'हिन्दी',
     },
     fr: {
       translation: {
         label: frlabels,
       },
+      label: 'Français',
     },
     it: {
       translation: {
         label: itlabels,
       },
+      label: 'Italiano',
     },
     pt: {
       translation: {
         label: ptlabels,
       },
+      label: 'Português',
     },
     mr: {
       translation: {
         label: mrlabels,
       },
+      label: 'मराठी',
     },
     nl: {
       translation: {
         label: nllabels,
       },
+      label: 'Nederlands',
     },
     ht: {
       translation: {
         label: htlabels,
       },
+      label: 'Kreyòl ayisyen',
     },
     pt_BR: {
       translation: {
         label: pt_BRlabels,
       },
+      label: 'Portugues do Brasil',
     },
     kn: {
       translation: {
         label: knlabels,
       },
+      label: 'ಕನ್ನಡ',
     },
     es: {
       translation: {
         label: eslabels,
       },
+      label: 'Español',
     },
     ur: {
       translation: {
         label: urlabels,
       },
+      label: 'اردو',
     },
     ca: {
       translation: {
         label: calabels,
       },
+      label: 'Català',
     },
     gj: {
       translation: {
         label: gjlabels,
       },
+      label: 'ગુજરાતી',
     },
     cs: {
       translation: {
         label: cslabels,
       },
+      label: 'Ceština',
     },
   },
 });

--- a/app/views/welcomeScreens/SimpleWelcomeScreen.js
+++ b/app/views/welcomeScreens/SimpleWelcomeScreen.js
@@ -38,9 +38,6 @@ class SimpleWelcomeScreen extends Component {
       });
     }
 
-    console.log('Currently selected language: ');
-    console.log(languages.language);
-
     this.state = {
       language: findUserLang(res => {
         this.setState({ language: res });
@@ -52,22 +49,23 @@ class SimpleWelcomeScreen extends Component {
   render() {
     return (
       <View style={styles.mainContainer}>
-        <NativePicker
-          items={this.state.localesList}
-          value={this.state.language}
-          onValueChange={(itemValue, itemIndex) => {
-            this.setState({ language: itemValue });
+        <View style={{ maxWidth: '35%', marginLeft: '12%' }}>
+          <NativePicker
+            items={this.state.localesList}
+            value={this.state.language}
+            onValueChange={(itemValue, itemIndex) => {
+              this.setState({ language: itemValue });
 
-            // If user picks manual lang, update and store setting
-            languages.changeLanguage(itemValue, (err, t) => {
-              if (err) return console.log('something went wrong loading', err);
-            });
-            console.log("Here's language data test:");
-            console.log(itemValue);
+              // If user picks manual lang, update and store setting
+              languages.changeLanguage(itemValue, (err, t) => {
+                if (err)
+                  return console.log('something went wrong loading', err);
+              });
 
-            SetStoreData('LANG_OVERRIDE', itemValue);
-          }}
-        />
+              SetStoreData('LANG_OVERRIDE', itemValue);
+            }}
+          />
+        </View>
         <View style={styles.infoCard}>
           <View style={styles.imageContainer}>
             <Image source={IconLogo} style={styles.infoCardImage} />

--- a/app/views/welcomeScreens/SimpleWelcomeScreen.js
+++ b/app/views/welcomeScreens/SimpleWelcomeScreen.js
@@ -1,13 +1,5 @@
-import React from 'react';
-import {
-  View,
-  Text,
-  Dimensions,
-  TouchableOpacity,
-  Image,
-  StyleSheet,
-  Linking,
-} from 'react-native';
+import React, { Component } from 'react';
+import { View, Text, Dimensions, Image, StyleSheet } from 'react-native';
 const width = Dimensions.get('window').width;
 import IconLogo from './../../assets/images/PKLogo.png';
 import IconGlobe from './../../assets/svgs/intro-globe';
@@ -15,6 +7,7 @@ import IconLocked from './../../assets/svgs/intro-locked';
 import IconSiren from './../../assets/svgs/intro-siren';
 import languages from './../../locales/languages';
 import ButtonWrapper from '../../components/ButtonWrapper';
+import NativePicker from '../../components/NativePicker';
 import Colors from '../../constants/colors';
 import FontWeights from '../../constants/fontWeights';
 import { SvgXml } from 'react-native-svg';
@@ -31,56 +24,141 @@ const DescriptionComponent = ({ icon, header, subheader, ...props }) => (
 
 const ICON_SIZE = 35;
 
-const SimpleWelcomeScreen = props => {
-  return (
-    <View style={styles.mainContainer}>
-      <View style={styles.infoCard}>
-        <View style={styles.imageContainer}>
-          <Image source={IconLogo} style={styles.infoCardImage} />
-        </View>
-        <Text style={styles.infoCardHeadText}>
-          {languages.t('label.private_kit')}
-        </Text>
-        <Text style={styles.infoCardSubheadText}>
-          {languages.t('label.intro_subtitle')}
-        </Text>
-        <View style={styles.descriptionsContainer}>
-          <DescriptionComponent
-            icon={
-              <SvgXml xml={IconGlobe} width={ICON_SIZE} height={ICON_SIZE} />
-            }
-            header={languages.t('label.intro_header_0')}
-            subheader={languages.t('label.intro_subheader_0')}
-          />
-          <DescriptionComponent
-            icon={
-              <SvgXml xml={IconLocked} width={ICON_SIZE} height={ICON_SIZE} />
-            }
-            header={languages.t('label.intro_header_1')}
-            subheader={languages.t('label.intro_subheader_1')}
-          />
-          <DescriptionComponent
-            icon={
-              <SvgXml xml={IconSiren} width={ICON_SIZE} height={ICON_SIZE} />
-            }
-            header={languages.t('label.intro_header_2')}
-            subheader={languages.t('label.intro_subheader_2')}
-          />
-        </View>
-      </View>
+const localesList = [
+  {
+    label: 'Català',
+    value: 'ca',
+  },
+  {
+    label: 'Ceština',
+    value: 'cs',
+  },
+  {
+    label: 'Deutsch',
+    value: 'de',
+  },
+  {
+    label: 'English',
+    value: 'en',
+  },
+  {
+    label: 'Español',
+    value: 'es',
+  },
+  {
+    label: 'Français',
+    value: 'fr',
+  },
+  {
+    label: 'ગુજરાતી',
+    value: 'gj',
+  },
+  {
+    label: 'हिन्दी',
+    value: 'hi',
+  },
+  {
+    label: 'Kreyòl ayisyen',
+    value: 'ht',
+  },
+  {
+    label: 'Italiano',
+    value: 'it',
+  },
+  {
+    label: 'ಕನ್ನಡ',
+    value: 'kn',
+  },
+  {
+    label: 'मराठी',
+    value: 'mr',
+  },
+  {
+    label: 'Nederlands',
+    value: 'nl',
+  },
+  {
+    label: 'Português',
+    value: 'pt',
+  },
+  {
+    label: 'Portugues do Brasil',
+    value: 'pt_BR',
+  },
+  {
+    label: 'اردو',
+    value: 'ur',
+  },
+];
 
-      <ButtonWrapper
-        title={languages.t('label.intro_get_started')}
-        onPress={() => {
-          props.navigation.replace('LocationTrackingScreen');
-          props.navigation.navigate('LocationTrackingScreen');
-        }}
-        bgColor={Colors.BLUE_BUTTON}
-        toBgColor={Colors.BLUE_TO_BUTTON}
-      />
-    </View>
-  );
-};
+class SimpleWelcomeScreen extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      localeSelected: 'en',
+    };
+  }
+
+  render() {
+    return (
+      <View style={styles.mainContainer}>
+        <NativePicker
+          items={localesList}
+          value={this.state.language}
+          onValueChange={(itemValue, itemIndex) => {
+            this.setState({ language: itemValue });
+            console.log("Here's language data test:");
+            console.log(languages.options.resources['en'].label);
+          }}
+        />
+        <View style={styles.infoCard}>
+          <View style={styles.imageContainer}>
+            <Image source={IconLogo} style={styles.infoCardImage} />
+          </View>
+          <Text style={styles.infoCardHeadText}>
+            {languages.t('label.private_kit')}
+          </Text>
+          <Text style={styles.infoCardSubheadText}>
+            {languages.t('label.intro_subtitle')}
+          </Text>
+          <View style={styles.descriptionsContainer}>
+            <DescriptionComponent
+              icon={
+                <SvgXml xml={IconGlobe} width={ICON_SIZE} height={ICON_SIZE} />
+              }
+              header={languages.t('label.intro_header_0')}
+              subheader={languages.t('label.intro_subheader_0')}
+            />
+            <DescriptionComponent
+              icon={
+                <SvgXml xml={IconLocked} width={ICON_SIZE} height={ICON_SIZE} />
+              }
+              header={languages.t('label.intro_header_1')}
+              subheader={languages.t('label.intro_subheader_1')}
+            />
+            <DescriptionComponent
+              icon={
+                <SvgXml xml={IconSiren} width={ICON_SIZE} height={ICON_SIZE} />
+              }
+              header={languages.t('label.intro_header_2')}
+              subheader={languages.t('label.intro_subheader_2')}
+            />
+          </View>
+        </View>
+
+        <ButtonWrapper
+          title={languages.t('label.intro_get_started')}
+          onPress={() => {
+            this.props.navigation.replace('LocationTrackingScreen');
+            this.props.navigation.navigate('LocationTrackingScreen');
+          }}
+          bgColor={Colors.BLUE_BUTTON}
+          toBgColor={Colors.BLUE_TO_BUTTON}
+        />
+      </View>
+    );
+  }
+}
 
 const styles = StyleSheet.create({
   mainContainer: {
@@ -165,6 +243,11 @@ const styles = StyleSheet.create({
     fontWeight: FontWeights.LIGHT,
     fontSize: 14,
     color: '#6A6A6A',
+  },
+  menuOptionText: {
+    fontWeight: FontWeights.REGULAR,
+    fontSize: 14,
+    padding: 10,
   },
 });
 

--- a/app/views/welcomeScreens/SimpleWelcomeScreen.js
+++ b/app/views/welcomeScreens/SimpleWelcomeScreen.js
@@ -5,11 +5,12 @@ import IconLogo from './../../assets/images/PKLogo.png';
 import IconGlobe from './../../assets/svgs/intro-globe';
 import IconLocked from './../../assets/svgs/intro-locked';
 import IconSiren from './../../assets/svgs/intro-siren';
-import languages from './../../locales/languages';
+import languages, { findUserLang } from './../../locales/languages';
 import ButtonWrapper from '../../components/ButtonWrapper';
 import NativePicker from '../../components/NativePicker';
 import Colors from '../../constants/colors';
 import FontWeights from '../../constants/fontWeights';
+import { SetStoreData } from '../../helpers/General';
 import { SvgXml } from 'react-native-svg';
 
 const DescriptionComponent = ({ icon, header, subheader, ...props }) => (
@@ -24,78 +25,27 @@ const DescriptionComponent = ({ icon, header, subheader, ...props }) => (
 
 const ICON_SIZE = 35;
 
-const localesList = [
-  {
-    label: 'Català',
-    value: 'ca',
-  },
-  {
-    label: 'Ceština',
-    value: 'cs',
-  },
-  {
-    label: 'Deutsch',
-    value: 'de',
-  },
-  {
-    label: 'English',
-    value: 'en',
-  },
-  {
-    label: 'Español',
-    value: 'es',
-  },
-  {
-    label: 'Français',
-    value: 'fr',
-  },
-  {
-    label: 'ગુજરાતી',
-    value: 'gj',
-  },
-  {
-    label: 'हिन्दी',
-    value: 'hi',
-  },
-  {
-    label: 'Kreyòl ayisyen',
-    value: 'ht',
-  },
-  {
-    label: 'Italiano',
-    value: 'it',
-  },
-  {
-    label: 'ಕನ್ನಡ',
-    value: 'kn',
-  },
-  {
-    label: 'मराठी',
-    value: 'mr',
-  },
-  {
-    label: 'Nederlands',
-    value: 'nl',
-  },
-  {
-    label: 'Português',
-    value: 'pt',
-  },
-  {
-    label: 'Portugues do Brasil',
-    value: 'pt_BR',
-  },
-  {
-    label: 'اردو',
-    value: 'ur',
-  },
-];
-
 class SimpleWelcomeScreen extends Component {
   constructor(props) {
     super(props);
+
+    // Get locales list from i18next for locales menu
+    let localesList = [];
+    for (let key in languages.options.resources) {
+      localesList = localesList.concat({
+        value: key,
+        label: languages.options.resources[key].label,
+      });
+    }
+
+    console.log('Currently selected language: ');
+    console.log(languages.language);
+
     this.state = {
-      localeSelected: 'en',
+      language: findUserLang(res => {
+        this.setState({ language: res });
+      }),
+      localesList: localesList,
     };
   }
 
@@ -103,12 +53,19 @@ class SimpleWelcomeScreen extends Component {
     return (
       <View style={styles.mainContainer}>
         <NativePicker
-          items={localesList}
+          items={this.state.localesList}
           value={this.state.language}
           onValueChange={(itemValue, itemIndex) => {
             this.setState({ language: itemValue });
+
+            // If user picks manual lang, update and store setting
+            languages.changeLanguage(itemValue, (err, t) => {
+              if (err) return console.log('something went wrong loading', err);
+            });
             console.log("Here's language data test:");
-            console.log(languages.options.resources['en'].label);
+            console.log(itemValue);
+
+            SetStoreData('LANG_OVERRIDE', itemValue);
           }}
         />
         <View style={styles.infoCard}>


### PR DESCRIPTION
A dropdown locale / language select for areas where phone language settings doesn't usually match spoken language. Primarily in prep for our pilot program. This PR is a work in progress. Brief summary:
- Set up with the native picker components for best ease of use. A bit annoying to handle on iOS (especially since I can't debug there)
- Uses a list of all prepared languages pulled from the i18next configuration
- If a language is manually selected, that choice is put in async storage and the app will override the phone setting with the user setting

Still to do:
- I don't have easy access to a macbook/iPhone, so I need some help to verify that the Picker component on iOS is working as expected
- Add unicode flags to the language labels
- Style both Android and iOS components to match v2 style in incoming PR (see Figma mockup for target)

Screenshots:
![Screenshot from 2020-04-05 06-07-10](https://user-images.githubusercontent.com/6233577/78473243-b183c980-7704-11ea-8f53-78257a097088.png)
![Screenshot from 2020-04-05 06-07-28](https://user-images.githubusercontent.com/6233577/78473247-b5175080-7704-11ea-835d-691008493f4e.png)
