### PR TITLE
Tweak the Licenses file to hold Legal in general

### DIFF
--- a/app/assets/LICENSE.json
+++ b/app/assets/LICENSE.json
@@ -1,6 +1,9 @@
 {
-    "licenses": [{
-        "name": "Private Kit",
+    "terms_and_licenses": [{
+        "name": "Terms of Use",
+        "text": "blah blah blah"
+    }, {
+        "name": "COVID Safe Paths",
         "text": "MIT License\n\nCopyright (c) 2020 TripleBlind, Inc\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
     }]
 }

--- a/app/locales/en/english.json
+++ b/app/locales/en/english.json
@@ -176,6 +176,6 @@
     "about_title": "About",
     "news_title": "Latest news",
     "event_history_title": "Event history",
-    "licenses_title": "Licenses",
+    "legal_page_title": "Legal",
     "tested_positive_title": "I tested positive"
 }

--- a/app/views/Licenses.js
+++ b/app/views/Licenses.js
@@ -45,8 +45,8 @@ class LicensesScreen extends Component {
       '<style>  html, body { font-size: 40px; margin: 0; padding: 0; } </style>';
     result += '<body>';
 
-    for (var i = 0; i < licenses.licenses.length; i++) {
-      var element = licenses.licenses[i];
+    for (var i = 0; i < licenses.terms_and_licenses.length; i++) {
+      var element = licenses.terms_and_licenses[i];
 
       result += '<B>' + element.name + '</B><P>';
       result += element.text.replace(/\n/g, '<br/>');
@@ -60,32 +60,19 @@ class LicensesScreen extends Component {
   render() {
     return (
       <NavigationBarWrapper
-        title={languages.t('label.licenses_title')}
+        title={languages.t('label.legal_page_title')}
         onBackPress={this.backToMain.bind(this)}>
         <ScrollView contentContainerStyle={styles.contentContainer}>
           <View style={styles.main}>
-            <View style={styles.row}>
-              <Text style={styles.valueName}>
-                {languages.t('label.private_kit')}{' '}
-              </Text>
-            </View>
-
             <View style={styles.row}>
               <Text style={styles.valueName}>Version: </Text>
               <Text style={styles.value}>{packageJson.version}</Text>
             </View>
 
             <View style={styles.row}>
-              <Text style={styles.valueName}>OS: </Text>
-              <Text style={styles.value}>
-                {Platform.OS + ' v' + Platform.Version}
-              </Text>
-            </View>
-
-            <View style={styles.row}>
-              <Text style={styles.valueName}>Screen Resolution: </Text>
-              <Text style={styles.value}>
-                {' '}
+              <Text style={styles.valueSmall}>
+                OS:
+                {Platform.OS + ' v' + Platform.Version}; Screen:
                 {Math.trunc(Dimensions.get('screen').width) +
                   ' x ' +
                   Math.trunc(Dimensions.get('screen').height)}
@@ -137,6 +124,12 @@ const styles = StyleSheet.create({
   value: {
     color: Colors.VIOLET_TEXT,
     fontSize: 20,
+    fontFamily: fontFamily.primaryMedium,
+    marginTop: 9,
+  },
+  valueSmall: {
+    color: Colors.VIOLET_TEXT,
+    fontSize: 16,
     fontFamily: fontFamily.primaryMedium,
     marginTop: 9,
   },

--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -173,7 +173,7 @@ class SettingsScreen extends Component {
               {this.getSettingRow('label.about_title', this.aboutButtonPressed)}
               <View style={styles.divider}></View>
               {this.getSettingRow(
-                'label.licenses_title',
+                'label.legal_page_title',
                 this.licensesButtonPressed,
               )}
             </View>


### PR DESCRIPTION
Repurposed the "License" screen to be general Legal info.  This will include
Term of Use/Service, Licenses for other components, etc.


 ### Testing Notes ###

Open the "Legal" page on the secondary screen menu.


 ### Environment Notes ###

This adds a new "legal_page_title" item