### PR TITLE
Add a .gitmessage template to the repo

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,59 @@
+Commit headline -- not longer than this line (50)
+
+Longer change description.  Please keep text no longer than this line -------
+
+ ### Testing Notes ###
+Include instructions for reviewers to run tests related to this PR.
+
+ ### Fixed Issues ###
+NONE - Replace with description and/or associated Github issue
+       numbers, e.g. Resolves #12, Resolves #100
+
+ ### Tech Notes ###
+NONE - Explain new algorithms in detail, new utility classes this
+       introduces, tool changes, etc. Basically, these are asides
+       you are writing to other developers on the project
+
+ ### API Notes ###
+NONE - Message types added or changed, new signals, APIs, etc.
+       It is very important to note any change which breaks backwards
+       compatibility.
+
+ ### Environment Notes ###
+NONE - New package requirements, new files being written to disk, etc.
+
+# This template is for commits to this repo.  Change the first line (think of
+# it as the "headline" for the commit) and then add a longer description of
+# the change.  To be nice, keep the headline to 50 characters (Github will
+# truncate after that in its UI) and wrap content at 78 characters
+# or less (to be nice in all text editors).  The first lines of this template
+# are exactly 50 and 78 characters for reference.
+#
+# Also use imperative writing in the headline and description, such as "Fix
+# broken code" not "Fixes the broken code" or "Fixed the broken code".  Good
+# imperative phrases are:
+#   * Add something new
+#   * Fix something broken
+#   * Remove unused something
+#   * Update this thing
+#   * Refactor that thing
+# As you see above, you can use [Github markdown](https://guides.github.com/features/mastering-markdown/)
+# freely. Notice the above violation of the 78 character rule in the long
+# hyperlink -- just don't include important stuff after the 78th character,
+# wrap as soon as possible.
+#
+# Finally, you can include nice code examples like this:
+# ```python
+# def example():
+#     print("Nicely highlighted python code")
+# ```
+#
+# Sections below can be filled out and edited as appropriate. The same
+# sections are used in the PR template, so this can be notes to yourself for
+# when you check in a larger body of work with multiple commits.  Sections
+# can optionally be removed.
+#
+# Please fill this out carefully. This moment is when the code you are
+# committing is clearest in the mind of you, the foremost expert in this
+# change. Please pause to think of side effects and impacts.
+#

--- a/app/assets/LICENSE.json
+++ b/app/assets/LICENSE.json
@@ -1,6 +1,9 @@
 {
-    "licenses": [{
-        "name": "Private Kit",
+    "terms_and_licenses": [{
+        "name": "Terms of Use",
+        "text": "blah blah blah"
+    }, {
+        "name": "COVID Safe Paths",
         "text": "MIT License\n\nCopyright (c) 2020 TripleBlind, Inc\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
     }]
 }

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -209,6 +209,8 @@ if ! found_exe react-native ; then
     echo "${GREEN}React Native tools installed!${RESET}"
 fi
 
+git config commit.template ./.gitmessage
+
 
 echo "${GREEN}You are now ready to go!${RESET}"
 echo


### PR DESCRIPTION
This is a good template for everyone to follow when filling out their commit
message.


 ### Testing Notes ###

Run dev_setup.sh (or manually do git config commit.template ./.gitmessage)

Now start a `git commit`.  The template should appear.