### PR TITLE
Minor UX and accessibility updates

### DIFF
--- a/gps/app/components/NavigationBarWrapper.js
+++ b/gps/app/components/NavigationBarWrapper.js
@@ -98,7 +98,6 @@ const BackArrowSvg = styled(SvgXml)`
   height: 18px;
   width: 18px;
   color: ${Colors.WHITE};
-  opacity: 0.4;
 `;
 
 NavigationBarWrapper.propTypes = {

--- a/gps/app/components/__tests__/__snapshots__/IconButton.spec.js.snap
+++ b/gps/app/components/__tests__/__snapshots__/IconButton.spec.js.snap
@@ -26,7 +26,7 @@ exports[`allows size override 1`] = `
       height={48}
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
         }
       }
       width={48}
@@ -85,7 +85,7 @@ exports[`changes color based on theme 1`] = `
       height={24}
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
         }
       }
       width={24}
@@ -122,7 +122,7 @@ exports[`renders different color for secondary 1`] = `
       secondary={true}
       style={
         Object {
-          "color": "rgba(64, 81, 219, 0.6)",
+          "color": "#4051DB",
         }
       }
       width={24}
@@ -159,7 +159,7 @@ exports[`renders the icon in a touchable opacity 1`] = `
       height={24}
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
         }
       }
       width={24}

--- a/gps/app/components/__tests__/__snapshots__/Typography.spec.js.snap
+++ b/gps/app/components/__tests__/__snapshots__/Typography.spec.js.snap
@@ -13,7 +13,7 @@ exports[`body1 is regular 1`] = `
   <Text
     style={
       Object {
-        "color": "#4051DB",
+        "color": "#000",
         "fontFamily": "IBMPlexSans",
         "fontSize": 18,
         "fontWeight": "normal",
@@ -56,7 +56,7 @@ exports[`changes color based on theme 1`] = `
   <Text
     style={
       Object {
-        "color": "#4051DB",
+        "color": "#000",
         "fontFamily": "IBMPlexSans",
         "fontSize": 18,
         "fontWeight": "normal",
@@ -84,7 +84,7 @@ exports[`headline1 is large and bold 1`] = `
   <Text
     style={
       Object {
-        "color": "#4051DB",
+        "color": "#000",
         "fontFamily": "IBMPlexSans-Bold",
         "fontSize": 52,
         "fontWeight": "bold",

--- a/gps/app/constants/__tests__/__snapshots__/Theme.spec.js.snap
+++ b/gps/app/constants/__tests__/__snapshots__/Theme.spec.js.snap
@@ -28,7 +28,7 @@ exports[`changes text color based on theme 1`] = `
   <Text
     style={
       Object {
-        "color": "#4051DB",
+        "color": "#000",
         "fontFamily": "IBMPlexSans",
         "fontSize": 18,
         "fontWeight": "normal",

--- a/gps/app/constants/colors.js
+++ b/gps/app/constants/colors.js
@@ -32,7 +32,7 @@ const colors = {
   INTRO_WHITE_BG: '#F7F8FF',
   PULSE_WHITE: '#FFFFFF40',
 
-  DIVIDER: '#A5AFFB',
+  DIVIDER: '#e5e7fa',
 
   BLUE_BUTTON: '#05369B',
   BLUE_TO_BUTTON: '#185BD3',

--- a/gps/app/constants/themes.js
+++ b/gps/app/constants/themes.js
@@ -7,8 +7,8 @@ import Color from './colors';
 /** Violet on pale violet bg. e.g. Settings */
 export const defaultTheme = {
   background: Color.VIOLET_ALPHA_06,
-  textPrimaryOnBackground: Color.VIOLET,
-  textSecondaryOnBackground: 'rgba(64, 81, 219, 0.6)',
+  textPrimaryOnBackground: Color.BLACK,
+  textSecondaryOnBackground: Color.VIOLET,
 
   navBar: Color.VIOLET,
   onNavBar: Color.WHITE,

--- a/gps/app/views/About.js
+++ b/gps/app/views/About.js
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
     marginTop: 36,
   },
   aboutSectionTitles: {
-    color: Colors.VIOLET_TEXT,
+    color: Colors.BLACK,
     fontSize: 26,
     fontFamily: fontFamily.primaryMedium,
     marginTop: 36,

--- a/gps/app/views/ChooseProvider.js
+++ b/gps/app/views/ChooseProvider.js
@@ -414,7 +414,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.WHITE,
   },
   headerTitle: {
-    color: Colors.VIOLET_TEXT,
+    color: Colors.BLACK,
   },
   sectionDescription: {
     marginTop: 12,

--- a/gps/app/views/ExposureHistory/__tests__/__snapshots__/DataCircle.spec.js.snap
+++ b/gps/app/views/ExposureHistory/__tests__/__snapshots__/DataCircle.spec.js.snap
@@ -118,7 +118,7 @@ exports[`size is configurable (snapshot) 1`] = `
         "backgroundColor": "transparent",
         "borderBottomLeftRadius": 12,
         "borderBottomRightRadius": 12,
-        "borderColor": "#4051DB",
+        "borderColor": "#000",
         "borderStyle": "solid",
         "borderTopLeftRadius": 12,
         "borderTopRightRadius": 12,
@@ -133,7 +133,7 @@ exports[`size is configurable (snapshot) 1`] = `
       riskLevel="today"
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
           "flexBasis": 0,
           "flexGrow": 1,
           "flexShrink": 1,
@@ -167,7 +167,7 @@ exports[`today matches snapshot 1`] = `
         "backgroundColor": "transparent",
         "borderBottomLeftRadius": 18,
         "borderBottomRightRadius": 18,
-        "borderColor": "#4051DB",
+        "borderColor": "#000",
         "borderStyle": "solid",
         "borderTopLeftRadius": 18,
         "borderTopRightRadius": 18,
@@ -182,7 +182,7 @@ exports[`today matches snapshot 1`] = `
       riskLevel="today"
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
           "flexBasis": 0,
           "flexGrow": 1,
           "flexShrink": 1,

--- a/gps/app/views/Settings/GoogleMapsImport.js
+++ b/gps/app/views/Settings/GoogleMapsImport.js
@@ -22,7 +22,7 @@ export const GoogleMapsImport = ({ navigation }) => {
       </TitleRow>
 
       <ParagraphContainer>
-        <Typography use='body2'>{t('import.subtitle')}</Typography>
+        <Typography secondary use='body2'>{t('import.subtitle')}</Typography>
       </ParagraphContainer>
 
       <Button

--- a/gps/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
+++ b/gps/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
@@ -63,7 +63,6 @@ exports[`renders default values from the flags provider 1`] = `
             Object {
               "color": "#FFF",
               "height": 18,
-              "opacity": 0.4,
               "width": 18,
             }
           }
@@ -97,7 +96,7 @@ exports[`renders default values from the flags provider 1`] = `
       bold={true}
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
           "fontFamily": "IBMPlexSans-Bold",
           "fontSize": 18,
           "fontWeight": "bold",
@@ -115,7 +114,7 @@ exports[`renders default values from the flags provider 1`] = `
     <Text
       style={
         Object {
-          "color": "#4051DB",
+          "color": "#000",
           "fontFamily": "IBMPlexSans",
           "fontSize": 16,
           "fontWeight": "normal",
@@ -168,7 +167,7 @@ exports[`renders default values from the flags provider 1`] = `
           bold={true}
           style={
             Object {
-              "color": "#4051DB",
+              "color": "#000",
               "fontFamily": "IBMPlexSans-Bold",
               "fontSize": 18,
               "fontWeight": "bold",
@@ -218,7 +217,7 @@ exports[`renders default values from the flags provider 1`] = `
             bold={true}
             style={
               Object {
-                "color": "#4051DB",
+                "color": "#000",
                 "fontFamily": "IBMPlexSans-Bold",
                 "fontSize": 18,
                 "fontWeight": "bold",
@@ -233,7 +232,7 @@ exports[`renders default values from the flags provider 1`] = `
           <Text
             style={
               Object {
-                "color": "#4051DB",
+                "color": "#000",
                 "fontFamily": "IBMPlexSans",
                 "fontSize": 16,
                 "fontWeight": "normal",
@@ -247,7 +246,7 @@ exports[`renders default values from the flags provider 1`] = `
             <Text
               style={
                 Object {
-                  "color": "#4051DB",
+                  "color": "#000",
                   "fontFamily": "IBMPlexSans",
                   "fontSize": 15,
                   "fontStyle": "italic",

--- a/gps/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/gps/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -62,7 +62,6 @@ Array [
             Object {
               "color": "#FFF",
               "height": 18,
-              "opacity": 0.4,
               "width": 18,
             }
           }

--- a/gps/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/gps/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -63,7 +63,6 @@ exports[`renders correctly 1`] = `
             Object {
               "color": "#FFF",
               "height": 18,
-              "opacity": 0.4,
               "width": 18,
             }
           }

--- a/gps/app/views/__tests__/__snapshots__/News.spec.js.snap
+++ b/gps/app/views/__tests__/__snapshots__/News.spec.js.snap
@@ -90,7 +90,6 @@ exports[`renders correctly 1`] = `
               Object {
                 "color": "#FFF",
                 "height": 18,
-                "opacity": 0.4,
                 "width": 18,
               }
             }

--- a/gps/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/gps/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -63,7 +63,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
             Object {
               "color": "#FFF",
               "height": 18,
-              "opacity": 0.4,
               "width": 18,
             }
           }
@@ -693,6 +692,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
             }
           >
             <Text
+              secondary={true}
               style={
                 Object {
                   "fontFamily": "IBMPlexSans",
@@ -1035,7 +1035,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
             Object {
               "color": "#FFF",
               "height": 18,
-              "opacity": 0.4,
               "width": 18,
             }
           }

--- a/gps/app/views/onboarding/Onboarding1.js
+++ b/gps/app/views/onboarding/Onboarding1.js
@@ -84,7 +84,7 @@ class Onboarding extends Component {
                     <TouchableOpacity
                       onPress={openPicker}
                       style={styles.languageSelector}>
-                      <Typography style={styles.languageSelectorText}>
+                      <Typography use='body2' style={styles.languageSelectorText}>
                         {label}
                       </Typography>
                     </TouchableOpacity>
@@ -140,16 +140,16 @@ const styles = StyleSheet.create({
   // eslint-disable-next-line react-native/no-color-literals
   languageSelector: {
     // alpha needs to be in the bg color otherwise it fades the contained text
-    backgroundColor: 'rgba(255, 255, 255, 0.4)',
+    borderWidth: 1,
+    borderColor: Colors.WHITE,
     paddingVertical: 4,
     paddingHorizontal: 11,
     borderRadius: 100,
   },
   languageSelectorText: {
-    fontSize: 12,
-    color: Colors.VIOLET,
+    color: Colors.WHITE,
     paddingVertical: 4,
-    paddingHorizontal: 11,
+    paddingHorizontal: 20,
     opacity: 1,
     textAlign: 'center',
     textTransform: 'uppercase',


### PR DESCRIPTION
#### Description:

This commit updates the text throughout the app to follow the WCAG AA color accessibility guidelines.

#### Linked issues:

No applicable issue to link to.

#### Screenshots:

<img width="377" alt="onboarding" src="https://user-images.githubusercontent.com/2924479/82277883-f2ebd380-9956-11ea-914f-a95548f52769.png">
<img width="376" alt="about" src="https://user-images.githubusercontent.com/2924479/82277887-f41d0080-9956-11ea-94f0-204fd1533311.png">
<img width="376" alt="choose_health_authority" src="https://user-images.githubusercontent.com/2924479/82277888-f41d0080-9956-11ea-8f3c-4d2d341bf627.png">
<img width="376" alt="exposure_history" src="https://user-images.githubusercontent.com/2924479/82277889-f41d0080-9956-11ea-92f8-86d0b3a3f3e9.png">
<img width="377" alt="dashboard" src="https://user-images.githubusercontent.com/2924479/82277890-f4b59700-9956-11ea-85a0-7f99c612adc8.png">

#### How to test:

Running an iOS simulator:

1. Open a new instance of the app.
2. Ensure first onboarding screen matches attach screenshot "onboarding".
3. Complete onboarding.
4. Open the app dashboard, ensure the screen matches attached screenshot "dashboard".
5. Select "Choose Health Authority", ensure the screen matches attached screenshot "choose_health_authority".
6. Return to dashboard, select "Exposure History", ensure the screen matches attached screenshot "exposure_history."
7. Return to dashboard, select "About", ensure the screen matches attached screenshot "about".
