### PR TITLE
Remote links for location export and import

### DIFF
--- a/app/COVIDSafePathsConfig.js
+++ b/app/COVIDSafePathsConfig.js
@@ -1,7 +1,5 @@
 import { NativeModules } from 'react-native';
 
-const config = {
+export const config = {
   tracingStrategy: NativeModules.COVIDSafePathsConfig.getTracingStrategy(),
 };
-
-export default config;

--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -10,6 +10,7 @@ import NativePicker from '../components/NativePicker';
 import NavigationBarWrapper from '../components/NavigationBarWrapper';
 import Colors from '../constants/colors';
 import { PARTICIPATE } from '../constants/storage';
+import { tracingStrategy } from '../COVIDSafePathsConfig';
 import { GetStoreData, SetStoreData } from '../helpers/General';
 import {
   LOCALE_LIST,
@@ -117,20 +118,25 @@ export const SettingsScreen = ({ navigation }) => {
             label={t('label.event_history_title')}
             description={t('label.event_history_subtitle')}
             onPress={() => navigation.navigate('ExposureHistoryScreen')}
+            last={tracingStrategy === 'gps' ? false : true}
           />
-          <Item
-            label={t('share.title')}
-            description={t('share.subtitle')}
-            onPress={() => navigation.navigate('ExportScreen')}
-            last
-          />
+          {tracingStrategy === 'gps' ? (
+            <Item
+              label={t('share.title')}
+              description={t('share.subtitle')}
+              onPress={() => navigation.navigate('ExportScreen')}
+              last
+            />
+          ) : null}
         </Section>
 
-        <FeatureFlag name='google_import'>
-          <Section>
-            <GoogleMapsImport navigation={navigation} />
-          </Section>
-        </FeatureFlag>
+        {tracingStrategy === 'gps' ? (
+          <FeatureFlag name='google_import'>
+            <Section>
+              <GoogleMapsImport navigation={navigation} />
+            </Section>
+          </FeatureFlag>
+        ) : null}
 
         <Section last>
           <Item


### PR DESCRIPTION
Why:
We would like to hide the links for the location sharing import and
export for the bte version of the app.

This commit:
Conditionally renders the links to the location import and export
screens.

### Before

<img width="584" alt="Screen Shot 2020-05-19 at 4 41 34 PM" src="https://user-images.githubusercontent.com/16049495/82376789-a359e600-99f0-11ea-9ad4-776a3445beba.png">

### After

<img width="584" alt="Screen Shot 2020-05-19 at 4 12 23 PM" src="https://user-images.githubusercontent.com/16049495/82376800-a8b73080-99f0-11ea-983b-4242440f06aa.png">


