### PR TITLE
Hide Choose Health Authorities on Settings Page

### DIFF
--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -104,11 +104,13 @@ export const SettingsScreen = ({ navigation }) => {
           </NativePicker>
         </Section>
         <Section>
-          <Item
-            label={t('label.choose_provider_title')}
-            description={t('label.choose_provider_subtitle')}
-            onPress={() => navigation.navigate('ChooseProviderScreen')}
-          />
+          {tracingStrategy === 'gps' ? (
+            <Item
+              label={t('label.choose_provider_title')}
+              description={t('label.choose_provider_subtitle')}
+              onPress={() => navigation.navigate('ChooseProviderScreen')}
+            />
+          ) : null}
           <Item
             label={t('label.news_title')}
             description={t('label.news_subtitle')}


### PR DESCRIPTION
Why:
The current logic for Choosing a Health Authority involves using location.
Until the new flow is worked out, we will simply hide it.