### PR TITLE
Remove workspaces object from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,13 +138,6 @@
       "style": "module"
     }
   },
-  "workspaces": {
-    "packages": [
-      "gps",
-      "bte",
-      "shared"
-    ]
-  },
   "detox": {
     "artifacts": {
       "rootDir": "./e2e/artifacts/",


### PR DESCRIPTION
This pull requests removes the `workspaces` object from `package.json` as it is no longer needed and prevents developers from adding new dependencies. 