### PR TITLE
[SAF-264] remove WRITE_EXTERNAL_STORAGE permission for Android App

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
   package="org.pathcheck.covidsafepaths">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 


### PR DESCRIPTION
#### Description:

Remove the `WRITE_EXTERNAL_STORAGE` permission from the `AndroidManifest.xml`. The ticket implies it was unnecessary, so I don't believe any application code changes are needed?

#### Linked issues:
https://pathcheck.atlassian.net/projects/SAF/issues/SAF-264

#### How to test:
As this was removing a vestigial permission, I didn't add any tests. I was able to run the app on an emulator. If there's a test I can add, please let me know!
