### PR TITLE
[Build] Show eslint output on failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
       # The above eslint action does not show you in the job log what failed,
       # this is just for debugging purposes
       - run: yarn lint
-        if: ${{ failure() }}
+        if: ${{ always() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,8 @@ jobs:
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
           check-name: eslint # this is the job name from above 👆
+
+      # The above eslint action does not show you in the job log what failed,
+      # this is just for debugging purposes
+      - run: yarn lint
+        if: ${{ failure() }}

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -6,7 +6,6 @@ const specReporter = require('detox/runners/jest/specReporter');
 // Set the default timeout
 jest.setTimeout(120000);
 
-// eslint-disable-next-line jest/no-jasmine-globals
 jasmine.getEnv().addReporter(adapter); // yes jasmine is correct here
 
 // This takes care of generating status logs on a per-spec basis. By default, jest only reports at file-level.

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -6,6 +6,7 @@ const specReporter = require('detox/runners/jest/specReporter');
 // Set the default timeout
 jest.setTimeout(120000);
 
+// eslint-disable-next-line jest/no-jasmine-globals
 jasmine.getEnv().addReporter(adapter); // yes jasmine is correct here
 
 // This takes care of generating status logs on a per-spec basis. By default, jest only reports at file-level.


### PR DESCRIPTION
The eslint checker adds annotations to the source, but does not show what failed in github actions. This should fix that.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

Now you can see warnings in the job log: https://github.com/Path-Check/covid-safe-paths/pull/886/checks?check_run_id=697716251
