### PR TITLE
Fix app identifier typo in ios matchfile

### DIFF
--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,6 +1,6 @@
 git_url("git@github.com:Path-Check/certificates.git")
 storage_mode("git")
-app_identifier(["org.pathcheck.covide-safepaths", "org.pathcheck.bt"])
+app_identifier(["org.pathcheck.covid-safepaths", "org.pathcheck.bt"])
 username("tech@pathcheck.org") # Your Apple Developer Portal username
 
 # type("appstore") # Options: appstore, adhoc, enterprise or development


### PR DESCRIPTION
Fix app identifier typo in ios matchfile …
9ae783e
Why:
Currently there is a typo in the match file, which would cause gps
releases to fail.

Co-Authored-By: tparesi <tparesi@gmail.com>