### PR TITLE
Consolidate unit-tests-android, only run if unit-tests pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
           CI: true
 
   unit-test-android-gps:
+    needs: unit-test
     runs-on: macOS-latest # macOS-latest is required, tests need HAXM emulator
     steps:
       - uses: actions/checkout@v2
@@ -66,6 +67,7 @@ jobs:
           working-directory: ./android
 
   unit-test-android-bte:
+    needs: unit-test
     runs-on: macOS-latest # macOS-latest is required, tests need HAXM emulator
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CI: true
 
-  unit-test-android-gps:
+  unit-test-android:
     needs: unit-test
     runs-on: macOS-latest # macOS-latest is required, tests need HAXM emulator
     steps:
@@ -59,40 +59,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: ./gradlew :app:connectedGpsDebugAndroidTest --no-daemon
+      - name: ./gradlew :app:connectedGpsDebugAndroidTest :app:connectedBteDebugAndroidTest --no-daemon
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 28
-          script: ./gradlew :app:connectedGpsDebugAndroidTest --no-daemon
-          working-directory: ./android
-
-  unit-test-android-bte:
-    needs: unit-test
-    runs-on: macOS-latest # macOS-latest is required, tests need HAXM emulator
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache node_modules/
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.OS }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-yarn-cache-
-      - run: yarn --frozen-lockfile
-
-      - name: Cache gradle
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: ./gradlew :app:connectedBteDebugAndroidTest --no-daemon
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 28
-          script: ./gradlew :app:connectedBteDebugAndroidTest --no-daemon
+          script: ./gradlew :app:connectedGpsDebugAndroidTest :app:connectedBteDebugAndroidTest --no-daemon
           working-directory: ./android
 
   unit-test-ios:


### PR DESCRIPTION
This will stop some of the macos action contention because we can only run 5 macos jobs at a time.

#### Linked issues:

NA

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
