### PR TITLE
Fixes broken unchecked icon

### DIFF
--- a/app/assets/images/index.js
+++ b/app/assets/images/index.js
@@ -1,7 +1,7 @@
 import BackArrow from './backArrow.png';
 import BackgroundAtRisk from './backgroundAtRisk.png';
 import BoxCheckedIcon from './boxCheckedIcon.png';
-import boxUncheckedIcon from './boxUncheckedIcon.png';
+import BoxUncheckedIcon from './boxUncheckedIcon.png';
 import Close from './closeIcon.png';
 import Export from './export.png';
 import ForeArrow from './foreArrow.png';
@@ -25,7 +25,7 @@ export const Images = {
   BackArrow,
   BackgroundAtRisk,
   BoxCheckedIcon,
-  boxUncheckedIcon,
+  BoxUncheckedIcon,
   Close,
   Export,
   ForeArrow,

--- a/app/components/Checkbox.js
+++ b/app/components/Checkbox.js
@@ -12,9 +12,7 @@ export const Checkbox = ({ label, onPress, checked }) => {
       accessible
       accessibilityLabel={label}>
       <Image
-        source={
-          checked === true ? Images.boxCheckedIcon : Images.boxUncheckedIcon
-        }
+        source={checked ? Images.BoxCheckedIcon : Images.boxUncheckedIcon}
         style={{ width: 25, height: 25, marginRight: 10 }}
       />
       <Typography use='body1'>{label}</Typography>


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Fixes a broken import of `boxUncheckedIcon.png` that was causing the checked state of the `<Checkbox />` component to not display.

I'm not sure why this was broken in the first place - @tstirrat, curious if you understand.

#### Linked issues:

N/A

#### Screenshots:

Broken checkbox
<img width="388" alt="Screen Shot 2020-05-22 at 5 16 30 PM" src="https://user-images.githubusercontent.com/20157849/82713325-3b093f80-9c50-11ea-9474-435097078bb1.png">

Updated/Fixed
<img width="394" alt="Screen Shot 2020-05-22 at 5 16 20 PM" src="https://user-images.githubusercontent.com/20157849/82713321-3b093f80-9c50-11ea-91e7-96eae0fdd5e8.png">

#### How to test:

Verify that the Checkbox on the EULA screen correctly displays when checked.
