### PR TITLE
Fix [SAF-195] Hide a data source from authorities dropdown menu

### DIFF
--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -359,20 +359,28 @@ class ChooseProviderScreen extends Component {
                       let name = Object.keys(item)[0];
                       let key = this.state.authoritiesList.indexOf(item);
 
-                      return (
-                        <MenuOption
-                          key={key}
-                          onSelect={() => {
-                            this.addAuthorityToState(name);
-                          }}
-                          disabled={this.state.authoritiesList.length === 1}>
-                          <Typography
-                            style={styles.menuOptionText}
-                            use={'body2'}>
-                            {name}
-                          </Typography>
-                        </MenuOption>
-                      );
+                      if (
+                        this.state.selectedAuthorities.findIndex(
+                          x => x.key === name,
+                        ) === -1
+                      ) {
+                        return (
+                          <MenuOption
+                            key={key}
+                            onSelect={() => {
+                              this.addAuthorityToState(name);
+                            }}
+                            disabled={this.state.authoritiesList.length === 1}>
+                            <Typography
+                              style={styles.menuOptionText}
+                              use={'body2'}>
+                              {name}
+                            </Typography>
+                          </MenuOption>
+                        );
+                      } else {
+                        return null;
+                      }
                     })}
                 <MenuOption
                   onSelect={() => {


### PR DESCRIPTION

<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Previously, when user selected a healthcare authority from the dropdown menu, the options would continue to appear. Now when a healthcare authority is selected, it is removed from the menu.

#### Linked issues:

Fixes [SAF-195]: Hide a data source from dropdown menu if the data source has been selected.

#### Screenshots:


Image from [SAF-195] describing issue
<img width="367" alt="Screen Shot 2020-05-22 at 9 17 59 PM" src="https://user-images.githubusercontent.com/39745913/82718699-08703e80-9c72-11ea-92b8-ad086c2df0f5.png">

Image from fix
<img width="342" alt="Screen Shot 2020-05-22 at 9 17 43 PM" src="https://user-images.githubusercontent.com/39745913/82718694-0312f400-9c72-11ea-9af5-d8c8adf94b16.png">


#### How to test:

Create a fresh install of SafePaths. Go to dashboard. Go to "Your Healthcare Authority." Select a healthcare authority from dropdown menu. 


[SAF-195]: https://pathcheck.atlassian.net/browse/SAF-195
[SAF-195]: https://pathcheck.atlassian.net/browse/SAF-195