### PR TITLE
set bte_staging to use adhoc signing

### DIFF
--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -2050,7 +2050,7 @@
 				PRIVATE_HEADERS_FOLDER_PATH = COVIDSafePaths.app/PrivateHeaders;
 				PRODUCT_BUNDLE_IDENTIFIER = org.pathcheck.bt;
 				PRODUCT_NAME = COVIDSafePaths;
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.pathcheck.bt";
+				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc org.pathcheck.bt";
 				PUBLIC_HEADERS_FOLDER_PATH = COVIDSafePaths.app/Headers;
 				SWIFT_OBJC_BRIDGING_HEADER = "COVIDSafePaths-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";


### PR DESCRIPTION
#### Description:
BTE staging job was using app store signing when it should have been using adhoc. Updated to enable ios staging jobs to pass.