### PR TITLE
Fix Missing Checkbox Icon

### DIFF
--- a/app/components/Checkbox.js
+++ b/app/components/Checkbox.js
@@ -12,7 +12,7 @@ export const Checkbox = ({ label, onPress, checked }) => {
       accessible
       accessibilityLabel={label}>
       <Image
-        source={checked ? Images.BoxCheckedIcon : Images.boxUncheckedIcon}
+        source={checked ? Images.BoxCheckedIcon : Images.BoxUncheckedIcon}
         style={{ width: 25, height: 25, marginRight: 10 }}
       />
       <Typography use='body1'>{label}</Typography>


### PR DESCRIPTION
#### Description:
Empty Checkbox has incorrect icon name, so nothing is rendered

#### Screenshots:
Before:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/25315679/82831190-bb64b600-9e85-11ea-91c6-42f209563078.png">

After:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/25315679/82831185-b6a00200-9e85-11ea-8c24-404999365e5c.png">


#### How to Test:
View a checkbox screen, like the terms agreement in onboarding.