### PR TITLE
Remove eslint action from workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,12 +23,6 @@ jobs:
 
       - run: yarn --frozen-lockfile
 
-      # v1 is broken, the given sha was the latest master (but we dont want to track master)
-      - uses: tinovyatkin/action-eslint@8b32772f075413f9192f43641e03d9bd0abae621
-        with:
-          repo-token: ${{secrets.GITHUB_TOKEN}}
-          check-name: eslint # this is the job name from above 👆
-
       # The above eslint action does not show you in the job log what failed,
       # this is just for debugging purposes
       - run: yarn lint


### PR DESCRIPTION
Why:
Currently the tinovyatkin/action-eslint@8b32772f075413f9192f43641e03d9bd0abae621
action fails silently and does not fail for the same reasons as `yarn
lint`

This commit:
Removes the action until we can troubleshoot it.