### PR TITLE
chore(Fix build) Fix iOS staging ipa artifact path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,4 +295,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: COVIDSafePaths-staging-bte
-          path: ios/COVIDSafePaths-bte.ipa
+          path: ios/COVIDSafePaths-bte-staging.ipa


### PR DESCRIPTION
Fix the broken CI on merge into `develop`.

[Failing because of an incorrect file path](https://github.com/Path-Check/covid-safe-paths/runs/709914047)

#### Linked issues:

NA

#### How to test:

Merge and let's see! :)


