### PR TITLE
Feature/android/location hashing

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -241,6 +241,10 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation 'com.github.drfonfon:android-kotlin-geohash:1.0'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.65'
+
     androidTestImplementation('com.wix:detox:+') // detox: e2e testing
     implementation "androidx.core:core-ktx:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/storage/GeohashTests.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/storage/GeohashTests.kt
@@ -67,7 +67,6 @@ class GeohashTests {
         }
 
         val scryptHashes = location.scryptHashes()
-        scryptHashes.forEach { android.util.Log.i("foobar", "hash " + it) }
         assertTrue(scryptHashes.contains("a2dcd196d350fda7"))
     }
 }

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/storage/GeohashTests.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/storage/GeohashTests.kt
@@ -55,7 +55,7 @@ class GeohashTests {
 
     @Test
     fun testScrypt() {
-        assertEquals("0ed62968fef3dc0a", scrypt("gcpuuz8u1586865600"))
+        assertEquals("e727d7eb7c51d1b3", scrypt("gcpuuz8u1586865600"))
     }
 
     @Test
@@ -67,6 +67,7 @@ class GeohashTests {
         }
 
         val scryptHashes = location.scryptHashes()
-        assertTrue(scryptHashes.contains("e2754c01925484c5"))
+        scryptHashes.forEach { android.util.Log.i("foobar", "hash " + it) }
+        assertTrue(scryptHashes.contains("a2dcd196d350fda7"))
     }
 }

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/storage/GeohashTests.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/storage/GeohashTests.kt
@@ -1,0 +1,72 @@
+package org.pathcheck.covidsafepaths.storage
+
+//
+//  GeohashTests.kt
+//  COVIDSafePaths
+//
+//  Created by Tambet Ingo on 05/28/2020.
+//
+
+import com.marianhello.bgloc.data.BackgroundLocation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.pathcheck.covidsafepaths.extensions.*
+
+class GeohashTests {
+    @Test
+    fun testTimeWindow() {
+        val location = BackgroundLocation().apply {
+            latitude = 41.24060321
+            longitude = 14.91328448
+            time = 1586865792000
+        }
+
+        val interval: Long = 60 * 5 * 1000
+        val (early, late) = location.timeWindow(interval)
+        assertEquals(1586865600000, early)
+        assertEquals(1586865900000, late)
+    }
+
+    @Test
+    fun testScryptHashSpec() {
+        val location = BackgroundLocation().apply {
+            latitude = 41.24060321
+            longitude = 14.91328448
+            time = 1589117939000
+        }
+
+        val geohashes = location.geohashes()
+        val expected = listOf(
+                "sr6de7ee1589118000000",
+                "sr6de7ee1589117700000",
+                "sr6de7es1589118000000",
+                "sr6de7es1589117700000",
+                "sr6de7e71589118000000",
+                "sr6de7e71589117700000",
+                "sr6de7ek1589118000000",
+                "sr6de7ek1589117700000"
+        )
+
+        geohashes.forEach { hash ->
+            assertTrue(expected.contains(hash))
+        }
+    }
+
+    @Test
+    fun testScrypt() {
+        assertEquals("0ed62968fef3dc0a", scrypt("gcpuuz8u1586865600"))
+    }
+
+    @Test
+    fun testValidScrypt() {
+        val location = BackgroundLocation().apply {
+            latitude = 41.24060321
+            longitude = 14.91328448
+            time = 1589117939000
+        }
+
+        val scryptHashes = location.scryptHashes()
+        assertTrue(scryptHashes.contains("e2754c01925484c5"))
+    }
+}

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/extensions/BackgroundLocation.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/extensions/BackgroundLocation.kt
@@ -1,0 +1,60 @@
+package org.pathcheck.covidsafepaths.extensions
+
+//
+//  BackgroundLocation.kt
+//  COVIDSafePaths
+//
+//  Created by Tambet Ingo on 05/28/2020.
+//
+
+import com.fonfon.kgeohash.GeoHash
+import com.marianhello.bgloc.data.BackgroundLocation
+import org.bouncycastle.crypto.generators.SCrypt
+import org.pathcheck.covidsafepaths.storage.RealmSecureStorage
+
+private val SALT = "salt".toByteArray()
+private const val LOCATION_INTERVAL: Long = RealmSecureStorage.LOCATION_INTERVAL
+
+// Radius around center point of a given location
+private val GEO_CIRCLE_RADII: List<Pair<Double, Double>> = listOf(
+        0.0 to 0.0, // center
+        0.0001 to 0.0, // N
+        0.00007 to 0.00007, // NE
+        0.0 to 0.0001, // E
+        -0.00007 to 0.00007, // SE
+        -0.0001 to 0.0, // S
+        -0.00007 to -0.00007, // SW
+        0.0 to -0.0001, // W
+        0.00007 to -0.00007 //NW
+)
+
+// Generates rounded time windows for interval before and after timestamp
+// https://pathcheck.atlassian.net/wiki/x/CoDXB
+// - Parameters:
+//   - interval: location storage interval in milliseconds
+fun BackgroundLocation.timeWindow(interval: Long): Pair<Long, Long> {
+    val early = (time - interval / 2) / interval * interval
+    val late = (time + interval / 2) / interval * interval
+    return early to late
+}
+
+// Generates array of geohashes concatenated with time, within a 10 meter radius of given location
+fun BackgroundLocation.geohashes(): List<String> =
+        GEO_CIRCLE_RADII
+                .map { radii ->
+                    val lat = latitude + radii.first
+                    val lng = longitude + radii.second
+                    GeoHash(lat, lng, 8)
+                }
+                .toSet()
+                .flatMap { geohash ->
+                    val (early, late) = timeWindow(LOCATION_INTERVAL)
+                    listOf("$geohash$early", "$geohash$late")
+                }
+
+internal fun scrypt(source: String): String =
+        SCrypt.generate(source.toByteArray(), SALT, 16384, 8, 1, 8)
+                .fold("", { str, it -> str + "%02x".format(it) })
+
+fun BackgroundLocation.scryptHashes(): List<String> =
+        geohashes().map { scrypt(it) }

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/extensions/BackgroundLocation.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/extensions/BackgroundLocation.kt
@@ -53,7 +53,7 @@ fun BackgroundLocation.geohashes(): List<String> =
                 }
 
 internal fun scrypt(source: String): String =
-        SCrypt.generate(source.toByteArray(), SALT, 16384, 8, 1, 8)
+        SCrypt.generate(source.toByteArray(), SALT, 4096, 8, 1, 8)
                 .fold("", { str, it -> str + "%02x".format(it) })
 
 fun BackgroundLocation.scryptHashes(): List<String> =

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/storage/Location.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/storage/Location.kt
@@ -1,18 +1,29 @@
 package org.pathcheck.covidsafepaths.storage
 
 import android.util.Log
-import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
+import com.facebook.react.bridge.*
 import com.marianhello.bgloc.data.BackgroundLocation
 import io.realm.RealmObject
-import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeMap
+import io.realm.RealmList
 import io.realm.annotations.PrimaryKey
+import org.pathcheck.covidsafepaths.extensions.scryptHashes
 import java.lang.Exception
 import kotlin.math.abs
 import kotlin.math.acos
 import kotlin.math.cos
 import kotlin.math.sin
+
+private fun List<String>.toWritableArray(): WritableArray =
+  fold(WritableNativeArray()) { array, str ->
+    array.pushString(str)
+    array
+  }
+
+private fun <T> List<T>.toRealmList(): RealmList<T> =
+  fold(RealmList<T>()) { dst, str ->
+    dst.add(str)
+    dst
+  }
 
 /*
   Realm requires a no-op constructor. Need to use var and fill will default value
@@ -26,16 +37,18 @@ open class Location(
   var accuracy: Float? = null,
   var bearing: Float? = null,
   var provider: String? = null,
+  var hashes: RealmList<String>? = null,
   var mockFlags: Int? = null,
   var source: Int = -1
 ) : RealmObject() {
 
   fun toWritableMap(): WritableMap {
-    val writableMap = WritableNativeMap()
-    writableMap.putDouble(KEY_TIME, time.toDouble())
-    writableMap.putDouble(KEY_LATITUDE, latitude)
-    writableMap.putDouble(KEY_LONGITUDE, longitude)
-    return writableMap
+    return WritableNativeMap().apply {
+      putDouble(KEY_TIME, time.toDouble())
+      putDouble(KEY_LATITUDE, latitude)
+      putDouble(KEY_LONGITUDE, longitude)
+      hashes?.let { putArray(KEY_HASHES, it.toWritableArray()) }
+    }
   }
 
   companion object {
@@ -43,6 +56,7 @@ open class Location(
     const val KEY_LATITUDE = "latitude"
     const val KEY_LONGITUDE = "longitude"
     const val KEY_SOURCE = "source"
+    const val KEY_HASHES = "hashes"
 
     const val SOURCE_DEVICE = 0
     const val SOURCE_MIGRATION = 1
@@ -59,6 +73,7 @@ open class Location(
           accuracy = if (backgroundLocation.hasAccuracy()) backgroundLocation.accuracy else null,
           bearing = if (backgroundLocation.hasBearing()) backgroundLocation.bearing else null,
           provider = backgroundLocation.provider,
+          hashes = backgroundLocation.scryptHashes().toRealmList(),
           mockFlags = backgroundLocation.mockFlags,
           source = SOURCE_DEVICE
       )

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/storage/Migration.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/storage/Migration.kt
@@ -1,0 +1,22 @@
+package org.pathcheck.covidsafepaths.storage
+
+//
+//  Migration.kt
+//  COVIDSafePaths
+//
+//  Created by Tambet Ingo on 05/25/2020.
+//
+
+import io.realm.DynamicRealm
+import io.realm.RealmMigration
+
+internal class Migration: RealmMigration {
+    override fun migrate(realm: DynamicRealm, oldVersion: Long, newVersion: Long) {
+        val schema = realm.schema
+
+        if (oldVersion == 0L) {
+            schema.get("Location")!!
+                    .addRealmListField("hashes", String::class.java)
+        }
+    }
+}

--- a/android/app/src/main/java/org/pathcheck/covidsafepaths/storage/RealmSecureStorage.kt
+++ b/android/app/src/main/java/org/pathcheck/covidsafepaths/storage/RealmSecureStorage.kt
@@ -37,6 +37,7 @@ class RealmSecureStorage(inMemory: Boolean?) {
     const val LOCATION_INTERVAL: Long = 60000 * 5
     private const val MAX_BACKFILL_TIME = 60000 * 60 * 24
     private const val DAYS_TO_KEEP = 14
+    private const val SCHEMA_VERSION: Long = 1
 
     private const val MANUALLY_KEYED_PREF_FILE_NAME = "safepaths_enc_prefs"
     private const val MANUALLY_KEYED_KEY_FILE_NAME = "safepaths_enc_key"
@@ -54,6 +55,8 @@ class RealmSecureStorage(inMemory: Boolean?) {
     val builder = RealmConfiguration.Builder()
         .encryptionKey(encryptionKey)
         .addModule(SafePathsRealmModule())
+        .schemaVersion(SCHEMA_VERSION)
+        .migration(Migration())
 
     if (inMemory != null && inMemory) {
       builder.name(UUID.randomUUID().toString()).inMemory()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,5 +20,6 @@
 android.useAndroidX=true
 android.enableJetifier=true
 # googlePlayServicesVersion=12.0.1
+android.jetifier.blacklist = .*bcprov-jdk15on.*
 
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
Adds the native Android component to support storing and retrieving scrypt hashes based on geohash and timestamp. Includes Realm migration with the addition of a hashes column, which is a List of Strings containing all possible hashes for the given timestamp.

This PR adds two new dependencies:

* geohash kotlin implementation: 
https://github.com/drfonfon/android-kotlin-geohash

* BouncyCastle for scrypt:
https://www.bouncycastle.org/

#### Linked issues:
iOS  PR with corrected comments: #919
Previous Android PR: #907
Previously the thought was to bridge a saveLocation method from the react side but that brought up the issue that the RN dependency actually saves it's own SQLite DB of location data. This required us to provide a transform the the library and implement the hashing natively on iOS and Android.

Android component for:
#807
#806

#### How to test:
Run Android tests
