### PR TITLE
Update Lokalise push to use --poll

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # Only run on a final merge into develop, uploads all changed keys to Lokalised
   lokalise-upload:
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   # Only run on a final merge into develop, uploads all changed keys to Lokalised
   lokalise-upload:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
 
     steps:

--- a/app/locales/push.sh
+++ b/app/locales/push.sh
@@ -36,6 +36,7 @@ lokalise2 file upload \
   --detect-icu-plurals \
   --apply-tm \
   --convert-placeholders \
+  --poll \
   --config .lokalise.yml --token=$LOKALISE_TOKEN
 
 echo "Uploading Documents (e.g. EULA)"
@@ -48,4 +49,5 @@ lokalise2 file upload \
   --detect-icu-plurals \
   --apply-tm \
   --convert-placeholders \
+  --poll \
   --project-id=565995355ea89e2a5f2926.77486458 --token=$LOKALISE_TOKEN


### PR DESCRIPTION
The cli api from 2.5.0+ uses non-blocking operations be default. `--poll` is now required to wait until the upload is complete.

#### How to test:

Ensure the push job completes after the files are uploaded.