### PR TITLE
Feature/ios/scrypt hashes

### DIFF
--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		68D8971324809DAE0091A254 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971124809DAE0091A254 /* Array+Extension.swift */; };
 		68D8971524809E4B0091A254 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971424809E4B0091A254 /* String+Extension.swift */; };
 		68D8971624809E4B0091A254 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971424809E4B0091A254 /* String+Extension.swift */; };
+		68D8971824809F5C0091A254 /* MARULocation+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971724809F5C0091A254 /* MARULocation+ExtensionTests.swift */; };
+		68D8971A24809F9C0091A254 /* GeohashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971924809F9C0091A254 /* GeohashTests.swift */; };
+		68D8971C24809FB50091A254 /* Array+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971B24809FB50091A254 /* Array+ExtensionTests.swift */; };
 		7A2281C376904F23BCA10FCA /* IBMPlexSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 89D241005D9647C4B0586127 /* IBMPlexSans.ttf */; };
 		8A5B44AA7D724388B70F100B /* IBMPlexSans-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 36B22BAB357B44949D2E168C /* IBMPlexSans-ExtraLight.ttf */; };
 		8CB0C49FEC0F493D95420B30 /* IBMPlexMono-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3053DF05D78949A09366B85D /* IBMPlexMono-ExtraLight.ttf */; };
@@ -246,6 +249,9 @@
 		68D8970E24809CEB0091A254 /* Geohash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geohash.swift; sourceTree = "<group>"; };
 		68D8971124809DAE0091A254 /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
 		68D8971424809E4B0091A254 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		68D8971724809F5C0091A254 /* MARULocation+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MARULocation+ExtensionTests.swift"; sourceTree = "<group>"; };
+		68D8971924809F9C0091A254 /* GeohashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashTests.swift; sourceTree = "<group>"; };
+		68D8971B24809FB50091A254 /* Array+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ExtensionTests.swift"; sourceTree = "<group>"; };
 		6BA94CE8425944B8990A49B3 /* IBMPlexSans-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexSans-Bold.ttf"; path = "../app/assets/fonts/IBMPlexSans-Bold.ttf"; sourceTree = "<group>"; };
 		6C8CF282C4264C88A4ED8ABF /* IBMPlexMono-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexMono-Medium.ttf"; path = "../shared/assets/fonts/IBMPlexMono-Medium.ttf"; sourceTree = "<group>"; };
 		71D1C872DB0CCC3BBC3D907E /* Pods-COVIDSafePaths.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVIDSafePaths.debug.xcconfig"; path = "Target Support Files/Pods-COVIDSafePaths/Pods-COVIDSafePaths.debug.xcconfig"; sourceTree = "<group>"; };
@@ -407,6 +413,9 @@
 				00E356F01AD99517003FC87E /* Supporting Files */,
 				271881C22461BF19001DE067 /* RealmSecureStorageTest.swift */,
 				271089AF24698720009AC76F /* LocationTests.swift */,
+				68D8971724809F5C0091A254 /* MARULocation+ExtensionTests.swift */,
+				68D8971924809F9C0091A254 /* GeohashTests.swift */,
+				68D8971B24809FB50091A254 /* Array+ExtensionTests.swift */,
 			);
 			path = COVIDSafePathsTests;
 			sourceTree = "<group>";
@@ -1095,8 +1104,11 @@
 				68D8970D24809B4E0091A254 /* MAURLocation+Extension.swift in Sources */,
 				68D8971024809CEB0091A254 /* Geohash.swift in Sources */,
 				68D8971324809DAE0091A254 /* Array+Extension.swift in Sources */,
+				68D8971A24809F9C0091A254 /* GeohashTests.swift in Sources */,
 				271089B024698720009AC76F /* LocationTests.swift in Sources */,
+				68D8971C24809FB50091A254 /* Array+ExtensionTests.swift in Sources */,
 				00E356F31AD99517003FC87E /* COVIDSafePathsTests.m in Sources */,
+				68D8971824809F5C0091A254 /* MARULocation+ExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -47,6 +47,16 @@
 		57693D8BEF8A40C289F7168A /* IBMPlexSans-ExtraLightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3A582C62ABAC478BBD976037 /* IBMPlexSans-ExtraLightItalic.ttf */; };
 		626DB8AB8AF9D02B9E411601 /* libPods-BTE.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 48FB16255EA745CC27C638A1 /* libPods-BTE.a */; };
 		6858E21561F14E61A6A85280 /* IBMPlexSans-SemiBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 747AA5DBBC684319A8273F2C /* IBMPlexSans-SemiBoldItalic.ttf */; };
+		68D8970624809AA50091A254 /* Scrypt in Frameworks */ = {isa = PBXBuildFile; productRef = 68D8970524809AA50091A254 /* Scrypt */; };
+		68D8970924809ABF0091A254 /* Scrypt in Frameworks */ = {isa = PBXBuildFile; productRef = 68D8970824809ABF0091A254 /* Scrypt */; };
+		68D8970C24809B4E0091A254 /* MAURLocation+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8970B24809B4E0091A254 /* MAURLocation+Extension.swift */; };
+		68D8970D24809B4E0091A254 /* MAURLocation+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8970B24809B4E0091A254 /* MAURLocation+Extension.swift */; };
+		68D8970F24809CEB0091A254 /* Geohash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8970E24809CEB0091A254 /* Geohash.swift */; };
+		68D8971024809CEB0091A254 /* Geohash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8970E24809CEB0091A254 /* Geohash.swift */; };
+		68D8971224809DAE0091A254 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971124809DAE0091A254 /* Array+Extension.swift */; };
+		68D8971324809DAE0091A254 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971124809DAE0091A254 /* Array+Extension.swift */; };
+		68D8971524809E4B0091A254 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971424809E4B0091A254 /* String+Extension.swift */; };
+		68D8971624809E4B0091A254 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8971424809E4B0091A254 /* String+Extension.swift */; };
 		7A2281C376904F23BCA10FCA /* IBMPlexSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 89D241005D9647C4B0586127 /* IBMPlexSans.ttf */; };
 		8A5B44AA7D724388B70F100B /* IBMPlexSans-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 36B22BAB357B44949D2E168C /* IBMPlexSans-ExtraLight.ttf */; };
 		8CB0C49FEC0F493D95420B30 /* IBMPlexMono-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3053DF05D78949A09366B85D /* IBMPlexMono-ExtraLight.ttf */; };
@@ -232,6 +242,10 @@
 		5D98D5DA5B77459FACDD673D /* IBMPlexSans-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexSans-Light.ttf"; path = "../shared/assets/fonts/IBMPlexSans-Light.ttf"; sourceTree = "<group>"; };
 		60B0614ED854C2369C1852FE /* Pods-GPSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GPSTests.release.xcconfig"; path = "Target Support Files/Pods-GPSTests/Pods-GPSTests.release.xcconfig"; sourceTree = "<group>"; };
 		668BDA050EF549C6B0759425 /* IBMPlexSans-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexSans-Bold.ttf"; path = "../shared/assets/fonts/IBMPlexSans-Bold.ttf"; sourceTree = "<group>"; };
+		68D8970B24809B4E0091A254 /* MAURLocation+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MAURLocation+Extension.swift"; sourceTree = "<group>"; };
+		68D8970E24809CEB0091A254 /* Geohash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Geohash.swift; sourceTree = "<group>"; };
+		68D8971124809DAE0091A254 /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
+		68D8971424809E4B0091A254 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		6BA94CE8425944B8990A49B3 /* IBMPlexSans-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexSans-Bold.ttf"; path = "../app/assets/fonts/IBMPlexSans-Bold.ttf"; sourceTree = "<group>"; };
 		6C8CF282C4264C88A4ED8ABF /* IBMPlexMono-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexMono-Medium.ttf"; path = "../shared/assets/fonts/IBMPlexMono-Medium.ttf"; sourceTree = "<group>"; };
 		71D1C872DB0CCC3BBC3D907E /* Pods-COVIDSafePaths.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-COVIDSafePaths.debug.xcconfig"; path = "Target Support Files/Pods-COVIDSafePaths/Pods-COVIDSafePaths.debug.xcconfig"; sourceTree = "<group>"; };
@@ -323,6 +337,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68D8970924809ABF0091A254 /* Scrypt in Frameworks */,
 				B2138BE26880EEA67E6D1C0E /* libPods-GPSTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -346,6 +361,7 @@
 				08445F50242849C1008754AC /* CoreGraphics.framework in Frameworks */,
 				08445F4E24283B0B008754AC /* CoreData.framework in Frameworks */,
 				08445F4C24283AFF008754AC /* Accelerate.framework in Frameworks */,
+				68D8970624809AA50091A254 /* Scrypt in Frameworks */,
 				A49C8C752B3AA7ABB92618E3 /* libPods-GPS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -505,6 +521,7 @@
 		13B07FAE1A68108700A75B9A /* COVIDSafePaths */ = {
 			isa = PBXGroup;
 			children = (
+				68D8970A24809B2D0091A254 /* Extension */,
 				C53FD0C324719C25006D3268 /* BTE */,
 				C53FD07C247199A4006D3268 /* GPS */,
 				276F786A245B6C8A00312927 /* bridge */,
@@ -540,6 +557,7 @@
 				276AB156245238E400D39B58 /* SecureStorage.swift */,
 				276AB15B245291DE00D39B58 /* Location.swift */,
 				271881BF2461AF76001DE067 /* RealmSecureStorage.swift */,
+				68D8970E24809CEB0091A254 /* Geohash.swift */,
 			);
 			name = storage;
 			path = COVIDSafePaths/storage;
@@ -581,6 +599,16 @@
 				2E9077662439A903005C98DE /* libSplashScreen.a */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		68D8970A24809B2D0091A254 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				68D8970B24809B4E0091A254 /* MAURLocation+Extension.swift */,
+				68D8971124809DAE0091A254 /* Array+Extension.swift */,
+				68D8971424809E4B0091A254 /* String+Extension.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -659,6 +687,9 @@
 				271881CC2461C95F001DE067 /* PBXTargetDependency */,
 			);
 			name = GPSTests;
+			packageProductDependencies = (
+				68D8970824809ABF0091A254 /* Scrypt */,
+			);
 			productName = COVIDSafePathsTests;
 			productReference = 00E356EE1AD99517003FC87E /* GPSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -679,6 +710,9 @@
 			dependencies = (
 			);
 			name = GPS;
+			packageProductDependencies = (
+				68D8970524809AA50091A254 /* Scrypt */,
+			);
 			productName = COVIDSafePaths;
 			productReference = 13B07F961A680F5B00A75B9A /* COVIDSafePaths.app */;
 			productType = "com.apple.product-type.application";
@@ -770,6 +804,9 @@
 				"pt-BR",
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
+			packageReferences = (
+				68D8970424809AA40091A254 /* XCRemoteSwiftPackageReference "swift-scrypt" */,
+			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
@@ -1054,6 +1091,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				271881C32461BF19001DE067 /* RealmSecureStorageTest.swift in Sources */,
+				68D8971624809E4B0091A254 /* String+Extension.swift in Sources */,
+				68D8970D24809B4E0091A254 /* MAURLocation+Extension.swift in Sources */,
+				68D8971024809CEB0091A254 /* Geohash.swift in Sources */,
+				68D8971324809DAE0091A254 /* Array+Extension.swift in Sources */,
 				271089B024698720009AC76F /* LocationTests.swift in Sources */,
 				00E356F31AD99517003FC87E /* COVIDSafePathsTests.m in Sources */,
 			);
@@ -1066,8 +1107,12 @@
 				271881C02461AF76001DE067 /* RealmSecureStorage.swift in Sources */,
 				C53FD0632471637D006D3268 /* COVIDSafePathsConfig.m in Sources */,
 				0835F8922441054A00E95AE3 /* RNBackgroundFetch+AppDelegate.m in Sources */,
+				68D8971224809DAE0091A254 /* Array+Extension.swift in Sources */,
+				68D8970F24809CEB0091A254 /* Geohash.swift in Sources */,
 				27F931572459E28800E1024C /* SecureStorageManager.m in Sources */,
+				68D8971524809E4B0091A254 /* String+Extension.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				68D8970C24809B4E0091A254 /* MAURLocation+Extension.swift in Sources */,
 				276AB15C245291DE00D39B58 /* Location.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				27F9315A2459E2BD00E1024C /* SecureStorageManager.swift in Sources */,
@@ -2424,6 +2469,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		68D8970424809AA40091A254 /* XCRemoteSwiftPackageReference "swift-scrypt" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MichaelNeas/swift-scrypt.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		68D8970524809AA50091A254 /* Scrypt */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68D8970424809AA40091A254 /* XCRemoteSwiftPackageReference "swift-scrypt" */;
+			productName = Scrypt;
+		};
+		68D8970824809ABF0091A254 /* Scrypt */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68D8970424809AA40091A254 /* XCRemoteSwiftPackageReference "swift-scrypt" */;
+			productName = Scrypt;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
 }

--- a/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/GPS_Tests.xcscheme
+++ b/ios/COVIDSafePaths.xcodeproj/xcshareddata/xcschemes/GPS_Tests.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "COVIDSafePaths.app"
+               BlueprintName = "GPS"
+               ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -57,15 +71,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "00E356ED1AD99517003FC87E"
-            BuildableName = "GPSTests.xctest"
-            BlueprintName = "GPSTests"
-            ReferencedContainer = "container:COVIDSafePaths.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ios/COVIDSafePaths.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/COVIDSafePaths.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Scrypt",
+        "repositoryURL": "https://github.com/MichaelNeas/swift-scrypt.git",
+        "state": {
+          "branch": "master",
+          "revision": "ef765c45ee568f662e2111ba59f51badfde56da2",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/ios/COVIDSafePaths/storage/Geohash.swift
+++ b/ios/COVIDSafePaths/storage/Geohash.swift
@@ -1,0 +1,120 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 Naoki Hiroshima
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// Influenced by https://github.com/nh7a/Geohash/blob/master/Sources/Geohash/Geohash.swift
+// GeoHash information https://www.movable-type.co.uk/scripts/geohash.html
+import Foundation
+
+public struct Geohash {
+  public static func decode(hash: String) -> (latitude: (min: Double, max: Double), longitude: (min: Double, max: Double))? {
+    // For example: hash = u4pruydqqvj
+    let bits = hash.map { bitmap[$0] ?? "?" }.joined(separator: "")
+    guard bits.count % 5 == 0 else { return nil }
+    // bits = 1101000100101011011111010111100110010110101101101110001
+    
+    let (lat, lon) = bits.enumerated().reduce(into: ([Character](), [Character]())) {
+      if $1.0 % 2 == 0 {
+        $0.1.append($1.1)
+      } else {
+        $0.0.append($1.1)
+      }
+    }
+    // lat = [1,1,0,1,0,0,0,1,1,1,1,1,1,1,0,1,0,1,1,0,0,1,1,0,1,0,0]
+    // lon = [1,0,0,0,0,1,1,1,0,1,1,0,0,1,1,0,1,0,0,1,1,1,0,1,1,1,0,1]
+    
+    func combiner(array a: (min: Double, max: Double), value: Character) -> (Double, Double) {
+      let mean = (a.min + a.max) / 2
+      return value == "1" ? (mean, a.max) : (a.min, mean)
+    }
+
+    let latRange = lat.reduce((-90.0, 90.0), combiner)
+    // latRange = (57.649109959602356, 57.649111300706863)
+    
+    let lonRange = lon.reduce((-180.0, 180.0), combiner)
+    // lonRange = (10.407439023256302, 10.407440364360809)
+    
+    return (latRange, lonRange)
+  }
+
+  public static func encode(latitude: Double, longitude: Double, length: Int) -> String {
+    // For example: (latitude, longitude) = (57.6491106301546, 10.4074396938086)
+    func combiner(array a: (min: Double, max: Double, array: [String]), value: Double) -> (Double, Double, [String]) {
+      let mean = (a.min + a.max) / 2
+      if value < mean {
+        return (a.min, mean, a.array + "0")
+      } else {
+        return (mean, a.max, a.array + "1")
+      }
+    }
+
+    let lat = Array(repeating: latitude, count: length*5).reduce((-90.0, 90.0, [String]()), combiner)
+    // lat = (57.64911063015461, 57.649110630154766, [1,1,0,1,0,0,0,1,1,1,1,1,1,1,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,0,...])
+    
+    let lon = Array(repeating: longitude, count: length*5).reduce((-180.0, 180.0, [String]()), combiner)
+    // lon = (10.407439693808236, 10.407439693808556, [1,0,0,0,0,1,1,1,0,1,1,0,0,1,1,0,1,0,0,1,1,1,0,1,1,1,0,1,0,1,..])
+    
+    let latlon = lon.2.enumerated().flatMap { [$1, lat.2[$0]] }
+    // latlon - [1,1,0,1,0,0,0,1,0,0,1,0,1,0,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,...]
+    
+    let bits = latlon.enumerated().reduce([String]()) { $1.0 % 5 > 0 ? $0 << $1.1 : $0 + $1.1 }
+    //  bits: [11010,00100,10101,10111,11010,11110,01100,10110,10110,11011,10001,10010,10101,...]
+    
+    let arr = bits.compactMap { charmap[$0] }
+    // arr: [u,4,p,r,u,y,d,q,q,v,j,k,p,b,...]
+    
+    return String(arr.prefix(length))
+  }
+
+  /// Radius around center point of a given location
+  public static let GEO_CIRCLE_RADII: [(latitude: Double, longitude: Double)] = [
+    (0, 0), // center
+    (0.0001, 0), // N
+    (0.00007, 0.00007), // NE
+    (0, 0.0001), // E
+    (-0.00007, 0.00007), // SE
+    (-0.0001, 0), // S
+    (-0.00007, -0.00007), // SW
+    (0, -0.0001), // W
+    (0.00007, -0.00007) //NW
+  ]
+
+  // MARK: Private
+  private static let bitmap = "0123456789bcdefghjkmnpqrstuvwxyz".enumerated()
+    .map {($1, String(integer: $0, radix: 2, padding: 5))}
+    .reduce(into: [Character: String]()) { $0[$1.0] = $1.1 }
+
+  private static let charmap = bitmap
+    .reduce(into: [String: Character]()) { $0[$1.1] = $1.0 }
+}
+
+private func + (left: [String], right: String) -> [String] {
+  var arr = left
+  arr.append(right)
+  return arr
+}
+
+private func << (left: [String], right: String) -> [String] {
+  var arr = left
+  var s = arr.popLast()!
+  s += right
+  arr.append(s)
+  return arr
+}

--- a/ios/COVIDSafePaths/storage/Location.swift
+++ b/ios/COVIDSafePaths/storage/Location.swift
@@ -15,6 +15,7 @@ class Location: Object {
   static let KEY_LATITUDE = "latitude"
   static let KEY_LONGITUDE = "longitude"
   static let KEY_SOURCE = "source"
+  static let KEY_HASHES = "hashes"
   
   static let SOURCE_DEVICE = 0
   static let SOURCE_MIGRATION = 1
@@ -27,6 +28,7 @@ class Location: Object {
   dynamic var longitude: Double = 0
   dynamic var source: Int = -1
   dynamic var provider: String?
+  var hashes = List<String>()
   let altitude = RealmOptional<Double>()
   let speed = RealmOptional<Float>()
   let accuracy = RealmOptional<Float>()
@@ -41,7 +43,8 @@ class Location: Object {
     return [
       Location.KEY_TIME: time * 1000,
       Location.KEY_LATITUDE: latitude,
-      Location.KEY_LONGITUDE: longitude
+      Location.KEY_LONGITUDE: longitude,
+      Location.KEY_HASHES: Array(hashes)
     ]
   }
   
@@ -56,6 +59,7 @@ class Location: Object {
     location.altitudeAccuracy.value = backgroundLocation.altitudeAccuracy?.floatValue
     location.bearing.value = backgroundLocation.heading?.floatValue
     location.source = SOURCE_DEVICE
+    location.hashes.append(objectsIn: backgroundLocation.scryptHashes)
     return location;
   }
   

--- a/ios/COVIDSafePaths/storage/RealmSecureStorage.swift
+++ b/ios/COVIDSafePaths/storage/RealmSecureStorage.swift
@@ -186,9 +186,11 @@ class RealmSecureStorage {
   func getRealmConfig() -> Realm.Configuration? {
     if let key = getEncyrptionKey() {
       if (inMemory) {
-        return Realm.Configuration(inMemoryIdentifier: "temp", encryptionKey: key as Data, objectTypes: [Location.self])
+        return Realm.Configuration(inMemoryIdentifier: "temp", encryptionKey: key as Data, schemaVersion: 1,
+                                   migrationBlock: { _, _ in }, objectTypes: [Location.self])
       } else {
-        return Realm.Configuration(encryptionKey: key as Data, objectTypes: [Location.self])
+        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 1,
+                                  migrationBlock: { _, _ in }, objectTypes: [Location.self])
       }
     } else {
       return nil

--- a/ios/COVIDSafePathsTests/Array+ExtensionTests.swift
+++ b/ios/COVIDSafePathsTests/Array+ExtensionTests.swift
@@ -1,0 +1,22 @@
+//
+//  Array+ExtensionTests.swift
+//  GPSTests
+//
+//  Created by Michael Neas on 5/28/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+
+import XCTest
+
+class Array_ExtensionTests: XCTestCase {
+
+    func testArrayInitHex() {
+      let bytes = Array<UInt8>(hex: "0xb1b1b2b2")
+      XCTAssertEqual(bytes, [177, 177, 178, 178])
+
+      let str = "b1b2b3b3b3b3b3b3b1b2b3b3b3b3b3b3"
+      let array = Array<UInt8>(hex: str)
+      let hex = array.toHexString()
+      XCTAssertEqual(str, hex)
+    }
+}

--- a/ios/COVIDSafePathsTests/GeohashTests.swift
+++ b/ios/COVIDSafePathsTests/GeohashTests.swift
@@ -1,0 +1,34 @@
+//
+//  GeohashTests.swift
+//  GPSTests
+//
+//  Created by Michael Neas on 5/28/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+
+
+import XCTest
+
+class GeohashTests: XCTestCase {
+  func testGeoHash() {
+    let location = TestMAURLocation(latitude: 42.360084, longitude: -71.058905, date: Date())
+    let hashes = [
+      "d",
+      "dr",
+      "drt",
+      "drt2",
+      "drt2z",
+      "drt2zp",
+      "drt2zp2",
+      "drt2zp2m",
+      "drt2zp2mr"
+    ]
+    for index in 0..<hashes.count {
+      XCTAssertEqual(Geohash.encode(latitude: location.latitude.doubleValue, longitude: location.longitude.doubleValue, length: index + 1), hashes[index])
+    }
+  }
+
+  func testGeohashSpec() {
+    XCTAssertEqual("sr6de7ee", Geohash.encode(latitude: 41.24060321, longitude: 14.91328448, length: 8))
+  }
+}

--- a/ios/COVIDSafePathsTests/MARULocation+ExtensionTests.swift
+++ b/ios/COVIDSafePathsTests/MARULocation+ExtensionTests.swift
@@ -1,0 +1,65 @@
+//
+//  MAURLocation+ExtensionTests.swift
+//  GPSTests
+//
+//  Created by Michael Neas on 5/27/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+import XCTest
+
+class MAURLocation_ExtensionTests: XCTestCase {
+
+  func testTimeWindow() {
+    let date = Date(timeIntervalSince1970: 1586865792000)
+    let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: date)
+    let windows = backgroundLocation.timeWindows(interval: 60 * 5 * 1000)
+    XCTAssertEqual(windows.early, 1586865600000)
+    XCTAssertEqual(windows.late, 1586865900000)
+  }
+
+  func testScryptHashSpec() {
+    let date = Date(timeIntervalSince1970: 1589117939000)
+    let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: date)
+    let scryptHashes = backgroundLocation.geoHashes
+
+    let hashes = ["sr6de7ee1589118000000",
+    "sr6de7ee1589117700000",
+    "sr6de7es1589118000000",
+    "sr6de7es1589117700000",
+    "sr6de7e71589118000000",
+    "sr6de7e71589117700000",
+    "sr6de7ek1589118000000",
+    "sr6de7ek1589117700000"
+    ]
+
+    for hash in scryptHashes  {
+      XCTAssertTrue(hashes.contains(hash))
+    }
+  }
+  
+  func testScrypt() {
+    let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: Date(timeIntervalSince1970: 1586865600000))
+    let input = "gcpuuz8u1586865600"
+    XCTAssertEqual(backgroundLocation.scrypt(on: input), "e727d7eb7c51d1b3")
+  }
+
+  func testValidScrypt() {
+    let date = Date(timeIntervalSince1970: 1589117939000)
+    let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: date)
+    let scryptHashes = backgroundLocation.scryptHashes
+    let expectedHashes = [
+      "a2dcd196d350fda7",
+      "9ec071d139d8221f",
+      "b3ddc01c5c2666e3",
+      "c0d26f3cc00fe1ac",
+      "5a9f2a50f0a8460e",
+      "37eb1f8a2949e0bd",
+      "6a900d469793d572",
+      "6f0cc27428f105b8"
+    ]
+
+    for hash in scryptHashes {
+      XCTAssertTrue(expectedHashes.contains(hash))
+    }
+  }
+}

--- a/ios/Extension/Array+Extension.swift
+++ b/ios/Extension/Array+Extension.swift
@@ -1,0 +1,72 @@
+//
+//  Array+Extensions.swift
+//  COVIDSafePaths
+//
+//  Created by Michael Neas on 5/28/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+
+import Foundation
+
+// influenced by: https://github.com/krzyzanowskim/CryptoSwift/blob/1755bd0917f401451d16faafe3c8e078b8eeb9c9/Sources/CryptoSwift/Array%2BExtension.swift
+// allows us to convert UInt8 arrays to hexStrings for scrypt
+extension Array {
+  init(reserveCapacity: Int) {
+    self = Array<Element>()
+    self.reserveCapacity(reserveCapacity)
+  }
+
+  var slice: ArraySlice<Element> {
+    self[self.startIndex ..< self.endIndex]
+  }
+}
+
+extension Array where Element == UInt8 {
+  public init(hex: String) {
+    self.init(reserveCapacity: hex.unicodeScalars.lazy.underestimatedCount)
+    var buffer: UInt8?
+    var skip = hex.hasPrefix("0x") ? 2 : 0
+    for char in hex.unicodeScalars.lazy {
+      guard skip == 0 else {
+        skip -= 1
+        continue
+      }
+      guard char.value >= 48 && char.value <= 102 else {
+        removeAll()
+        return
+      }
+      let v: UInt8
+      let c: UInt8 = UInt8(char.value)
+      switch c {
+        case let c where c <= 57:
+          v = c - 48
+        case let c where c >= 65 && c <= 70:
+          v = c - 55
+        case let c where c >= 97:
+          v = c - 87
+        default:
+          removeAll()
+          return
+      }
+      if let b = buffer {
+        append(b << 4 | v)
+        buffer = nil
+      } else {
+        buffer = v
+      }
+    }
+    if let b = buffer {
+      append(b)
+    }
+  }
+
+  public func toHexString() -> String {
+    `lazy`.reduce(into: "") {
+      var s = String($1, radix: 16)
+      if s.count == 1 {
+        s = "0" + s
+      }
+      $0 += s
+    }
+  }
+}

--- a/ios/Extension/MAURLocation+Extension.swift
+++ b/ios/Extension/MAURLocation+Extension.swift
@@ -1,0 +1,54 @@
+//
+//  MAURLocation+Extension.swift
+//  COVIDSafePaths
+//
+//  Created by Michael Neas on 5/21/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+import Foundation
+import Scrypt
+
+public extension MAURLocation {
+  /// Generates rounded time windows for interval before and after timestamp
+  /// https://pathcheck.atlassian.net/wiki/x/CoDXB
+  /// - Parameters:
+  ///   - interval: location storage interval in seconds
+  func timeWindows(interval: TimeInterval) -> (early: Int, late: Int) {
+    let time1 = Int(((time.timeIntervalSince1970 - interval / 2) / interval).rounded(.down) * interval)
+    let time2 = Int(((time.timeIntervalSince1970 + interval / 2) / interval).rounded(.down) * interval)
+    return (time1, time2)
+  }
+
+  /// Generates array of geohashes concatenated with time, within a 10 meter radius of given location
+  var geoHashes: [String] {
+    Geohash.GEO_CIRCLE_RADII.map({ radii in
+      (latitude.doubleValue + radii.latitude, longitude.doubleValue + radii.longitude)
+    }).reduce(into: Set<String>(), { (hashes, currentLocation) in
+      hashes.insert(Geohash.encode(latitude: currentLocation.0, longitude: currentLocation.1, length: 8))
+    }).reduce(into: [String](), { (hashes, hash) in
+      let timeWindow = timeWindows(interval: Double(60 * 5 * 1000))
+      hashes.append("\(hash)\(timeWindow.early)")
+      hashes.append("\(hash)\(timeWindow.late)")
+    })
+  }
+
+  /// Encodes geoHashes with the scrypt algorithm
+  var scryptHashes: [String] {
+    geoHashes.map(scrypt)
+  }
+
+  /// Apply scrypt hash algorithm on a String
+  ///
+  /// - Parameters:
+  ///     - hash: value to hash
+  func scrypt(on hash: String) -> String {
+    let hash = Array(hash.utf8)
+    let generic = Array("salt".utf8)
+    ///  A “cost” (N) that is to be determined.  Initially was 16384, then modified to 4096
+    ///  A salt of “salt”
+    ///  A block size of 8
+    ///  A keylen (output) of 8 bytes = 16 hex digits.
+    /// Parallelization (p) of 1 - this is the default.
+    return try! Scrypt.scrypt(password: hash, salt: generic, length: 8,N: 4096, r: 8, p: 1).toHexString()
+  }
+}

--- a/ios/Extension/String+Extension.swift
+++ b/ios/Extension/String+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  String+Extension.swift
+//  COVIDSafePaths
+//
+//  Created by Michael Neas on 5/28/20.
+//  Copyright © 2020 Path Check Inc. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+  init(integer n: Int, radix: Int, padding: Int) {
+    let s = String(n, radix: radix)
+    let pad = (padding - s.count % padding) % padding
+    self = Array(repeating: "0", count: pad).joined(separator: "") + s
+  }
+}


### PR DESCRIPTION
Description:

Previous PR got a little messy, getting the c library to work nicely.  I remade the PR for better commits.

Adds the native iOS component to support storing and retrieving scrypt hashes based on geohash and timestamp. Includes Realm migration with the addition of a hashes column, which is a List of Strings containing all possible hashes for the given timestamp. No migration code needs to go inside the block but the schema version must increase and there must exist a migrationBlock. https://realm.io/docs/swift/latest/#migrations

This PR brings in and slightly modifies a geohash struct found here: https://github.com/nh7a/Geohash/blob/master/Sources/Geohash/Geohash.swift

CryptoSwift implementation of Scrypt was performing too poorly (290 seconds for 4 hashes with the suggested N size). Added Swift Package Managed wrapper above libscrypt found here: https://github.com/greymass/swift-scrypt
Linked issues:

Android PR with corrected comments: #907
Previous iOS PR: #898 #919 
Previously the thought was to bridge a saveLocation method from the react side but that brought up the issue that the RN dependency actually saves it's own SQLite DB of location data. This required us to provide a transform the the library and implement the hashing natively on iOS and Android.

iOS component for:
#807
#806
How to test:

Run ios/COVIDSafePathsTests/