### PR TITLE
Remove location hashes from location upload JSON

### DIFF
--- a/app/views/Export/ExportLocally.js
+++ b/app/views/Export/ExportLocally.js
@@ -55,7 +55,13 @@ const ExportLocally = ({ navigation }) => {
       let unixtimeUTC = Date.parse(nowUTC);
 
       let options = {};
-      let jsonData = JSON.stringify(locationData);
+      let jsonData = JSON.stringify(
+        locationData.map(({ latitude, longitude, time }) => ({
+          latitude,
+          longitude,
+          time,
+        })),
+      );
       const title = 'COVIDSafePaths.json';
       const filename = unixtimeUTC + '.json';
       const message = 'Here is my location log from COVID Safe Paths.';


### PR DESCRIPTION
#### Description:
https://github.com/Path-Check/covid-safe-paths/pull/925 and https://github.com/Path-Check/covid-safe-paths/pull/928 recently added location hashes to each location stored on the device. 

When we retrieve these locations to export them to safe places we want to make sure we do not upload the hashes as well. This PR makes sure that we only upload a location's `latitude` `longitude`, and `time` to safe places.


#### How to test:
You can call `console.log(jsonData)` in the `onShare` method in Export.js to verify that hashes are not uploaded
