### PR TITLE
[SAF-275] - Download HA JSON file up into fragments, one for every 12 hours

### DIFF
--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -434,8 +434,7 @@ async function asyncCheckIntersect() {
   // Fetch previous dayBins for intersections
   let dayBins = await GetStoreData(CROSSED_PATHS);
 
-  // Init the arrays for new intersection data and for the news urls
-  let tempDayBins = [];
+  // Init the array for the news urls
   let name_news = [];
 
   // get the saved set of locations for the user, already sorted
@@ -492,7 +491,7 @@ async function asyncCheckIntersect() {
   if (dayBins.some(a => a > 0)) notifyUserOfRisk();
 
   // store the results
-  SetStoreData(CROSSED_PATHS, tempDayBins); // TODO: Store per authority?
+  SetStoreData(CROSSED_PATHS, dayBins); // TODO: Store per authority?
 
   // save off the current time as the last checked time
   let unixtimeUTC = dayjs().valueOf();

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -432,7 +432,7 @@ async function asyncCheckIntersect() {
     return null;
 
   // Fetch previous dayBins for intersections
-  const dayBins = await GetStoreData(CROSSED_PATHS);
+  let dayBins = await GetStoreData(CROSSED_PATHS);
 
   // Init the arrays for new intersection data and for the news urls
   let tempDayBins = [];
@@ -472,10 +472,10 @@ async function asyncCheckIntersect() {
         // Update each day's bin with the result from the intersection.  To keep the
         //  difference between no data (==-1) and exposure data (>=0), there
         //  are a total of 3 cases to consider.
-        tempDayBins = tempDayBins.map((currentValue, i) => {
+        dayBins = tempDayBins.map((currentValue, i) => {
           if (currentValue < 0) return dayBins[i];
           if (dayBins[i] < 0) return currentValue;
-          return currentValue + tempDayBins[i];
+          return currentValue + dayBins[i];
         });
       } catch (error) {
         // TODO: We silently fail.  Could be a JSON parsing issue, could be a network issue, etc.


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
This PR adds functionality for fetching HA data points in chunks.

It also depends on [#938](https://github.com/Path-Check/covid-safe-paths/pull/938) that is also in draft, due to lack of unit-tests.

For each health authority, we now store a `cursor` attribute, which tells us the last page of data points that was downloaded and intersected with local GPS data points. Each page consists of data point hashes that have been published by that HA in the last 12 hours.

The pages that are "older" than the `cursor` are skipped, which reduces the overall intersection calculation time.

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### How to test:
- This is still a WIP pull request, unit-tests will be pushed in future commits, and it serves as a demo for the algorithm