### PR TITLE
Update detox scripts to use correct product

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     },
     "configurations": {
       "iphone11.sim": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/COVIDSafePaths.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/GPS.app",
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme GPS_Development -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
@@ -161,7 +161,7 @@
         }
       },
       "iphone8.sim": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/COVIDSafePaths.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/GPS.app",
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme GPS_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
@@ -169,7 +169,7 @@
         }
       },
       "iphone-se.sim": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/COVIDSafePaths.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/GPS.app",
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme GPS_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
@@ -177,7 +177,7 @@
         }
       },
       "iphone11-bte.sim": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/COVIDSafePaths.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/BTE.app",
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme BTE_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
@@ -185,7 +185,7 @@
         }
       },
       "iphone8-bte.sim": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/COVIDSafePaths.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/BTE.app",
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme BTE_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
@@ -193,7 +193,7 @@
         }
       },
       "iphone-se-bte.sim": {
-        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/COVIDSafePaths.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/BTE.app",
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme BTE_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {


### PR DESCRIPTION
Why:
A previous commit updated the product names for the various builds and
the detox test scripts were not updated to the new names.

This commit:
Updates the detox scripts to the correct names.

### How to test:

The detox tests pass on CI