### PR TITLE
Use xcode 11.5 for workflow ios builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_11.app
+        run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1
@@ -231,7 +231,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_11.app
+        run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_11.app
+        run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_11.app
+        run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_11.app
+        run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set XCode Version
-        run: sudo xcode-select -s /Applications/Xcode_11.app
+        run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
         uses: actions/cache@v1
@@ -182,7 +182,7 @@ jobs:
     needs: e2e-ios-build
     timeout-minutes: 15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app
+      DEVELOPER_DIR: /Applications/Xcode_11.5.app
     steps:
       - uses: actions/checkout@master
       - name: Cache node_modules/
@@ -210,7 +210,7 @@ jobs:
 
       # - run: xcrun simctl list runtimes
 
-      - run: xcrun simctl create "iPhone SE" com.apple.CoreSimulator.SimDeviceType.iPhone-SE com.apple.CoreSimulator.SimRuntime.iOS-13-4
+      - run: xcrun simctl create "iPhone SE (2nd generation)" com.apple.CoreSimulator.SimDeviceType.iPhone-SE com.apple.CoreSimulator.SimRuntime.iOS-13-5
 
       - run: xcrun simctl list
 

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -123,7 +123,6 @@
 		C5C850C7248014F700A494CA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C5C850C6248014F700A494CA /* main.m */; };
 		C5C850CA2480156200A494CA /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C5C850C92480156200A494CA /* AppDelegate.m */; };
 		C5EF723724864F8500AA39D5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C5EF72202485D0E600AA39D5 /* main.m */; };
-		C5EF7246248654A900AA39D5 /* Scrypt in Frameworks */ = {isa = PBXBuildFile; productRef = C5EF7245248654A900AA39D5 /* Scrypt */; };
 		D43E27B6F1E045D798270A11 /* IBMPlexSans-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4904B061CC24439783E20928 /* IBMPlexSans-SemiBold.ttf */; };
 		D668C3DAB08B4FCBB01E8C2D /* IBMPlexMono-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E5C8EDCCEFCE4874A747E404 /* IBMPlexMono-Light.ttf */; };
 		D7E714F18C9C4172BC01ADF8 /* IBMPlexMono-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BF6254720C1D4A3288ECE351 /* IBMPlexMono-SemiBold.ttf */; };
@@ -349,7 +348,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C5EF7246248654A900AA39D5 /* Scrypt in Frameworks */,
 				B2138BE26880EEA67E6D1C0E /* libPods-GPSTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -716,7 +714,6 @@
 			);
 			name = GPSTests;
 			packageProductDependencies = (
-				C5EF7245248654A900AA39D5 /* Scrypt */,
 			);
 			productName = COVIDSafePathsTests;
 			productReference = 00E356EE1AD99517003FC87E /* GPSTests.xctest */;
@@ -2268,11 +2265,6 @@
 			productName = Scrypt;
 		};
 		68EFB21724857A3D003D84F3 /* Scrypt */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 68D8970424809AA40091A254 /* XCRemoteSwiftPackageReference "swift-scrypt" */;
-			productName = Scrypt;
-		};
-		C5EF7245248654A900AA39D5 /* Scrypt */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 68D8970424809AA40091A254 /* XCRemoteSwiftPackageReference "swift-scrypt" */;
 			productName = Scrypt;

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme GPS_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone SE"
+          "type": "iPhone SE (2nd generation)"
         }
       },
       "iphone11-bte.sim": {
@@ -197,7 +197,7 @@
         "build": "xcodebuild -workspace ios/COVIDSafePaths.xcworkspace -scheme BTE_Production -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone SE"
+          "type": "iPhone SE (2nd generation)"
         }
       }
     },


### PR DESCRIPTION
Why:
We would like to be able to use the swift package manager and be on the
latest version of xcode to have the most up to date support and
security patches. Currently all of our github actions are building with
xcode 11.

This commit:
Updates the various actions to use Xcode_11.5.app, which is the most
recent version available on github virtual environments at the moment:

https://github.com/actions/virtual-environments/blob/43e26fa96b8e36c96dc4f825b349bd417625b92c/images/macos/macos-10.15-Readme.md

Note that for us to be able to use the ExposureNotification entitlement
recently released by apple we will need to build with Xcode 11.5 beta,
which isn't available on github actions at the moment.

#### How to test

Notice that the github actions that include building an ios binary work.