### PR TITLE
Fixes incorrect app strings for Android.

### DIFF
--- a/android/app/src/bte/res/values/strings.xml
+++ b/android/app/src/bte/res/values/strings.xml
@@ -3,7 +3,7 @@
   <!-- Shown on app info, app switcher, etc -->
   <string name="app_name" translatable="false">PathCheck BT</string>
   <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">Path Check BT</string>
+  <string name="app_name_short" translatable="false">PathCheck BT</string>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Path Check BT notifications</string>
+  <string name="notification_channel_description">PathCheck BT notifications</string>
 </resources>

--- a/android/app/src/gps/res/values/strings.xml
+++ b/android/app/src/gps/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
+  <string name="app_name" translatable="false">PathCheck GPS</string>
   <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">Path Check BT</string>
+  <string name="app_name_short" translatable="false">PathCheck GPS</string>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">Path Check BT notifications</string>
+  <string name="notification_channel_description">PathCheck GPS notifications</string>
 </resources>


### PR DESCRIPTION
Fix incorrect strings (`app_name`, `app_name_short`, `notification_channel_description`) for GPS and BTE product flavors.