### PR TITLE
Update Android Unit Tests with Timestamp Examples in Milliseconds

### DIFF
--- a/android/app/src/androidTestGps/java/org/pathcheck/covidsafepaths/gps/storage/GeohashTests.kt
+++ b/android/app/src/androidTestGps/java/org/pathcheck/covidsafepaths/gps/storage/GeohashTests.kt
@@ -55,7 +55,7 @@ class GeohashTests {
 
     @Test
     fun testScrypt() {
-        assertEquals("e727d7eb7c51d1b3", scrypt("gcpuuz8u1586865600"))
+        assertEquals("c9414c55812d796a", scrypt("gcpuuz8u1586865600000"))
     }
 
     @Test


### PR DESCRIPTION
#### Description:
The location hashing algorithm overview has been updated to use UTC timestamps in units of milliseconds instead of seconds
https://pathcheck.atlassian.net/wiki/spaces/TEST/pages/81231882/Hashing+of+GPS+points+-+Design#The-Hash-Calculation

This PR updates a single android unit tests that had an example location timestamp in seconds. This should clarify any confusion about what unit timestamps should be in. Moving forward all location timestamps should be in milliseconds in both Safe Paths and Safe Places

#### How to test:

Run the android unit tests locally. More specifically you could run the single test I've modified in `GeohashTests.kt`
