### PR TITLE
Update yarn run-ios-bte script ios target

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "validate": "yarn prettier --list-different && yarn tsc && yarn lint",
     "run-android-bte": "react-native run-android --variant=bteDebug --appId=org.pathcheck.covidsafepathsBte",
     "run-android-gps": "react-native run-android --variant=gpsDebug --appId=org.pathcheck.covidsafepaths",
-    "run-ios-bte": "yarn install:pod && react-native run-ios --scheme \"BTE_Development\"",
+    "run-ios-bte": "yarn install:pod && react-native run-ios --scheme \"BTE_Development\" --simulator \"iPhone 11 (13.5)\"",
     "run-ios-gps": "yarn install:pod && react-native run-ios --scheme \"GPS_Development\"",
     "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('You must use Yarn to install, not NPM')\"",
     "install:pod": "cd ios && bundle install --quiet && bundle exec pod install --silent",


### PR DESCRIPTION
Why:
Currently the yarn run-ios-bte script does not successfully build and
run the bte version of the app. The reason for this is because a recent
commit changed the bte ios target to 13.5, as it is required to use the
exposure notifications api, but the react-native cli does not correctly
find the ios 13.5 versions of the simulator to build to.

This commit:
Explicitly specifies iOS 13.5 in the build script.
