### PR TITLE
Run validate script in ci actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Validate
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  eslint:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -27,9 +27,7 @@ jobs:
       - uses: tinovyatkin/action-eslint@8b32772f075413f9192f43641e03d9bd0abae621
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
-          check-name: eslint # this is the job name from above 👆
+          check-name: validate # this is the job name from above 👆
 
-      # The above eslint action does not show you in the job log what failed,
-      # this is just for debugging purposes
-      - run: yarn lint
+      - run: yarn validate
         if: ${{ always() }}

--- a/app/api/export/exportConsentApi.ts
+++ b/app/api/export/exportConsentApi.ts
@@ -1,4 +1,4 @@
-import type { HealthcareAuthority } from '../HealthcareAuthorities/getHealthcareAuthoritiesApi';
+import type { HealthcareAuthority } from '../healthcareAuthorities/getHealthcareAuthoritiesApi';
 
 const exportConsentApi = async (
   authority: HealthcareAuthority,

--- a/app/api/export/exportUploadApi.ts
+++ b/app/api/export/exportUploadApi.ts
@@ -1,4 +1,4 @@
-import { HealthcareAuthority } from '../HealthcareAuthorities/getHealthcareAuthoritiesApi';
+import { HealthcareAuthority } from '../healthcareAuthorities/getHealthcareAuthoritiesApi';
 
 // Concern Point should be defined outside of this module.
 // Currently the concern point generation is done in JS, and the contract is changing.


### PR DESCRIPTION
Why:
Currently ci is only running eslint as a static analysis tool. We would
like to be running prettier and tsc as well during ci.

This commit:
Changes the lint action to a validate action which will run prettier,
eslint, and tsc.