### PR TITLE
Update logkitty dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "jest": "^25.1.0",
     "lint-diff": "^1.2.1",
     "lint-staged": "^10.0.9",
+    "logkitty": "^0.7.1",
     "metro-react-native-babel-preset": "^0.58.0",
     "mockdate": "^2.0.5",
     "prettier": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6527,6 +6527,15 @@ logkitty@^0.6.0:
     dayjs "^1.8.15"
     yargs "^12.0.5"
 
+logkitty@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/logkitty/-/logkitty-0.7.1.tgz#8e8d62f4085a826e8d38987722570234e33c6aa7"
+  integrity sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==
+  dependencies:
+    ansi-fragments "^0.2.1"
+    dayjs "^1.8.15"
+    yargs "^15.1.0"
+
 lolex@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
@@ -10898,7 +10907,7 @@ yargs@^13.0.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.3.1:
+yargs@^15.1.0, yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==


### PR DESCRIPTION
Why:
Currently we have a security vulnerability in the logkitty dependency.

This commit:
Updates to the latest version. Not that the isnt a direct dependency,
but an indirect dependency of react-native itself. A better solution
would be to update react-native to 0.62 but we are just logkitty for
sake of time. A future commit should remove logkitty as a direct
dependency.