### PR TITLE
Fix type declaration for @emotion/native

### DIFF
--- a/app/declarations.d.ts
+++ b/app/declarations.d.ts
@@ -7,7 +7,8 @@ declare module '*.svg' {
 
 declare module '*.png' {}
 
-declare module '@emtion/native' {
-  const styled: Record<string, unknown>;
+declare module '@emotion/native' {
+  /* eslint-disable @typescript-eslint/no-explicit-any*/
+  const styled: any;
   export default styled;
 }


### PR DESCRIPTION
Why:
Currently there is a typo causing the tsc to fail compilation.