### PR TITLE
Tab Bar Fixes

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -66,7 +66,6 @@ const ExportStack = () => (
       cardStyleInterpolator: fade,
       gestureEnabled: false,
     }}>
-    <Stack.Screen name='ExportStart' component={ExportStart} />
     <Stack.Screen name='ExportSelectHA' component={ExportSelectHA} />
     <Stack.Screen name='ExportCodeInput' component={ExportCodeInput} />
     <Stack.Screen
@@ -94,13 +93,6 @@ const MoreTabStack = () => (
     <Stack.Screen
       name={EN_LOCAL_DIAGNOSIS_KEYS_SCREEN_NAME}
       component={ENLocalDiagnosisKeyScreen}
-    />
-    <Stack.Screen
-      name='ExportScreen'
-      component={ExportStack}
-      options={{
-        ...TransitionPresets.ModalSlideFromBottomIOS,
-      }}
     />
   </Stack.Navigator>
 );
@@ -151,8 +143,8 @@ const MainAppTabs = () => {
       {/* We feature flag in settings between whether to send to route or e2e export */}
       {isGPS && (
         <Tab.Screen
-          name='Export'
-          component={ExportStack}
+          name='ExportStart'
+          component={ExportStart}
           options={{
             tabBarLabel: t('navigation.locations'),
             tabBarIcon: ({ focused, size }) => (
@@ -226,6 +218,14 @@ export const Entry = () => {
         ) : (
           <Stack.Screen name={'Onboarding'} component={OnboardingStack} />
         )}
+        {/* Modal View: */}
+        <Stack.Screen
+          name={'ExportFlow'}
+          component={ExportStack}
+          options={{
+            ...TransitionPresets.ModalSlideFromBottomIOS,
+          }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/app/components/NavigationBarWrapper.tsx
+++ b/app/components/NavigationBarWrapper.tsx
@@ -80,7 +80,7 @@ const TopContainer = styled.SafeAreaView`
 const themeBackground = ({ theme }: Theme) =>
   theme.background || Colors.INTRO_WHITE_BG;
 
-const BottomContainer = styled.SafeAreaView`
+const BottomContainer = styled.View`
   flex: 1;
   background-color: ${themeBackground};
 `;

--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -324,11 +324,7 @@ class ChooseProviderScreen extends Component {
             <Menu
               name='AuthoritiesMenu'
               renderer={SlideInMenu}
-              style={{
-                flex: 1,
-                justifyContent: 'center',
-                paddingHorizontal: 12,
-              }}>
+              style={{ padding: 20 }}>
               <MenuTrigger>
                 <Button
                   label={languages.t('label.authorities_add_button_label')}

--- a/app/views/Export/ExportCodeInput.js
+++ b/app/views/Export/ExportCodeInput.js
@@ -19,6 +19,7 @@ import { Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
 import fontFamily from '../../constants/fonts';
 import { Theme } from '../../constants/themes';
+import exitWarningAlert from './exitWarningAlert';
 
 const CODE_LENGTH = 6;
 
@@ -166,7 +167,7 @@ export const ExportSelectHA = ({ route, navigation }) => {
             <IconButton
               icon={Icons.Close}
               size={22}
-              onPress={() => navigation.navigate('SettingsScreen')}
+              onPress={() => exitWarningAlert(navigation)}
             />
           </View>
           <View style={{ flex: 1, marginBottom: 20 }}>

--- a/app/views/Export/ExportComplete.js
+++ b/app/views/Export/ExportComplete.js
@@ -4,13 +4,12 @@ import { useTranslation } from 'react-i18next';
 import ExportTemplate from './ExportTemplate';
 
 export const ExportComplete = ({ navigation }) => {
-  const onClose = () => navigation.navigate('SettingsScreen');
+  const onClose = () => navigation.navigate('ExportStart');
   const { t } = useTranslation();
 
   return (
     <ExportTemplate
       lightTheme
-      onClose={onClose}
       onNext={onClose}
       nextButtonLabel={t('common.done')}
       headline={t('export.complete_title')}

--- a/app/views/Export/ExportSelectHA.js
+++ b/app/views/Export/ExportSelectHA.js
@@ -60,7 +60,7 @@ export const ExportSelectHA = ({ navigation }) => {
               <IconButton
                 icon={Icons.Close}
                 size={22}
-                onPress={() => navigation.navigate('SettingsScreen')}
+                onPress={() => navigation.navigate('ExportStart')}
               />
             </View>
             <Typography use='headline2' style={styles.exportSectionTitles}>

--- a/app/views/Export/ExportStart.js
+++ b/app/views/Export/ExportStart.js
@@ -6,15 +6,14 @@ import ExportTemplate from './ExportTemplate';
 export const ExportStart = ({ navigation }) => {
   const { t } = useTranslation();
 
-  const onNext = () => navigation.navigate('ExportSelectHA');
-  const onClose = () => navigation.navigate('SettingsScreen');
+  const onNext = () => navigation.navigate('ExportFlow');
   return (
     <ExportTemplate
-      onClose={onClose}
       onNext={onNext}
       headline={t('export.start_title')}
       body={t('export.start_body')}
       nextButtonLabel={t('common.start')}
+      ignoreModalStyling // this is in a tab
     />
   );
 };

--- a/app/views/Export/ExportTemplate.js
+++ b/app/views/Export/ExportTemplate.js
@@ -63,6 +63,7 @@ export const ExportTemplate = ({
   // https://react.i18next.com/latest/trans-component
   bodyLinkText,
   bodyLinkOnPress,
+  ignoreModalStyling, // So first screen can be slightly different in tabs
 }) => {
   useEffect(() => {
     function handleBackPress() {
@@ -133,7 +134,9 @@ export const ExportTemplate = ({
           )}
           {/* Add extra padding on the bottom if available for phone. 
            Interlays with the flexGrow on the scroll view to ensure that scrolling content has priority. */}
-          <View style={{ maxHeight: 20, flexGrow: 1 }} />
+          {!ignoreModalStyling && (
+            <View style={{ maxHeight: 20, flexGrow: 1 }} />
+          )}
         </SafeAreaView>
       </BackgroundContainer>
     </Theme>

--- a/app/views/Export/exitWarningAlert.js
+++ b/app/views/Export/exitWarningAlert.js
@@ -17,7 +17,7 @@ const exitWarningAlert = (navigation) => {
       },
       {
         text: i18next.t('export.exit_warning_confirm'),
-        onPress: () => navigation.navigate('SettingsScreen'),
+        onPress: () => navigation.navigate('ExportStart'),
         style: 'destructive',
       },
     ],

--- a/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
@@ -21,8 +21,7 @@ exports[`renders default values from the flags provider 1`] = `
       }
     }
   />
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <View
     style={
       Object {
         "backgroundColor": "#F7F8FF",
@@ -264,6 +263,6 @@ exports[`renders default values from the flags provider 1`] = `
         </View>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </View>
 </View>
 `;

--- a/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -13,8 +13,7 @@ Array [
       }
     }
   />,
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <View
     style={
       Object {
         "backgroundColor": "#F7F8FF",
@@ -272,6 +271,6 @@ Array [
         </View>
       </View>
     </RCTScrollView>
-  </RCTSafeAreaView>,
+  </View>,
 ]
 `;

--- a/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -21,8 +21,7 @@ exports[`renders correctly 1`] = `
       }
     }
   />
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <View
     style={
       Object {
         "backgroundColor": "#F7F8FF",
@@ -225,6 +224,6 @@ Somerville, MA 02144
         />
       </View>
     </View>
-  </RCTSafeAreaView>
+  </View>
 </View>
 `;

--- a/app/views/__tests__/__snapshots__/News.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/News.spec.js.snap
@@ -48,8 +48,7 @@ exports[`renders correctly 1`] = `
         }
       }
     />
-    <RCTSafeAreaView
-      emulateUnlessSupported={true}
+    <View
       style={
         Object {
           "backgroundColor": "#F7F8FF",
@@ -267,7 +266,7 @@ exports[`renders correctly 1`] = `
           />
         </View>
       </BVLinearGradient>
-    </RCTSafeAreaView>
+    </View>
   </BVLinearGradient>
 </View>
 `;

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -21,8 +21,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
       }
     }
   />
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <View
     style={
       Object {
         "backgroundColor": "#F7F8FF",
@@ -712,7 +711,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
         />
       </View>
     </RCTScrollView>
-  </RCTSafeAreaView>
+  </View>
 </View>
 `;
 
@@ -737,8 +736,7 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
       }
     }
   />
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <View
     style={
       Object {
         "backgroundColor": "#F7F8FF",
@@ -1258,6 +1256,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
         />
       </View>
     </RCTScrollView>
-  </RCTSafeAreaView>
+  </View>
 </View>
 `;


### PR DESCRIPTION
Follow ups to #984 to fix some styling and navigation issues:

- remove the safe area on the screen wrappers (No longer needed because of tab navigation). This fixes the screen mount jank issue. 
- align styling of buttons between Providers & Export so switching between the two has a consistent experieence.
- Puts the export at a modal level, so it's hoisted above the tab bar. 

<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/84314010-5cfe2f80-ab35-11ea-9731-4b86eb29ca8f.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/84314021-612a4d00-ab35-11ea-8422-6b5b745c2234.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/84314031-64bdd400-ab35-11ea-912f-3a2e27bd8adc.png">
