### PR TITLE
Convert Legal screen to typescript.

### DIFF
--- a/app/TracingStrategyAssets.ts
+++ b/app/TracingStrategyAssets.ts
@@ -3,7 +3,28 @@ import { useTranslation } from 'react-i18next';
 import { Images } from './assets';
 import { isGPS } from './COVIDSafePathsConfig';
 
-export function useAssets() {
+export type TracingStrategyAssetMap = {
+  onboarding2Background: string;
+  onboarding2Header: string;
+  onboarding2Subheader: string;
+  onboarding3Background: string;
+  onboarding3Header: string;
+  onboarding3Subheader: string;
+  onboarding4Background: string;
+  onboarding4Header: string;
+  onboarding4Subheader: string;
+  onboarding4Button: string;
+  settingsLoggingActive: string;
+  settingsLoggingInactive: string;
+  aboutHeader: string;
+  legalHeader: string;
+  detailedHistoryWhatThisMeansPara: string;
+  exposurePageSubheader: string;
+  offPageCta: string;
+  offPageButton: string;
+};
+
+export function useAssets(): TracingStrategyAssetMap {
   const { t } = useTranslation();
 
   // Onboarding2

--- a/app/TracingStrategyAssets.ts
+++ b/app/TracingStrategyAssets.ts
@@ -3,28 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Images } from './assets';
 import { isGPS } from './COVIDSafePathsConfig';
 
-export type TracingStrategyAssetMap = {
-  onboarding2Background: string;
-  onboarding2Header: string;
-  onboarding2Subheader: string;
-  onboarding3Background: string;
-  onboarding3Header: string;
-  onboarding3Subheader: string;
-  onboarding4Background: string;
-  onboarding4Header: string;
-  onboarding4Subheader: string;
-  onboarding4Button: string;
-  settingsLoggingActive: string;
-  settingsLoggingInactive: string;
-  aboutHeader: string;
-  legalHeader: string;
-  detailedHistoryWhatThisMeansPara: string;
-  exposurePageSubheader: string;
-  offPageCta: string;
-  offPageButton: string;
-};
-
-export function useAssets(): TracingStrategyAssetMap {
+export function useAssets(): Record<string, string> {
   const { t } = useTranslation();
 
   // Onboarding2

--- a/app/components/NavigationBarWrapper.tsx
+++ b/app/components/NavigationBarWrapper.tsx
@@ -20,10 +20,10 @@ import Colors from '../constants/colors';
 const widthScale = Math.min(Dimensions.get('window').width / 400, 1.0);
 
 interface NavigationBarWrapperProps {
-  children: JSX.Element;
+  children: React.ReactNode;
   title: string;
   onBackPress: () => void;
-  includeBottomNav: boolean;
+  includeBottomNav?: boolean;
   includeBackButton?: boolean;
 }
 export interface ThemeProps {

--- a/app/constants/fonts.ts
+++ b/app/constants/fonts.ts
@@ -1,0 +1,18 @@
+const fontFamily = {
+  primaryBold: 'IBMPlexSans-Bold',
+  primaryBoldItalic: 'IBMPlexSans-BoldItalic',
+  primaryExtraLight: 'IBMPlexSans-ExtraLight',
+  primaryExtraLightItalic: 'IBMPlexSans-ExtraLightItalic',
+  primaryItalic: 'IBMPlexSans-Italic',
+  primaryLight: 'IBMPlexSans-Light',
+  primaryLightItalic: 'IBMPlexSans-LightItalic',
+  primaryMedium: 'IBMPlexSans-Medium',
+  primaryMediumItalic: 'IBMPlexSans-MediumItalic',
+  primaryRegular: 'IBMPlexSans',
+  primarySemiBold: 'IBMPlexSans-SemiBold',
+  primarySemiBoldItalic: 'IBMPlexSans-SemiBoldItalic',
+  primaryThin: 'IBMPlexSans-Thin',
+  primaryThinItalic: 'IBMPlexSans-ThinItalic',
+};
+
+export default fontFamily;

--- a/app/views/Licenses.tsx
+++ b/app/views/Licenses.tsx
@@ -9,18 +9,30 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import {
+  NavigationParams,
+  NavigationScreenProp,
+  NavigationState,
+} from 'react-navigation';
 
-import fontFamily from './../constants/fonts';
+import fontFamily from '../constants/fonts';
 import { Images } from '../assets';
-import { NavigationBarWrapper, Typography } from '../components';
+import { NavigationBarWrapper } from '../components/NavigationBarWrapper';
+import { Typography } from '../components/Typography';
 import Colors from '../constants/colors';
 import { Theme } from '../constants/themes';
 import { useAssets } from '../TracingStrategyAssets';
 
+type LicensesScreenProps = {
+  navigation: NavigationScreenProp<NavigationState, NavigationParams>;
+};
+
 const PRIVACY_POLICY_URL =
   'https://docs.google.com/document/d/17u0f8ni9S0D4w8RCUlMMqxAlXKJAd2oiYGP8NUwkINo/edit';
 
-export const LicensesScreen = ({ navigation }) => {
+export const LicensesScreen = ({
+  navigation,
+}: LicensesScreenProps): JSX.Element => {
   const { t } = useTranslation();
   const { legalHeader } = useAssets();
 


### PR DESCRIPTION
### Why:
We would like to use typescript in general for better developer ergonomics

### This commit:
Updates files related to the `Legal` screen to `ts`

![Simulator Screen Shot - iPhone 11 - 2020-06-10 at 18 43 19](https://user-images.githubusercontent.com/2637355/84326138-47dfcb80-ab4a-11ea-8904-6fc76a4152c2.png)
