### PR TITLE
Introduce exposure detail for demo

### DIFF
--- a/app/ExposureNotificationContext.tsx
+++ b/app/ExposureNotificationContext.tsx
@@ -6,6 +6,8 @@ import * as ExposureNotifications from './exposureNotificationsNativeModule';
 export type ENAuthorizationStatus = 'authorized' | 'notAuthorized';
 
 interface ExposureNotificationsState {
+  hasBeenExposed: boolean;
+  toggleHasExposure: () => void;
   exposureNotificationAuthorizationStatus: ENAuthorizationStatus;
   requestExposureNotificationAuthorization: () => void;
 }
@@ -13,6 +15,8 @@ interface ExposureNotificationsState {
 const initialStatus: ENAuthorizationStatus = 'notAuthorized';
 
 const ExposureNotificationsContext = createContext<ExposureNotificationsState>({
+  hasBeenExposed: false,
+  toggleHasExposure: () => {},
   exposureNotificationAuthorizationStatus: initialStatus,
   requestExposureNotificationAuthorization: () => {},
 });
@@ -28,6 +32,7 @@ const ExposureNotificationsProvider = ({
     exposureNotificationAuthorizationStatus,
     setExposureNotificationAuthorizationStatus,
   ] = useState<ENAuthorizationStatus>(initialStatus);
+  const [hasBeenExposed, setHasBeenExposed] = useState<boolean>(false);
 
   const requestExposureNotificationAuthorization = () => {
     const cb = (authorizationStatus: ENAuthorizationStatus) => {
@@ -36,9 +41,15 @@ const ExposureNotificationsProvider = ({
     ExposureNotifications.requestAuthorization(cb);
   };
 
+  const toggleHasExposure = () => {
+    setHasBeenExposed(!hasBeenExposed);
+  };
+
   return (
     <ExposureNotificationsContext.Provider
       value={{
+        hasBeenExposed,
+        toggleHasExposure,
         exposureNotificationAuthorizationStatus,
         requestExposureNotificationAuthorization,
       }}>

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -99,7 +99,7 @@ export const switchEnabled = defaultBlue;
 
 // Text
 export const primaryText = midnightBlue;
-export const secondaryText = mediumGray;
+export const secondaryText = darkGray;
 export const tertiaryText = secondaryBlue;
 export const invertedText = white;
 export const invertedSecondaryText = lightGray;

--- a/app/styles/outlines.ts
+++ b/app/styles/outlines.ts
@@ -6,6 +6,11 @@ export const baseBorderRadius = 4;
 export const borderRadiusLarge = 8;
 export const borderRadiusMax = 500;
 
+export const roundedBorder: ViewStyle = {
+  borderWidth: 1,
+  borderRadius: baseBorderRadius,
+};
+
 export const baseShadow: ViewStyle = {
   shadowColor: Colors.black,
   shadowOpacity: 0.2,

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -16,9 +16,9 @@ export const huge = 52;
 // Line Heights
 export const smallestLineHeight = 16;
 export const smallerLineHeight = 20;
-export const smallLineHeight = 22;
-export const mediumLineHeight = 24;
-export const largeLineHeight = 34;
+export const smallLineHeight = 24;
+export const mediumLineHeight = 28;
+export const largeLineHeight = 32;
 export const largestLineHeight = 40;
 export const hugeLineHeight = 52;
 
@@ -41,13 +41,26 @@ export const mediumFont: TextStyle = {
 };
 
 export const largeFont: TextStyle = {
-  lineHeight: mediumLineHeight,
+  lineHeight: largestLineHeight,
   fontSize: large,
 };
 
-export const content: TextStyle = {
+// Headers
+export const header1: TextStyle = {
+  ...largeFont,
+  fontWeight: heavyWeight,
+  color: Colors.primaryText,
+};
+
+export const mainContent: TextStyle = {
   ...mediumFont,
   color: Colors.primaryText,
+};
+
+export const secondaryContent: TextStyle = {
+  ...mediumFont,
+  color: Colors.secondaryText,
+  lineHeight: mediumLineHeight,
 };
 
 export const label: TextStyle = {

--- a/app/views/ExposureHistory/DetailedHistory.js
+++ b/app/views/ExposureHistory/DetailedHistory.js
@@ -1,11 +1,16 @@
-import styled from '@emotion/native';
-import React from 'react';
+import React, { useContext } from 'react';
+import { View, StyleSheet } from 'react-native';
 
 import { Typography } from '../../components';
 import languages from '../../locales/languages';
 import { useAssets } from '../../TracingStrategyAssets';
 import { ExposureCalendarView } from './ExposureCalendarView';
 import { SingleExposureDetail } from './SingleExposureDetail';
+import { isGPS } from '../../TracingStrategyAssets';
+import ExposureNotificationContext from '../../ExposureNotificationContext';
+import HasBeenExposedDetail from './HasBeenExposedDetail';
+
+import { Spacing } from '../../styles';
 
 /**
  * Detailed info when there is some exposure found
@@ -14,60 +19,94 @@ import { SingleExposureDetail } from './SingleExposureDetail';
  */
 export const DetailedHistory = ({ history }) => {
   const { detailedHistoryPageWhatThisMeansPara } = useAssets();
+  const { hasBeenExposed } = useContext(ExposureNotificationContext);
   const exposedDays = history.filter((day) => day.exposureMinutes > 0);
+
+  const Divider = () => {
+    return <View style={styles.divider} />;
+  };
+
+  const gpsExposureInfo = () => {
+    return (
+      <>
+        {exposedDays.map(({ exposureMinutes, date }) => (
+          <SingleExposureDetail
+            key={date.format()}
+            date={date}
+            exposureMinutes={exposureMinutes}
+          />
+        ))}
+
+        {exposedDays.length === 0 ? (
+          <>
+            <Typography use='headline3'>
+              {languages.t('label.home_no_contact_header')}
+            </Typography>
+            <Typography use='body3'>
+              {languages.t('label.home_no_contact_subtext')}
+            </Typography>
+            <Divider />
+          </>
+        ) : (
+          <>
+            <Typography use='headline3'>
+              {languages.t('history.what_does_this_mean')}
+            </Typography>
+            <Typography use='body3'>
+              {detailedHistoryPageWhatThisMeansPara}
+            </Typography>
+          </>
+        )}
+
+        <Divider />
+
+        {exposedDays.length ? (
+          <>
+            <Typography use='headline3'>
+              {languages.t('history.what_if_no_symptoms')}
+            </Typography>
+            <Typography use='body3'>
+              {languages.t('history.what_if_no_symptoms_para')}
+            </Typography>
+          </>
+        ) : null}
+      </>
+    );
+  };
+
+  const bteExposureInfo = (hasBeenExposed) => {
+    const exposure = {
+      date: Date.now(),
+      possibleExposureTimeInMin: 45,
+      currentDailyReports: 1,
+    };
+
+    return (
+      <>
+        {hasBeenExposed ? (
+          <View style={styles.detailsContainer}>
+            <HasBeenExposedDetail exposure={exposure} />
+          </View>
+        ) : null}
+      </>
+    );
+  };
 
   return (
     <>
       <ExposureCalendarView weeks={3} history={history} />
-
       <Divider />
-
-      {exposedDays.map(({ exposureMinutes, date }) => (
-        <SingleExposureDetail
-          key={date.format()}
-          date={date}
-          exposureMinutes={exposureMinutes}
-        />
-      ))}
-
-      {exposedDays.length === 0 ? (
-        <>
-          <Typography use='headline3'>
-            {languages.t('label.home_no_contact_header')}
-          </Typography>
-          <Typography use='body3'>
-            {languages.t('label.home_no_contact_subtext')}
-          </Typography>
-          <Divider />
-        </>
-      ) : (
-        <>
-          <Typography use='headline3'>
-            {languages.t('history.what_does_this_mean')}
-          </Typography>
-          <Typography use='body3'>
-            {detailedHistoryPageWhatThisMeansPara}
-          </Typography>
-        </>
-      )}
-
-      <Divider />
-
-      {exposedDays.length ? (
-        <>
-          <Typography use='headline3'>
-            {languages.t('history.what_if_no_symptoms')}
-          </Typography>
-          <Typography use='body3'>
-            {languages.t('history.what_if_no_symptoms_para')}
-          </Typography>
-        </>
-      ) : null}
+      {isGPS ? gpsExposureInfo() : bteExposureInfo(hasBeenExposed)}
     </>
   );
 };
 
-const Divider = styled.View`
-  height: 24px;
-  width: 100%;
-`;
+const styles = StyleSheet.create({
+  divider: {
+    width: '100%',
+    height: Spacing.large,
+  },
+  detailsContainer: {
+    flex: 1,
+  },
+});

--- a/app/views/ExposureHistory/ExposureHistory.js
+++ b/app/views/ExposureHistory/ExposureHistory.js
@@ -7,7 +7,7 @@ import { BackHandler, ScrollView } from 'react-native';
 import { NavigationBarWrapper, Typography } from '../../components';
 import { MAX_EXPOSURE_WINDOW } from '../../constants/history';
 import { CROSSED_PATHS } from '../../constants/storage';
-import { Theme, charcoal, defaultTheme } from '../../constants/themes';
+import { defaultTheme } from '../../constants/themes';
 import { GetStoreData } from '../../helpers/General';
 import languages from '../../locales/languages';
 import { DetailedHistory } from './DetailedHistory';
@@ -47,39 +47,30 @@ export const ExposureHistoryScreen = ({ navigation }) => {
     };
   }, [navigation]);
 
-  const hasExposure =
-    history?.length && history.some((h) => h.exposureMinutes > 0);
+  const themeBackground = defaultTheme.background;
 
-  const themeBackground = hasExposure
-    ? charcoal.background
-    : defaultTheme.background;
-
-  const themeText = hasExposure
-    ? charcoal.textPrimaryOnBackground
-    : defaultTheme.textPrimaryOnBackground;
+  const themeText = defaultTheme.textPrimaryOnBackground;
 
   return (
-    <Theme use={hasExposure ? 'charcoal' : 'default'}>
-      <NavigationBarWrapper
-        includeBackButton={false}
-        title={languages.t('label.event_history_title')}
-        onBackPress={() => navigation.goBack()}>
-        <ScrollView
-          contentContainerStyle={css`
-            padding: 20px;
-            background-color: ${themeBackground};
-            color: ${themeText};
-          `}>
-          {isLoading ? (
-            <Typography use='body2'>
-              {languages.t('label.loading_public_data')}
-            </Typography>
-          ) : (
-            <DetailedHistory history={history} />
-          )}
-        </ScrollView>
-      </NavigationBarWrapper>
-    </Theme>
+    <NavigationBarWrapper
+      includeBackButton={false}
+      title={languages.t('label.event_history_title')}
+      onBackPress={() => navigation.goBack()}>
+      <ScrollView
+        contentContainerStyle={css`
+          padding: 20px;
+          background-color: ${themeBackground};
+          color: ${themeText};
+        `}>
+        {isLoading ? (
+          <Typography use='body2'>
+            {languages.t('label.loading_public_data')}
+          </Typography>
+        ) : (
+          <DetailedHistory history={history} />
+        )}
+      </ScrollView>
+    </NavigationBarWrapper>
   );
 };
 

--- a/app/views/ExposureHistory/HasBeenExposedDetail.tsx
+++ b/app/views/ExposureHistory/HasBeenExposedDetail.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import dayjs from 'dayjs';
+
+import { Typography } from '../../components/Typography';
+
+import {
+  Typography as TypographyStyles,
+  Outlines,
+  Colors,
+  Spacing,
+} from '../../styles';
+
+type Posix = number;
+
+interface Exposure {
+  date: Posix;
+  possibleExposureTimeInMin: number;
+  currentDailyReports: number;
+}
+
+interface HasBeenExposedDetailProps {
+  exposure: Exposure;
+}
+
+const HasBeenExposedDetail = ({
+  exposure: { date, possibleExposureTimeInMin, currentDailyReports },
+}: HasBeenExposedDetailProps): JSX.Element => {
+  const exposureDate = dayjs(date).format('dddd, MMM DD');
+  const exposureTime = `Possible Exposure Time: ${possibleExposureTimeInMin}`;
+  const dailyReports = `Current daily reports: ${currentDailyReports}`;
+  const explainationContent = `For ${possibleExposureTimeInMin} consecutive minutes, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.`;
+
+  return (
+    <View style={styles.container}>
+      <Typography style={styles.date}>{exposureDate}</Typography>
+      <Typography style={styles.info}>{exposureTime}</Typography>
+      <Typography sytle={styles.info}>{dailyReports}</Typography>
+      <View style={styles.contentContainer}>
+        <Typography style={styles.content}>{explainationContent}</Typography>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+    padding: Spacing.medium,
+    ...Outlines.roundedBorder,
+    borderColor: Colors.lighterGray,
+  },
+  date: {
+    ...TypographyStyles.header1,
+  },
+  info: {
+    lineHeight: TypographyStyles.largeLineHeight,
+  },
+  contentContainer: {
+    paddingTop: Spacing.xxSmall,
+  },
+  content: {
+    ...TypographyStyles.secondaryContent,
+  },
+});
+
+export default HasBeenExposedDetail;

--- a/app/views/Settings/ENDebugMenu.tsx
+++ b/app/views/Settings/ENDebugMenu.tsx
@@ -1,5 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { Alert, BackHandler, ScrollView } from 'react-native';
+import {
+  NavigationParams,
+  NavigationScreenProp,
+  NavigationState,
+} from 'react-navigation';
 
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
 import { Item } from './Item';
@@ -15,11 +20,7 @@ import {
   simulateExposureDetectionError,
   getExposureConfiguration,
 } from '../../exposureNotificationsNativeModule';
-import {
-  NavigationParams,
-  NavigationScreenProp,
-  NavigationState,
-} from 'react-navigation';
+import ExposureNotificationContext from '../../ExposureNotificationContext';
 
 type ENDebugMenuProps = {
   navigation: NavigationScreenProp<NavigationState, NavigationParams>;
@@ -29,6 +30,7 @@ export const EN_DEBUG_MENU_SCREEN_NAME = 'ENDebugMenu';
 export const EN_LOCAL_DIAGNOSIS_KEYS_SCREEN_NAME = 'ENLocalDiagnosisKeyScreen';
 
 export const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
+  const { toggleHasExposure } = useContext(ExposureNotificationContext);
   useEffect(() => {
     const handleBackPress = () => {
       navigation.goBack();
@@ -81,12 +83,22 @@ export const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
     };
   };
 
+  const handleOnPressToggleExposure = () => {
+    toggleHasExposure();
+  };
+
   return (
     <NavigationBarWrapper
       includeBottomNav
       title={'EN Debug Menu'}
       onBackPress={backToSettings}>
       <ScrollView>
+        <Section>
+          <Item
+            label='Toggle Exposure State'
+            onPress={handleOnPressToggleExposure}
+          />
+        </Section>
         <Section>
           <Item
             label='Detect Exposures Now'


### PR DESCRIPTION
Why:
We would like to display exposure info to the user on the exposure
history screen for an upcoming demo.

This commit:
Adds an exposure detail component and wires up a way to toggle the
exposed and not exposed state in the bt app. We used fake data and
did not provide any translations for sake of time. This will need to be
updated in a future commit.

We also removed the Theme component as this is not a feature we will be
supporting moving forward.

### gif

![has-exposure](https://user-images.githubusercontent.com/16049495/84371099-27922a00-aba7-11ea-83dc-99e8e034bcf3.gif)
