### PR TITLE
Export Upload Error Message Verbosity

### DIFF
--- a/app/api/export/exportUploadApi.ts
+++ b/app/api/export/exportUploadApi.ts
@@ -19,7 +19,7 @@ const exportUploadApi = async (
   });
   const success = res.status === 201;
   if (!success) {
-    throw res.status;
+    throw new Error(`Export Upload API failed with status code: ${res.status}`);
   }
   return;
 };

--- a/app/views/Export/ExportConfirmUpload.js
+++ b/app/views/Export/ExportConfirmUpload.js
@@ -22,7 +22,7 @@ export const ExportComplete = ({ navigation, route }) => {
       navigation.navigate('ExportComplete');
       setIsUploading(false);
     } catch (e) {
-      Alert.alert(t('common.something_went_wrong'));
+      Alert.alert(t('common.something_went_wrong'), e.message);
       setIsUploading(false);
     }
   };


### PR DESCRIPTION
Improves error message on export upload failure.
This is to immediately help debug why some exports are failing in testing.