### PR TITLE
Show next steps screen for affected users

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -20,6 +20,7 @@ import {
   ExportSelectHA,
 } from './views/Export';
 import { ExposureHistoryScreen } from './views/ExposureHistory/ExposureHistory';
+import NextSteps from './views/NextSteps';
 import {
   EN_DEBUG_MENU_SCREEN_NAME,
   EN_LOCAL_DIAGNOSIS_KEYS_SCREEN_NAME,
@@ -82,6 +83,22 @@ const ExportStack = () => (
   </Stack.Navigator>
 );
 
+const ExposureHistoryStack = () => (
+  <Stack.Navigator
+    mode='modal'
+    screenOptions={{
+      ...SCREEN_OPTIONS,
+      cardStyleInterpolator: fade,
+      gestureEnabled: false,
+    }}>
+    <Stack.Screen
+      name='ExposureHistoryScreen'
+      component={ExposureHistoryScreen}
+    />
+    <Stack.Screen name='NextStepsScreen' component={NextSteps} />
+  </Stack.Navigator>
+);
+
 const MoreTabStack = () => (
   <Stack.Navigator screenOptions={SCREEN_OPTIONS}>
     <Stack.Screen name='SettingsScreen' component={SettingsScreen} />
@@ -127,8 +144,8 @@ const MainAppTabs = () => {
         }}
       />
       <Tab.Screen
-        name='ExposureHistoryScreen'
-        component={ExposureHistoryScreen}
+        name='ExposureHistoryStack'
+        component={ExposureHistoryStack}
         options={{
           tabBarLabel: t('navigation.history'),
           tabBarIcon: ({ focused, size }) => (

--- a/app/styles/buttons.ts
+++ b/app/styles/buttons.ts
@@ -2,21 +2,21 @@ import { ViewStyle } from 'react-native';
 
 import * as Colors from './colors';
 import * as Outlines from './outlines';
-import * as Layout from './layout';
+import * as Spacing from './spacing';
 
 const base: ViewStyle = {
   flexDirection: 'row',
   justifyContent: 'center',
   alignItems: 'center',
+  borderRadius: Outlines.baseBorderRadius,
 };
 
 // Size
 export const baseHeight = 50;
 
 const large: ViewStyle = {
-  paddingTop: 10,
-  paddingBottom: 11,
-  width: Layout.baseFullWidthWithMargin,
+  paddingTop: Spacing.large,
+  paddingBottom: Spacing.large + 1,
 };
 
 // Color
@@ -25,46 +25,23 @@ const primaryBlue: ViewStyle = {
   borderColor: Colors.primaryBlue,
 };
 
-const primaryBlack: ViewStyle = {
-  backgroundColor: Colors.darkGray,
-  borderColor: Colors.darkGray,
-};
-
-const primaryYellow: ViewStyle = {
-  backgroundColor: Colors.primaryYellow,
-  borderColor: Colors.primaryYellow,
-};
-
 // Outline
-const rounded: ViewStyle = {
-  borderRadius: Outlines.borderRadiusMax,
+const outlined: ViewStyle = {
+  borderWidth: 1,
+  backgroundColor: Colors.transparent,
+};
+
+// Combinations
+export const largeBlueOutline: ViewStyle = {
+  ...base,
+  ...large,
+  ...primaryBlue,
+  ...outlined,
 };
 
 // Combinations
 export const largeBlue: ViewStyle = {
   ...base,
   ...large,
-  ...rounded,
   ...primaryBlue,
-};
-
-export const largeBlack: ViewStyle = {
-  ...base,
-  ...large,
-  ...rounded,
-  ...primaryBlack,
-};
-
-export const largeYellow: ViewStyle = {
-  ...base,
-  ...large,
-  ...rounded,
-  ...primaryYellow,
-};
-
-export const borderOnly = (buttonStyle: ViewStyle): ViewStyle => {
-  return {
-    ...buttonStyle,
-    backgroundColor: Colors.transparent,
-  };
 };

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -21,15 +21,19 @@ export const darkGray = '#4e4e4e';
 export const darkestGray = '#2e2e2e';
 export const silver = '#bebebe';
 
+// Reds
+export const red = '#ff0000';
+
+export const primaryRed = red;
+
 // Blues
-export const dogerBlue = '#428af8';
-export const nileBlue = '#222d4d';
-export const navyBlue = '#1d2230';
+export const royalBlue = '#4051db';
+export const royalerBlue = '#5061e6';
 export const midnightBlue = '#161a25';
 
-export const primaryBlue = dogerBlue;
-export const secondaryBlue = nileBlue;
-export const tertiaryBlue = navyBlue;
+export const primaryBlue = royalBlue;
+export const secondaryBlue = midnightBlue;
+export const tertiaryBlue = royalerBlue;
 
 // Yellows
 export const amber = '#ffc000';
@@ -41,8 +45,6 @@ export const secondaryYellow = kournikova;
 export const tertiaryYellow = orangePeel;
 
 // Violets
-export const royalBlue = '#4051db';
-export const royalerBlue = '#5061e6';
 export const jacksonsPurple = '#1f2c9b';
 export const cornflowerBlue = '#6979f8';
 export const moonRaker = '#e5e7fa';
@@ -51,10 +53,6 @@ export const melrose = '#a5affb';
 export const primaryViolet = royalBlue;
 export const secondaryViolet = jacksonsPurple;
 export const tertiaryViolet = melrose;
-
-// Defaults
-export const defaultRed = '#c20000';
-export const defaultBlue = '#007aff';
 
 // Transparent
 export const transparent = 'rgba(0, 0, 0, 0)';
@@ -65,6 +63,8 @@ export const transparentDark = 'rgba(0,0,0,0.7)';
 
 // Accents
 export const defaultAccent = primaryBlue;
+export const defaultBlue = primaryBlue;
+export const defaultRed = primaryRed;
 
 // Backgrounds
 export const primaryBackground = white;

--- a/app/styles/outlines.ts
+++ b/app/styles/outlines.ts
@@ -2,9 +2,9 @@ import { ViewStyle } from 'react-native';
 
 import * as Colors from './colors';
 
-export const baseBorderRadius = 4;
-export const borderRadiusLarge = 8;
-export const borderRadiusMax = 500;
+export const baseBorderRadius = 8;
+export const largeBorderRadius = 16;
+export const maxBorderRadius = 500;
 
 export const hairline = 1;
 export const thin = 2;

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -45,11 +45,21 @@ export const largeFont: TextStyle = {
   fontSize: large,
 };
 
+export const largestFont: TextStyle = {
+  lineHeight: largestLineHeight,
+  fontSize: largest,
+};
+
 // Headers
 export const header1: TextStyle = {
+  ...largestFont,
+  fontWeight: heaviestWeight,
+  color: Colors.primaryText,
+};
+
+export const header2: TextStyle = {
   ...largeFont,
   fontWeight: heavyWeight,
-  color: Colors.primaryText,
 };
 
 export const mainContent: TextStyle = {
@@ -68,9 +78,16 @@ export const label: TextStyle = {
   color: Colors.primaryText,
 };
 
-export const cta: TextStyle = {
+export const ctaButtonOutlined: TextStyle = {
   ...largeFont,
-  color: Colors.primaryText,
+  fontWeight: heavyWeight,
+  color: Colors.primaryBlue,
+};
+
+export const ctaButtonFilled: TextStyle = {
+  ...largeFont,
+  fontWeight: heavyWeight,
+  color: Colors.white,
 };
 
 export const title: TextStyle = {

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { TouchableOpacity, StyleSheet, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import dayjs from 'dayjs';
 
 import { Typography } from '../../components/Typography';
@@ -8,6 +9,7 @@ import {
   Typography as TypographyStyles,
   Outlines,
   Colors,
+  Buttons,
   Spacing,
 } from '../../styles';
 
@@ -45,20 +47,36 @@ interface PossibleExposureDetailProps {
 const PossibleExposureDetail = ({
   datum: { date, possibleExposureTimeInMin, currentDailyReports },
 }: PossibleExposureDetailProps) => {
+  const navigation = useNavigation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
   const exposureTime = `Possible Exposure Time: ${possibleExposureTimeInMin}`;
   const dailyReports = `Current daily reports: ${currentDailyReports}`;
   const explainationContent = `For ${possibleExposureTimeInMin} consecutive minutes, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.`;
 
+  const handleOnPressNextSteps = () => {
+    navigation.navigate('NextStepsScreen');
+  };
+
+  const nextStepsButtonText = 'What should I do next?';
+
   return (
-    <View style={styles.container}>
-      <Typography style={styles.date}>{exposureDate}</Typography>
-      <Typography style={styles.info}>{exposureTime}</Typography>
-      <Typography sytle={styles.info}>{dailyReports}</Typography>
-      <View style={styles.contentContainer}>
-        <Typography style={styles.content}>{explainationContent}</Typography>
+    <>
+      <View style={styles.container}>
+        <Typography style={styles.date}>{exposureDate}</Typography>
+        <Typography style={styles.info}>{exposureTime}</Typography>
+        <Typography sytle={styles.info}>{dailyReports}</Typography>
+        <View style={styles.contentContainer}>
+          <Typography style={styles.content}>{explainationContent}</Typography>
+        </View>
       </View>
-    </View>
+      <TouchableOpacity
+        style={styles.nextStepsButton}
+        onPress={handleOnPressNextSteps}>
+        <Typography style={styles.nextStepsButtonText}>
+          {nextStepsButtonText}
+        </Typography>
+      </TouchableOpacity>
+    </>
   );
 };
 
@@ -115,7 +133,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.lighterGray,
   },
   date: {
-    ...TypographyStyles.header1,
+    ...TypographyStyles.header2,
   },
   info: {
     lineHeight: TypographyStyles.largeLineHeight,
@@ -125,6 +143,13 @@ const styles = StyleSheet.create({
   },
   content: {
     ...TypographyStyles.secondaryContent,
+  },
+  nextStepsButton: {
+    ...Buttons.largeBlueOutline,
+    marginTop: Spacing.xLarge,
+  },
+  nextStepsButtonText: {
+    ...TypographyStyles.ctaButtonOutlined,
   },
 });
 

--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -109,7 +109,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 36,
     height: 36,
-    borderRadius: Outlines.borderRadiusMax,
+    borderRadius: Outlines.maxBorderRadius,
     borderColor: Colors.transparent,
     borderWidth: Outlines.thick,
   },

--- a/app/views/NextSteps/index.tsx
+++ b/app/views/NextSteps/index.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { TouchableOpacity, View, StyleSheet } from 'react-native';
+import {
+  NavigationParams,
+  NavigationScreenProp,
+  NavigationState,
+} from 'react-navigation';
+
+import { Typography } from '../../components/Typography';
+import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
+
+import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
+
+interface NextStepsProps {
+  navigation: NavigationScreenProp<NavigationState, NavigationParams>;
+}
+
+const NextSteps = ({ navigation }: NextStepsProps): JSX.Element => {
+  const handleOnBackPress = () => {
+    navigation.goBack();
+  };
+
+  const headerText =
+    'The Boston Public Health Department recommends you take a self-assessment';
+
+  const contentTextOne =
+    'It is possible that you may have crossed paths with somebody who has been diagnosed with COVID-19.';
+
+  const contentTextTwo =
+    "This does not mean that you are infected, but you should take precautions anyway. People who don't exhibit symptoms can sometimes still be contagious.";
+
+  const buttonText = 'Take Self Assessment';
+
+  const handleOnPressTakeAssessment = () => {};
+
+  return (
+    <NavigationBarWrapper
+      includeBottomNav
+      title={'Next Steps'}
+      onBackPress={handleOnBackPress}>
+      <View style={styles.container}>
+        <View style={styles.headerContainer}>
+          <Typography style={styles.headerText}>{headerText}</Typography>
+        </View>
+        <View style={styles.contentContainer}>
+          <Typography style={styles.contentText}>{contentTextOne}</Typography>
+          <Typography style={styles.contentText}>{contentTextTwo}</Typography>
+        </View>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={handleOnPressTakeAssessment}>
+            <Typography style={styles.buttonText}>{buttonText}</Typography>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </NavigationBarWrapper>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+    padding: Spacing.medium,
+  },
+  headerContainer: {
+    flex: 1,
+  },
+  headerText: {
+    ...TypographyStyles.header1,
+  },
+  contentContainer: {
+    flex: 2,
+  },
+  contentText: {
+    ...TypographyStyles.mainContent,
+    paddingTop: Spacing.small,
+  },
+  buttonContainer: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  button: {
+    ...Buttons.largeBlue,
+  },
+  buttonText: {
+    ...TypographyStyles.ctaButtonFilled,
+  },
+});
+
+export default NextSteps;


### PR DESCRIPTION
Why:
When a user has a potential exposure, we would like to indicate to them
what the next steps are.

This commit:
Introduces a next steps screen, and wires up the navigation to that
screen from the ExposureHistory screen. Note that the content is
currently hard coded and will need to be replaces with HA specific
content in a future commit.


### gif

![next-steps](https://user-images.githubusercontent.com/16049495/84422381-efacd600-abea-11ea-8d6f-98969331928c.gif)
