### PR TITLE
Show new exposure badge on history tab icon

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -1,14 +1,21 @@
 /* eslint-disable react/display-name */
+import React, { useContext, useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { useTranslation } from 'react-i18next';
+import { SvgXml } from 'react-native-svg';
 import { NavigationContainer } from '@react-navigation/native';
 import {
   CardStyleInterpolators,
   TransitionPresets,
   createStackNavigator,
 } from '@react-navigation/stack';
-import React from 'react';
 import { useSelector } from 'react-redux';
-import isOnboardingCompleteSelector from './store/selectors/isOnboardingCompleteSelector';
+
+import { Main } from './views/Main';
+import { SettingsScreen } from './views/Settings';
 import AboutScreen from './views/About';
+import { LicensesScreen } from './views/Licenses';
 import {
   ExportCodeInput,
   ExportComplete,
@@ -26,25 +33,22 @@ import {
   EN_LOCAL_DIAGNOSIS_KEYS_SCREEN_NAME,
   ENDebugMenu,
 } from './views/Settings/ENDebugMenu';
+import { ENLocalDiagnosisKeyScreen } from './views/Settings/ENLocalDiagnosisKeyScreen';
 import { FeatureFlagsScreen } from './views/FeatureFlagToggles';
 import ImportScreen from './views/Import';
-import { LicensesScreen } from './views/Licenses';
-import { Main } from './views/Main';
 import { EnableExposureNotifications } from './views/onboarding/EnableExposureNotifications';
 import Onboarding1 from './views/onboarding/Onboarding1';
 import Onboarding2 from './views/onboarding/Onboarding2';
 import Onboarding3 from './views/onboarding/Onboarding3';
 import Onboarding4 from './views/onboarding/Onboarding4';
 import { OnboardingPermissions } from './views/onboarding/OnboardingPermissions';
-import { SettingsScreen } from './views/Settings';
-import { ENLocalDiagnosisKeyScreen } from './views/Settings/ENLocalDiagnosisKeyScreen';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { useTranslation } from 'react-i18next';
+
+import ExposureNotificationContext from './ExposureNotificationContext';
+import isOnboardingCompleteSelector from './store/selectors/isOnboardingCompleteSelector';
 import { isGPS } from './COVIDSafePathsConfig';
 import * as Icons from './assets/svgs/TabBarNav';
-import { SvgXml } from 'react-native-svg';
 
-import { Colors, Spacing } from './styles';
+import { Affordances, Colors, Spacing } from './styles';
 
 const Tab = createBottomTabNavigator();
 const Stack = createStackNavigator();
@@ -83,21 +87,31 @@ const ExportStack = () => (
   </Stack.Navigator>
 );
 
-const ExposureHistoryStack = () => (
-  <Stack.Navigator
-    mode='modal'
-    screenOptions={{
-      ...SCREEN_OPTIONS,
-      cardStyleInterpolator: fade,
-      gestureEnabled: false,
-    }}>
-    <Stack.Screen
-      name='ExposureHistoryScreen'
-      component={ExposureHistoryScreen}
-    />
-    <Stack.Screen name='NextStepsScreen' component={NextSteps} />
-  </Stack.Navigator>
-);
+const ExposureHistoryStack = ({ navigation }) => {
+  const { observeExposures } = useContext(ExposureNotificationContext);
+  useEffect(() => {
+    const unsubscribeTabPress = navigation.addListener('tabPress', () => {
+      observeExposures();
+    });
+    return unsubscribeTabPress;
+  }, [navigation, observeExposures]);
+
+  return (
+    <Stack.Navigator
+      mode='modal'
+      screenOptions={{
+        ...SCREEN_OPTIONS,
+        cardStyleInterpolator: fade,
+        gestureEnabled: false,
+      }}>
+      <Stack.Screen
+        name='ExposureHistoryScreen'
+        component={ExposureHistoryScreen}
+      />
+      <Stack.Screen name='NextStepsScreen' component={NextSteps} />
+    </Stack.Navigator>
+  );
+};
 
 const SelfAssessmentStack = () => (
   <Stack.Navigator
@@ -128,6 +142,22 @@ const MoreTabStack = () => (
 
 const MainAppTabs = () => {
   const { t } = useTranslation();
+  const { userHasNewExposure } = useContext(ExposureNotificationContext);
+
+  const applyBadge = (icon) => {
+    return (
+      <>
+        <View style={styles.iconBadge} />
+        {icon}
+      </>
+    );
+  };
+
+  const styles = StyleSheet.create({
+    iconBadge: {
+      ...Affordances.iconBadge,
+    },
+  });
 
   return (
     <Tab.Navigator
@@ -160,16 +190,19 @@ const MainAppTabs = () => {
         component={ExposureHistoryStack}
         options={{
           tabBarLabel: t('navigation.history'),
-          tabBarIcon: ({ focused, size }) => (
-            <SvgXml
-              xml={focused ? Icons.HistoryActive : Icons.HistoryInactive}
-              width={size}
-              height={size}
-            />
-          ),
+          tabBarIcon: ({ focused, size }) => {
+            const tabIcon = (
+              <SvgXml
+                xml={focused ? Icons.HistoryActive : Icons.HistoryInactive}
+                width={size}
+                height={size}
+              />
+            );
+
+            return userHasNewExposure ? applyBadge(tabIcon) : tabIcon;
+          },
         }}
       />
-      {/* We feature flag in settings between whether to send to route or e2e export */}
       {isGPS && (
         <Tab.Screen
           name='ExportStart'

--- a/app/styles/affordances.ts
+++ b/app/styles/affordances.ts
@@ -1,0 +1,13 @@
+import * as Colors from './colors';
+
+export const iconBadge = {
+  position: 'absolute',
+  right: 8,
+  top: -4,
+  backgroundColor: Colors.primaryYellow,
+  borderRadius: 6,
+  width: 12,
+  height: 12,
+  justifyContent: 'center',
+  alignItems: 'center',
+};

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -36,7 +36,7 @@ export const secondaryBlue = midnightBlue;
 export const tertiaryBlue = royalerBlue;
 
 // Yellows
-export const amber = '#ffc000';
+export const amber = '#ffcc00';
 export const kournikova = '#ffdd76';
 export const orangePeel = '#ff9900';
 

--- a/app/styles/index.ts
+++ b/app/styles/index.ts
@@ -1,3 +1,4 @@
+import * as Affordances from './affordances';
 import * as Buttons from './buttons';
 import * as Colors from './colors';
 import * as Forms from './forms';
@@ -8,6 +9,7 @@ import * as Spacing from './spacing';
 import * as Typography from './typography';
 
 export {
+  Affordances,
   Buttons,
   Colors,
   Forms,

--- a/app/views/ExposureHistory/ExposureHistory.js
+++ b/app/views/ExposureHistory/ExposureHistory.js
@@ -1,8 +1,8 @@
+import React, { useEffect, useState } from 'react';
+import { BackHandler, ScrollView } from 'react-native';
 import { css } from '@emotion/native';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
-import React, { useEffect, useState } from 'react';
-import { BackHandler, ScrollView } from 'react-native';
 
 import { NavigationBarWrapper, Typography } from '../../components';
 import { MAX_EXPOSURE_WINDOW } from '../../constants/history';

--- a/app/views/Settings/ENDebugMenu.tsx
+++ b/app/views/Settings/ENDebugMenu.tsx
@@ -33,7 +33,7 @@ export const EN_DEBUG_MENU_SCREEN_NAME = 'ENDebugMenu';
 export const EN_LOCAL_DIAGNOSIS_KEYS_SCREEN_NAME = 'ENLocalDiagnosisKeyScreen';
 
 export const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
-  const { toggleHasExposure } = useContext(ExposureNotificationContext);
+  const { resetExposures } = useContext(ExposureNotificationContext);
   useEffect(() => {
     const handleBackPress = () => {
       navigation.goBack();
@@ -89,8 +89,8 @@ export const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
     };
   };
 
-  const handleOnPressToggleExposure = () => {
-    toggleHasExposure();
+  const handleOnPressResetExposures = () => {
+    resetExposures();
   };
 
   const handleOnPressToggleExposureNotifications = () => {
@@ -106,8 +106,8 @@ export const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
       <ScrollView>
         <Section>
           <Item
-            label='Toggle Exposure State'
-            onPress={handleOnPressToggleExposure}
+            label='Reset Exposures'
+            onPress={handleOnPressResetExposures}
             last
           />
         </Section>

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -6,7 +6,6 @@ import { SvgXml } from 'react-native-svg';
 import { Icons, Images } from '../../assets';
 import { Button } from '../../components/Button';
 import { Type, Typography } from '../../components/Typography';
-import { Theme } from '../../constants/themes';
 import ExposureNotificationContext from '../../ExposureNotificationContext';
 import { useDispatch } from 'react-redux';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
@@ -14,9 +13,7 @@ import onboardingCompleteAction from '../../store/actions/onboardingCompleteActi
 import { Spacing, Colors } from '../../styles';
 
 export const EnableExposureNotifications = (): JSX.Element => {
-  const { requestExposureNotificationAuthorization } = useContext(
-    ExposureNotificationContext,
-  );
+  const { requestENAuthorization } = useContext(ExposureNotificationContext);
   const { t } = useTranslation();
 
   const dispatch = useDispatch();
@@ -28,55 +25,53 @@ export const EnableExposureNotifications = (): JSX.Element => {
   const titleText = t('label.launch_exposure_notif_header');
 
   const handleOnPressEnable = () => {
-    requestExposureNotificationAuthorization();
+    requestENAuthorization();
     dispatchOnboardingComplete();
   };
 
   return (
-    <Theme use='violet'>
-      <ImageBackground
-        source={Images.LaunchScreenBackground}
-        style={styles.backgroundImage}>
-        <StatusBar
-          barStyle='light-content'
-          backgroundColor='transparent'
-          translucent
-        />
+    <ImageBackground
+      source={Images.LaunchScreenBackground}
+      style={styles.backgroundImage}>
+      <StatusBar
+        barStyle='light-content'
+        backgroundColor='transparent'
+        translucent
+      />
 
-        <View
-          testID={'onboarding-permissions-screen'}
-          style={styles.mainContainer}>
-          <View style={styles.contentContainer}>
-            <View style={styles.iconContainer}>
-              <SvgXml xml={Icons.ExposureIcon} />
-            </View>
-            <Typography
-              style={styles.headerText}
-              use={Type.Headline2}
-              testID='Header'>
-              {titleText}
-            </Typography>
-            <Typography style={styles.subheaderText} use={Type.Body2}>
-              {subTitleText}
-            </Typography>
+      <View
+        testID={'onboarding-permissions-screen'}
+        style={styles.mainContainer}>
+        <View style={styles.contentContainer}>
+          <View style={styles.iconContainer}>
+            <SvgXml xml={Icons.ExposureIcon} />
           </View>
-
-          <View style={styles.footerContainer}>
-            <Button
-              secondary
-              label={disableButtonLabel}
-              onPress={dispatchOnboardingComplete}
-              testID={'onboarding-permissions-disable-button'}
-            />
-            <Button
-              label={buttonLabel}
-              onPress={handleOnPressEnable}
-              testID={'onboarding-permissions-button'}
-            />
-          </View>
+          <Typography
+            style={styles.headerText}
+            use={Type.Headline2}
+            testID='Header'>
+            {titleText}
+          </Typography>
+          <Typography style={styles.subheaderText} use={Type.Body2}>
+            {subTitleText}
+          </Typography>
         </View>
-      </ImageBackground>
-    </Theme>
+
+        <View style={styles.footerContainer}>
+          <Button
+            secondary
+            label={disableButtonLabel}
+            onPress={dispatchOnboardingComplete}
+            testID={'onboarding-permissions-disable-button'}
+          />
+          <Button
+            label={buttonLabel}
+            onPress={handleOnPressEnable}
+            testID={'onboarding-permissions-button'}
+          />
+        </View>
+      </View>
+    </ImageBackground>
   );
 };
 


### PR DESCRIPTION
Why:
When a user has a new exposure we would like to provide them an
affordance that they have something to review in the exposure history
screen.

This commit:
Introduces some logic to conditionally render an icon badge on the
exposure history tab. A new style module, Affordances, was added to
house the view styles for the badge. A new `userHasNewExposure` boolean
was added to the exposure notifications context to house the application
state of whether or not a user has a new exposure.

Note that we have not set up the actual logic for determining the status
of new exposure for the user, as we do not yet have actual exposure data
being received in the app, this is for demonstration purposes and will
need to be wired up to real data in a future commit.

Various other minor clean up was captured in this commit as well.

### gif 

![exposure-indicator](https://user-images.githubusercontent.com/16049495/84493553-eb79ca80-ac75-11ea-8144-659e8d38d339.gif)
