### PR TITLE
Remove react-native-screens navigator

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { MenuProvider } from 'react-native-popup-menu';
-import { enableScreens } from 'react-native-screens';
 import SplashScreen from 'react-native-splash-screen';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
@@ -27,8 +26,6 @@ export const UnconnectedApp = () => (
     </MenuProvider>
   </FlagsProvider>
 );
-
-enableScreens();
 
 const App = () => {
   useEffect(() => {

--- a/app/views/assessment/index.js
+++ b/app/views/assessment/index.js
@@ -1,7 +1,7 @@
 import { CardStyleInterpolators } from '@react-navigation/stack';
 import React, { useMemo, useRef } from 'react';
 import { Alert, TouchableOpacity } from 'react-native';
-import { createNativeStackNavigator } from 'react-native-screens/native-stack';
+import { createStackNavigator } from '@react-navigation/stack';
 
 import { SvgXml } from 'react-native-svg';
 import { Icons } from '../../assets';
@@ -61,7 +61,7 @@ import { Colors } from '../../styles';
 
 /** @type {{ [key: string]: Survey }} */
 
-const Stack = createNativeStackNavigator();
+const Stack = createStackNavigator();
 
 const Assessment = ({ navigation }) => {
   /** @type {React.MutableRefObject<SurveyAnswers>} */

--- a/yarn.lock
+++ b/yarn.lock
@@ -7177,7 +7177,8 @@ react-native-safe-area-view@^0.14.9:
 
 react-native-screens@^2.8.0:
   version "2.8.0"
-  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.8.0.tgz#9f989096fc5ccf248e0dfa93a74f1a64057e15f1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.8.0.tgz#9f989096fc5ccf248e0dfa93a74f1a64057e15f1"
+  integrity sha512-fUCIQLZX+5XB0ypWX038P3zso54IFFjTsQUZJWEsjC3pp5rPItAt5SzqtJn+uVjcJaczZ+dpIuvj6IFLqkWLZQ==
 
 react-native-share@^3.1.0:
   version "3.3.2"


### PR DESCRIPTION
Why:
A previous commit introduced a native navigator and an initialization
function for react-native-screens. When doing so it broke unit specs on
ci.

This commit:
Switches the native stack navigator in the self assessment flow to a
plain react-navigation navigator, similar to every other navigator in
the application.

Note that there was no explanation provided in the PR, #926, that
introduced this as to why it was being introduced. It is possible that
there was a good reason and we might need to add this back in, but as of
this commit is not clear why we need to be using this package.