### PR TITLE
Adjust badge alignment.

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -151,8 +151,8 @@ const MainAppTabs = () => {
   const applyBadge = (icon) => {
     return (
       <>
-        <View style={styles.iconBadge} />
         {icon}
+        <View style={styles.iconBadge} />
       </>
     );
   };

--- a/app/styles/affordances.ts
+++ b/app/styles/affordances.ts
@@ -2,8 +2,8 @@ import * as Colors from './colors';
 
 export const iconBadge = {
   position: 'absolute',
-  right: 8,
-  top: -4,
+  right: 22,
+  top: 3,
   backgroundColor: Colors.primaryYellow,
   borderRadius: 6,
   width: 12,


### PR DESCRIPTION
### Why
We'd like tab bar badges to be aligned relative to tab bar icons such that they reflect the designs in figma and also conform to platform-specific convention.

### This Commit
This commit modifies the positioning of the badge icon relative to the tab bar icons to more closely hew to the figma designs, and also ensures that, if the badge and the icon do overlap, the badge sits above the icon (per iOS/Android convention).

### Before:
<img width="1024" alt="Screen Shot 2020-06-14 at 9 36 35 PM" src="https://user-images.githubusercontent.com/2637355/84610240-eb511900-ae87-11ea-972a-47e2857eb1d0.png">

### After:
<img width="1073" alt="Screen Shot 2020-06-14 at 9 32 04 PM" src="https://user-images.githubusercontent.com/2637355/84610261-f7d57180-ae87-11ea-9373-fac07db08e3c.png">
