### PR TITLE
Fix reference to share test result translation

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -278,7 +278,6 @@
     "about": "About",
     "faq": "FAQ",
     "report_issue": "Report an issue",
-    "report_positive_test": "Report a positive test result",
     "legal": "Legal",
     "more": "More"
   }

--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -137,9 +137,9 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
 
         <View style={styles.section}>
           <SettingsListItem
-            label={t('settings.report_positive_test')}
+            label={t('settings.share_test_result')}
             onPress={navigateTo('ExportFlow')}
-            description={t('settings.report_positive_test_description')}
+            description={t('settings.share_test_result_description')}
             style={styles.lastListItem}
           />
         </View>

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -250,7 +250,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
               }
               use="body1"
             >
-              settings.report_positive_test
+              Report a positive test result
             </Text>
             <Text
               style={
@@ -265,7 +265,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
               }
               use="body1"
             >
-              settings.report_positive_test_description
+              Share Covid-19 exporsure information with your health authority with a provided code
             </Text>
           </View>
         </View>
@@ -801,7 +801,7 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
               }
               use="body1"
             >
-              settings.report_positive_test
+              Report a positive test result
             </Text>
             <Text
               style={
@@ -816,7 +816,7 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
               }
               use="body1"
             >
-              settings.report_positive_test_description
+              Share Covid-19 exporsure information with your health authority with a provided code
             </Text>
           </View>
         </View>


### PR DESCRIPTION
#### Description:

The Report a Positive Test Result item on the settings screen was using the wrong translation key. This fixes that.

#### Screenshots:

![Screen Shot 2020-06-15 at 1 39 35 PM](https://user-images.githubusercontent.com/5807753/84693858-cdc69280-af0d-11ea-8095-24cf9665f9cd.png)]
