### PR TITLE
Wrap the HCAService in a GPS check - uses location

### DIFF
--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -48,11 +48,13 @@ export const Main = () => {
     const { canTrack } = await tracingService.checkStatusAndStartOrStop();
     setTrackingInfo({ canTrack });
 
-    const authoritiesInBoundsState = await HCAService.hasAuthoritiesInBounds();
-    setHasAuthorityInBounds(authoritiesInBoundsState);
+    if (isGPS) {
+      const authoritiesInBoundsState = await HCAService.hasAuthoritiesInBounds();
+      setHasAuthorityInBounds(authoritiesInBoundsState);
 
-    const savedAuthoritiesState = await HCAService.hasSavedAuthorities();
-    setHasSavedAuthorities(savedAuthoritiesState);
+      const savedAuthoritiesState = await HCAService.hasSavedAuthorities();
+      setHasSavedAuthorities(savedAuthoritiesState);
+    }
   }, [
     tracingService,
     setTrackingInfo,


### PR DESCRIPTION
#### Description:

Moving the HCAService into Main.js, requires an isGPS check to not run for the BT app.
