### PR TITLE
Replace App Name in Translations

### DIFF
--- a/app/locales/nl.json
+++ b/app/locales/nl.json
@@ -51,7 +51,7 @@
   "label": {
     "authorities_add_button_label": "Voeg een vertrouwde bron toe",
     "authorities_add_url": "Voeg autoriteit toe via URL",
-    "authorities_desc": "Kies vertrouwde gezondheidsinstanties in uw regio om blootstellingsgegevens te verkrijgen. Selecteer een naam uit het wereldwijde register of voer het webadres in dat is verstrekt door een autoriteit die Safe Paths heeft geïmplementeerd.",
+    "authorities_desc": "Kies vertrouwde gezondheidsinstanties in uw regio om blootstellingsgegevens te verkrijgen. Selecteer een naam uit het wereldwijde register of voer het webadres in dat is verstrekt door een autoriteit die PathCheck heeft geïmplementeerd.",
     "authorities_input_placeholder": "Plak hier uw URL",
     "authorities_new_in_area_msg": "Meld u aan voor {{count}} nieuwe gezondheidinstantie in uw regio",
     "authorities_new_in_area_title": "{\"one\":\"Nieuwe gezondheidsinstantie\",\"other\":\"Nieuwe gezondheidsinstanties\"}",
@@ -63,7 +63,7 @@
     "auto_subscribe_checkbox": "Automatisch abonnement inschakelen",
     "choose_provider_subtitle": "Om op de hoogte te blijven van mogelijke blootstellingen, kunt u het best abonneren op een gezondheidsinstantie.",
     "choose_provider_title": "Kies een gezondheidsinstantie",
-    "default_news_site_name": "Safe Paths nieuws",
+    "default_news_site_name": "PathCheck nieuws",
     "enter_authority_url": "URL invoeren of plakken",
     "event_history_subtitle": "Herken uw persoonlijke blootstelling met informatie van gezondheidsinstanties.",
     "event_history_title": "Blootstelling geschiedenis",
@@ -118,7 +118,7 @@
   "onboarding": {
     "eula_checkbox": "Ik accepteer de licentieovereenkomst",
     "eula_continue": "Ga verder",
-    "eula_message": "*U moet accepteren om Safe Paths te gebruiken"
+    "eula_message": "*U moet accepteren om PathCheck te gebruiken"
   },
   "screen_titles": {
     "about": "Informatie",

--- a/app/locales/zh_Hant.json
+++ b/app/locales/zh_Hant.json
@@ -16,7 +16,7 @@
   "import": {
     "button_text": "過去の位置情報をインポートする",
     "google": {
-      "disclaimer": "Safe Paths與Google不存在從屬關係也不會分享您的資料",
+      "disclaimer": "PathCheck與Google不存在從屬關係也不會分享您的資料",
       "title": "Google 地圖"
     },
     "subtitle": "確認您下載此應用程式前，是否與新冠病毒確診者接觸，您可以載入您個人位置歷史資訊",
@@ -25,7 +25,7 @@
   "label": {
     "authorities_add_button_label": "新增可信來源",
     "authorities_add_url": "新增可信的疾病管制機構網頁超連結",
-    "authorities_desc": "選擇您所在地區受信任的醫療機構，獲取其潛在感染高風險路徑數據。從全局註冊表(global registry)選取資料集名稱或從使用Safe Paths的官方網頁超連結",
+    "authorities_desc": "選擇您所在地區受信任的醫療機構，獲取其潛在感染高風險路徑數據。從全局註冊表(global registry)選取資料集名稱或從使用PathCheck的官方網頁超連結",
     "authorities_input_placeholder": "在此貼上網頁超連結",
     "authorities_no_sources": "尚無資料來源",
     "authorities_removal_alert_cancel": "取消",
@@ -34,7 +34,7 @@
     "authorities_removal_alert_title": "移除疾病管制官方機構",
     "choose_provider_subtitle": "如要了解潛在接觸情況，您需要向疾病管制機構訂閱",
     "choose_provider_title": "選擇疾病管制機構",
-    "default_news_site_name": "Safe Paths 新聞",
+    "default_news_site_name": "PathCheck 新聞",
     "event_history_subtitle": "從疾病管制機構共享的數據了解您個人接觸風險",
     "event_history_title": "接觸歷史",
     "latest_news": "最新新聞",


### PR DESCRIPTION
#### Description:
Replace COVID Safe Paths text with PathCheck in translations

#### Linked issues:
https://pathcheck.atlassian.net/browse/SAF-590