### PR TITLE
Use same styles for buttons

### DIFF
--- a/app/styles/buttons.ts
+++ b/app/styles/buttons.ts
@@ -25,6 +25,11 @@ const primaryBlue: ViewStyle = {
   borderColor: Colors.primaryBlue,
 };
 
+const white: ViewStyle = {
+  backgroundColor: Colors.white,
+  borderColor: Colors.white,
+};
+
 // Outline
 const outlined: ViewStyle = {
   borderWidth: 1,
@@ -39,9 +44,14 @@ export const largeBlueOutline: ViewStyle = {
   ...outlined,
 };
 
-// Combinations
 export const largeBlue: ViewStyle = {
   ...base,
   ...large,
   ...primaryBlue,
+};
+
+export const largeWhite: ViewStyle = {
+  ...base,
+  ...large,
+  ...white,
 };

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -137,34 +137,16 @@ export const tappableListItem: TextStyle = {
 
 // Buttons
 export const buttonText: TextStyle = {
-  fontSize: medium,
+  fontSize: large,
   fontWeight: heavyWeight,
 };
 
-export const darkButtonText: TextStyle = {
+export const buttonTextDark: TextStyle = {
   ...buttonText,
-  color: Colors.white,
+  color: Colors.primaryViolet,
 };
 
-export const baseWeightButtonText: TextStyle = {
+export const buttonTextLight: TextStyle = {
   ...buttonText,
-  fontWeight: baseWeight,
-};
-
-export const borderlessButtonText: TextStyle = {
-  color: Colors.defaultBlue,
-  fontSize: medium,
-  fontWeight: heaviestWeight,
-};
-
-export const ctaButtonOutlined: TextStyle = {
-  ...largeFont,
-  fontWeight: heavyWeight,
-  color: Colors.primaryBlue,
-};
-
-export const ctaButtonFilled: TextStyle = {
-  ...largeFont,
-  fontWeight: heavyWeight,
   color: Colors.white,
 };

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -158,7 +158,7 @@ const styles = StyleSheet.create({
     marginTop: Spacing.xLarge,
   },
   nextStepsButtonText: {
-    ...TypographyStyles.ctaButtonOutlined,
+    ...TypographyStyles.buttonTextDark,
   },
 });
 

--- a/app/views/NextSteps/index.tsx
+++ b/app/views/NextSteps/index.tsx
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
     ...Buttons.largeBlue,
   },
   buttonText: {
-    ...TypographyStyles.ctaButtonFilled,
+    ...TypographyStyles.buttonTextLight,
   },
 });
 

--- a/app/views/Settings/GoogleMapsImport.tsx
+++ b/app/views/Settings/GoogleMapsImport.tsx
@@ -71,7 +71,7 @@ const styles = StyleSheet.create({
     ...Buttons.largeBlueOutline,
   },
   buttonText: {
-    ...TypographyStyles.ctaButtonOutlined,
+    ...TypographyStyles.buttonTextDark,
   },
   disclaimerText: {
     ...TypographyStyles.disclaimer,

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -403,7 +403,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
                     "color": "#4051db",
                     "fontSize": 19,
                     "fontWeight": "500",
-                    "lineHeight": 40,
                   },
                 ]
               }


### PR DESCRIPTION
Why:
Currently a few of the buttons on various screens are not using the same
button and text label styles.

This commit:
Updates the buttons to use the same styles.

Co-Authored-By: achen178 <achen178@gmail.com>
Co-Authored-By: ericwbailey <eric.w.bailey@gmail.com>

### Before

![buttons-before](https://user-images.githubusercontent.com/16049495/84707033-fc536600-af2b-11ea-92d3-e0456e8c463a.gif)

### **After**

![buttons-after](https://user-images.githubusercontent.com/16049495/84707046-007f8380-af2c-11ea-9951-840059111896.gif)
