### PR TITLE
Make health authority name generic

### DIFF
--- a/app/views/NextSteps/index.tsx
+++ b/app/views/NextSteps/index.tsx
@@ -16,8 +16,9 @@ const NextSteps = ({ navigation }: NextStepsProps): JSX.Element => {
     navigation.goBack();
   };
 
-  const headerText =
-    'The Boston Public Health Department recommends you take a self-assessment';
+  const healthAuthority = 'The PathCheck Health Department';
+
+  const headerText = `${healthAuthority} recommends you take a self-assessment`;
 
   const contentTextOne =
     'It is possible that you may have crossed paths with somebody who has been diagnosed with COVID-19.';


### PR DESCRIPTION
Why:
Currently we have `The Boston Health Department` hardcoded on the next
steps screen. Eventually we would like this to say the appropriate
health authority, but until we have that worked out, we will prefer to
use a generic placeholder for the Health authority name.