### PR TITLE
Fix typography regressions

### DIFF
--- a/app/components/Checkbox.js
+++ b/app/components/Checkbox.js
@@ -1,21 +1,35 @@
 import React from 'react';
-import { Image, TouchableOpacity } from 'react-native';
+import { StyleSheet, Image, TouchableOpacity } from 'react-native';
 
 import { Images } from '../assets';
 import { Typography } from './Typography';
 
+import { Forms } from '../styles';
+
 export const Checkbox = ({ label, onPress, checked }) => {
   return (
     <TouchableOpacity
-      style={{ flexDirection: 'row' }}
+      style={styles.checkbox}
       onPress={onPress}
       accessible
       accessibilityLabel={label}>
       <Image
         source={checked ? Images.BoxCheckedIcon : Images.BoxUncheckedIcon}
-        style={{ width: 25, height: 25, marginRight: 10 }}
+        style={styles.checkboxIcon}
       />
-      <Typography use='body1'>{label}</Typography>
+      <Typography style={styles.checkboxText}>{label}</Typography>
     </TouchableOpacity>
   );
 };
+
+const styles = StyleSheet.create({
+  checkbox: {
+    ...Forms.checkbox,
+  },
+  checkboxIcon: {
+    ...Forms.checkboxIcon,
+  },
+  checkboxText: {
+    ...Forms.checkboxText,
+  },
+});

--- a/app/styles/buttons.ts
+++ b/app/styles/buttons.ts
@@ -37,21 +37,24 @@ const outlined: ViewStyle = {
 };
 
 // Combinations
-export const largeBlueOutline: ViewStyle = {
-  ...base,
-  ...large,
-  ...primaryBlue,
-  ...outlined,
-};
-
 export const largeBlue: ViewStyle = {
   ...base,
   ...large,
   ...primaryBlue,
 };
 
+export const largeBlueOutline: ViewStyle = {
+  ...largeBlue,
+  ...outlined,
+};
+
 export const largeWhite: ViewStyle = {
   ...base,
   ...large,
   ...white,
+};
+
+export const largeWhiteOutline: ViewStyle = {
+  ...largeWhite,
+  ...outlined,
 };

--- a/app/styles/forms.ts
+++ b/app/styles/forms.ts
@@ -1,4 +1,4 @@
-import { TextStyle } from 'react-native';
+import { ViewStyle, TextStyle } from 'react-native';
 
 import * as Colors from './colors';
 import * as Spacing from './spacing';
@@ -7,8 +7,8 @@ import * as Typography from './typography';
 
 // Global Form Styles
 export const textInputFormField: TextStyle = {
-  color: Colors.primaryText,
   flex: 1,
+  color: Colors.primaryText,
   backgroundColor: Colors.formInputBackground,
   borderRadius: Outlines.baseBorderRadius,
   borderColor: Colors.formInputBorder,
@@ -27,4 +27,20 @@ export const required: TextStyle = {
   fontSize: 12,
   color: Colors.primaryText,
   marginTop: 6,
+};
+
+export const checkbox: ViewStyle = {
+  flexDirection: 'row',
+  alignItems: 'center',
+};
+
+export const checkboxIcon: ViewStyle = {
+  width: 25,
+  height: 25,
+  marginRight: Spacing.medium,
+};
+
+export const checkboxText: TextStyle = {
+  ...Typography.mediumFont,
+  color: Colors.invertedText,
 };

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -44,6 +44,11 @@ export const monospace: TextStyle = {
 };
 
 // Standard Font Types
+export const tinyFont: TextStyle = {
+  lineHeight: smallestLineHeight,
+  fontSize: tiny,
+};
+
 export const smallFont: TextStyle = {
   lineHeight: smallLineHeight,
   fontSize: small,

--- a/app/views/EulaModal.js
+++ b/app/views/EulaModal.js
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import {
+  TouchableOpacity,
+  Linking,
+  Modal,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Linking, Modal, StyleSheet, View } from 'react-native';
 import loadLocalResource from 'react-native-local-resource';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import WebView from 'react-native-webview';
@@ -11,7 +17,12 @@ import es_PR from '../locales/eula/es_PR.html';
 import ht from '../locales/eula/ht.html';
 
 import { Icons } from '../assets';
-import { Colors } from '../styles';
+import {
+  Spacing,
+  Buttons,
+  Colors,
+  Typography as TypographyStyles,
+} from '../styles';
 
 const EULA_FILES = { en, es_PR, ht };
 
@@ -48,12 +59,14 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
 
   const canContinue = boxChecked;
 
+  const handleOnPressGetStarted = () => setModalVisibility(true);
   return (
     <>
-      <Button
-        label={t('label.launch_get_started')}
-        onPress={() => setModalVisibility(true)}
-      />
+      <TouchableOpacity style={styles.button} onPress={handleOnPressGetStarted}>
+        <Typography style={styles.buttonText}>
+          {t('label.launch_get_started')}
+        </Typography>
+      </TouchableOpacity>
       <Modal animationType='slide' transparent visible={modalVisible}>
         <View style={styles.container}>
           <SafeAreaView style={{ flex: 1 }}>
@@ -78,14 +91,16 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
           </SafeAreaView>
           <SafeAreaView style={{ backgroundColor: Colors.secondaryBlue }}>
             <View style={styles.ctaBox}>
-              <Checkbox
-                label={t('onboarding.eula_checkbox')}
-                onPress={() => toggleCheckbox(!boxChecked)}
-                checked={boxChecked}
-              />
-              <Typography style={styles.smallDescriptionText}>
-                {t('onboarding.eula_message')}
-              </Typography>
+              <View style={styles.checkboxContainer}>
+                <Checkbox
+                  label={t('onboarding.eula_checkbox')}
+                  onPress={() => toggleCheckbox(!boxChecked)}
+                  checked={boxChecked}
+                />
+                <Typography style={styles.smallDescriptionText}>
+                  {t('onboarding.eula_message')}
+                </Typography>
+              </View>
               <Button
                 label={t('onboarding.eula_continue')}
                 disabled={!canContinue}
@@ -112,9 +127,11 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.white,
   },
   ctaBox: {
-    padding: 15,
-    paddingTop: 0,
+    paddingHorizontal: Spacing.medium,
     backgroundColor: Colors.secondaryBlue,
+  },
+  checkboxContainer: {
+    paddingVertical: Spacing.medium,
   },
   closeIcon: {
     marginBottom: 6,
@@ -122,7 +139,13 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
   },
   smallDescriptionText: {
-    fontSize: 14,
-    marginVertical: 12,
+    ...TypographyStyles.label,
+    color: Colors.invertedText,
+  },
+  button: {
+    ...Buttons.largeWhite,
+  },
+  buttonText: {
+    ...TypographyStyles.buttonTextDark,
   },
 });

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -1,17 +1,27 @@
 import React, { useContext } from 'react';
+import {
+  TouchableOpacity,
+  ImageBackground,
+  StatusBar,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { ImageBackground, StatusBar, StyleSheet, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
-import { Icons, Images } from '../../assets';
-import { Button } from '../../components/Button';
 import { Typography } from '../../components/Typography';
 import { Theme } from '../../constants/themes';
 import ExposureNotificationContext from '../../ExposureNotificationContext';
 import { useDispatch } from 'react-redux';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
 
-import { Spacing, Colors, Typography as TypographyStyles } from '../../styles';
+import {
+  Spacing,
+  Buttons,
+  Colors,
+  Typography as TypographyStyles,
+} from '../../styles';
+import { Icons, Images } from '../../assets';
 
 export const EnableExposureNotifications = (): JSX.Element => {
   const { requestENAuthorization } = useContext(ExposureNotificationContext);
@@ -27,6 +37,10 @@ export const EnableExposureNotifications = (): JSX.Element => {
 
   const handleOnPressEnable = () => {
     requestENAuthorization();
+    dispatchOnboardingComplete();
+  };
+
+  const handleOnPressDontEnable = () => {
     dispatchOnboardingComplete();
   };
 
@@ -58,17 +72,23 @@ export const EnableExposureNotifications = (): JSX.Element => {
           </View>
 
           <View style={styles.footerContainer}>
-            <Button
-              secondary
-              label={disableButtonLabel}
-              onPress={dispatchOnboardingComplete}
-              testID={'onboarding-permissions-disable-button'}
-            />
-            <Button
-              label={buttonLabel}
+            <TouchableOpacity
+              style={styles.dontEnableButton}
+              onPress={handleOnPressDontEnable}
+              testID={'onboarding-permissions-disable-button'}>
+              <Typography style={styles.dontEnableButtonText}>
+                {disableButtonLabel}
+              </Typography>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.enableButton}
               onPress={handleOnPressEnable}
-              testID={'onboarding-permissions-button'}
-            />
+              testID={'onboarding-permissions-button'}>
+              <Typography style={styles.enableButtonText}>
+                {buttonLabel}
+              </Typography>
+            </TouchableOpacity>
           </View>
         </View>
       </ImageBackground>
@@ -97,15 +117,26 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
   },
   headerText: {
-    ...TypographyStyles.header1,
+    ...TypographyStyles.header2,
     color: Colors.white,
   },
   iconContainer: {
-    marginBottom: '10%',
+    paddingBottom: Spacing.large,
   },
   subheaderText: {
-    ...TypographyStyles.header2,
-    color: Colors.white,
-    marginTop: '3%',
+    ...TypographyStyles.mainContent,
+    color: Colors.invertedText,
+  },
+  enableButton: {
+    ...Buttons.largeWhite,
+  },
+  enableButtonText: {
+    ...TypographyStyles.buttonTextDark,
+  },
+  dontEnableButton: {
+    ...Buttons.largeWhiteOutline,
+  },
+  dontEnableButtonText: {
+    ...TypographyStyles.buttonTextLight,
   },
 });

--- a/app/views/onboarding/Onboarding2.js
+++ b/app/views/onboarding/Onboarding2.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Dimensions,
+  TouchableOpacity,
   ImageBackground,
   StatusBar,
   StyleSheet,
@@ -8,12 +9,12 @@ import {
 } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
-import { Button, Typography } from '../../components';
+import { Typography } from '../../components';
 import languages from '../../locales/languages';
 import { useAssets } from '../../TracingStrategyAssets';
 import { sharedStyles } from './styles';
 
-import { Colors } from '../../styles';
+import { Buttons, Colors, Typography as TypographyStyles } from '../../styles';
 
 const width = Dimensions.get('window').width;
 
@@ -49,12 +50,15 @@ const Onboarding = (props) => {
       </View>
       <View style={styles.verticalSpacer} />
       <View style={sharedStyles.footerContainer}>
-        <Button
-          label={languages.t('label.launch_next')}
+        <TouchableOpacity
+          style={styles.button}
           onPress={() => {
             props.navigation.replace('Onboarding3');
-          }}
-        />
+          }}>
+          <Typography style={styles.buttonText}>
+            {languages.t('label.launch_next')}
+          </Typography>
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -79,6 +83,12 @@ const styles = StyleSheet.create({
   },
   verticalSpacer: {
     flex: 1,
+  },
+  button: {
+    ...Buttons.largeBlue,
+  },
+  buttonText: {
+    ...TypographyStyles.buttonTextLight,
   },
 });
 

--- a/app/views/onboarding/Onboarding3.js
+++ b/app/views/onboarding/Onboarding3.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Dimensions,
+  TouchableOpacity,
   ImageBackground,
   StatusBar,
   StyleSheet,
@@ -8,12 +9,12 @@ import {
 } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
-import { Button, Typography } from '../../components';
+import { Typography } from '../../components';
 import languages from '../../locales/languages';
 import { useAssets } from '../../TracingStrategyAssets';
 import { sharedStyles } from './styles';
 
-import { Colors } from '../../styles';
+import { Buttons, Colors, Typography as TypographyStyles } from '../../styles';
 
 const width = Dimensions.get('window').width;
 
@@ -49,12 +50,15 @@ const Onboarding = (props) => {
       </View>
       <View style={styles.verticalSpacer} />
       <View style={sharedStyles.footerContainer}>
-        <Button
-          label={languages.t('label.launch_next')}
+        <TouchableOpacity
+          style={styles.button}
           onPress={() => {
             props.navigation.replace('Onboarding4');
-          }}
-        />
+          }}>
+          <Typography style={styles.buttonText}>
+            {languages.t('label.launch_next')}
+          </Typography>
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -79,6 +83,12 @@ const styles = StyleSheet.create({
   },
   verticalSpacer: {
     flex: 1,
+  },
+  button: {
+    ...Buttons.largeBlue,
+  },
+  buttonText: {
+    ...TypographyStyles.buttonTextLight,
   },
 });
 

--- a/app/views/onboarding/Onboarding4.js
+++ b/app/views/onboarding/Onboarding4.js
@@ -2,18 +2,19 @@ import React from 'react';
 import {
   Dimensions,
   ImageBackground,
+  TouchableOpacity,
   StatusBar,
   StyleSheet,
   View,
 } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
-import { Button, Typography } from '../../components';
+import { Typography } from '../../components';
 import { isGPS } from '../../COVIDSafePathsConfig';
 import { useAssets } from '../../TracingStrategyAssets';
 import { sharedStyles } from './styles';
 
-import { Colors } from '../../styles';
+import { Buttons, Colors, Typography as TypographyStyles } from '../../styles';
 
 const width = Dimensions.get('window').width;
 
@@ -26,7 +27,7 @@ const Onboarding = (props) => {
     onboarding4Icon,
   } = useAssets();
 
-  const onNext = () =>
+  const handleOnPressNext = () =>
     props.navigation.replace(
       isGPS ? 'OnboardingPermissions' : 'EnableExposureNotifications',
     );
@@ -55,7 +56,9 @@ const Onboarding = (props) => {
       </View>
       <View style={styles.verticalSpacer} />
       <View style={sharedStyles.footerContainer}>
-        <Button label={onboarding4Button} onPress={onNext} />
+        <TouchableOpacity style={styles.button} onPress={handleOnPressNext}>
+          <Typography style={styles.buttonText}>{onboarding4Button}</Typography>
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -83,6 +86,12 @@ const styles = StyleSheet.create({
   },
   iconCircle: {
     backgroundColor: Colors.onboardingIconYellow,
+  },
+  button: {
+    ...Buttons.largeBlue,
+  },
+  buttonText: {
+    ...TypographyStyles.buttonTextLight,
   },
 });
 

--- a/app/views/onboarding/OnboardingPermissions.js
+++ b/app/views/onboarding/OnboardingPermissions.js
@@ -1,9 +1,8 @@
 import React, { useContext, useState } from 'react';
 import {
-  Dimensions,
+  TouchableOpacity,
   ImageBackground,
   Platform,
-  ScrollView,
   StatusBar,
   StyleSheet,
   View,
@@ -11,9 +10,6 @@ import {
 import { SvgXml } from 'react-native-svg';
 import { useDispatch } from 'react-redux';
 
-import { Icons, Images } from '../../assets';
-import { sharedStyles } from './styles';
-import { Button } from '../../components/Button';
 import { Typography } from '../../components/Typography';
 import { PARTICIPATE } from '../../constants/storage';
 import { Theme } from '../../constants/themes';
@@ -21,11 +17,15 @@ import { SetStoreData } from '../../helpers/General';
 import languages from '../../locales/languages';
 import PermissionsContext, { PermissionStatus } from '../../PermissionsContext';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
-import fontFamily from '../../constants/fonts';
 
-import { Colors } from '../../styles';
-
-const width = Dimensions.get('window').width;
+import { sharedStyles } from './styles';
+import { Icons, Images } from '../../assets';
+import {
+  Spacing,
+  Buttons,
+  Colors,
+  Typography as TypographyStyles,
+} from '../../styles';
 
 export const OnboardingPermissions = () => {
   const isiOS = Platform.OS === 'ios';
@@ -91,7 +91,7 @@ export const OnboardingPermissions = () => {
     }
   };
 
-  const onSkipStep = () => {
+  const handleOnPressMaybeLater = () => {
     moveToNextStep();
   };
 
@@ -99,6 +99,8 @@ export const OnboardingPermissions = () => {
     SetStoreData(PARTICIPATE, location.status === PermissionStatus.GRANTED);
     dispatchOnboardingComplete();
   };
+
+  const dontEnableText = 'Maybe Later';
 
   return (
     <Theme use='violet'>
@@ -111,7 +113,7 @@ export const OnboardingPermissions = () => {
           translucent
         />
 
-        <ScrollView
+        <View
           testID={'onboarding-permissions-screen'}
           style={styles.mainContainer}>
           <View style={styles.contentContainer}>
@@ -121,20 +123,25 @@ export const OnboardingPermissions = () => {
             <Typography style={styles.headerText}>{header}</Typography>
             <Typography style={styles.subheaderText}>{subHeader}</Typography>
           </View>
-        </ScrollView>
-        <View style={[styles.footerContainer]}>
-          <Button
-            label={'Maybe Later'}
-            secondary
-            style={styles.marginBottom}
-            onPress={onSkipStep}
-            testID={'onboarding-permissions-skip-button'}
-          />
-          <Button
-            label={buttonLabel}
-            onPress={handleButtonPress}
-            testID={'onboarding-permissions-button'}
-          />
+          <View style={styles.footerContainer}>
+            <TouchableOpacity
+              style={styles.dontEnableButton}
+              onPress={handleOnPressMaybeLater}
+              testID={'onboarding-permissions-skip-button'}>
+              <Typography style={styles.dontEnableButtonText}>
+                {dontEnableText}
+              </Typography>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.enableButton}
+              onPress={handleButtonPress}
+              testID={'onboarding-permissions-button'}>
+              <Typography style={styles.enableButtonText}>
+                {buttonLabel}
+              </Typography>
+            </TouchableOpacity>
+          </View>
         </View>
       </ImageBackground>
     </Theme>
@@ -150,34 +157,39 @@ const styles = StyleSheet.create({
   },
   mainContainer: {
     flex: 1,
+    padding: Spacing.large,
   },
   contentContainer: {
-    width: width * 0.9,
+    flex: 3,
+    justifyContent: 'center',
+  },
+  footerContainer: {
     flex: 1,
-    alignSelf: 'center',
-    marginTop: 70,
+    width: '100%',
+    justifyContent: 'space-around',
   },
   headerText: {
-    lineHeight: 32,
-    color: Colors.white,
-    fontSize: 26,
-    fontFamily: fontFamily.primaryRegular,
+    ...TypographyStyles.header2,
+    color: Colors.invertedText,
   },
   subheaderText: {
-    color: Colors.white,
-    marginTop: 24,
-    lineHeight: 24,
-    fontSize: 18,
-    fontFamily: fontFamily.primaryRegular,
-  },
-  marginBottom: {
-    marginBottom: 21,
+    ...TypographyStyles.mainContent,
+    color: Colors.invertedText,
+    paddingTop: Spacing.medium,
   },
   iconCircle: {
     backgroundColor: Colors.white,
   },
-  footerContainer: {
-    padding: 24,
-    width: '100%',
+  enableButton: {
+    ...Buttons.largeWhite,
+  },
+  enableButtonText: {
+    ...TypographyStyles.buttonTextDark,
+  },
+  dontEnableButton: {
+    ...Buttons.largeWhiteOutline,
+  },
+  dontEnableButtonText: {
+    ...TypographyStyles.buttonTextLight,
   },
 });


### PR DESCRIPTION
Why:
A previous commit updated the Typography component such that the styles
were handled by stylesheets, rather than react component logic, but the
onboarding screens were not updated to use the correct styles so some
visual regressions were introduced.

This commit:
Fixes the regressions by using the common styles.

### Before


![onboarding-typography-before](https://user-images.githubusercontent.com/16049495/84773114-f2704800-afa9-11ea-9208-8205dd80fd40.gif)

### After

![onboarding-typography-after](https://user-images.githubusercontent.com/16049495/84773130-f7cd9280-afa9-11ea-858d-a2648dbfc7c7.gif)
