### PR TITLE
Use redux for selected HAs in intersection logic 

### DIFF
--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -33,8 +33,9 @@ import {
 import { MIN_LOCATION_UPDATE_MS } from '../services/LocationService';
 import languages from '../locales/languages';
 
+import { store } from '../store'
+
 import getCursor from '../api/healthcareAuthorities/getCursorApi';
-import getHealthAuthorities from '../api/healthcareAuthorities/getHealthcareAuthoritiesApi';
 
 /**
  * Performs "safety" cleanup of the data, to help ensure that we actually have location
@@ -380,70 +381,68 @@ async function asyncCheckIntersect() {
   let localHAData = await GetStoreData(AUTHORITY_SOURCE_SETTINGS, false);
   if (!localHAData) localHAData = [];
 
-  try {
-    const authorities = await getHealthAuthorities();
+  const { selectedAuthorities } = store.getState().healthcareAuthorities;
+  
+  for (const authority of selectedAuthorities) {
+    try {
+      let {
+        name,
+        api_endpoint_url,
+        info_website_url,
+        notification_threshold_percent,
+        notification_threshold_timeframe,
+        pages,
+      } = await getCursor(authority);
 
-    if (authorities) {
-      for (const authority of authorities) {
-        let {
-          name,
-          api_endpoint_url,
-          info_website_url,
-          notification_threshold_percent,
-          notification_threshold_timeframe,
-          pages,
-        } = await getCursor(authority);
-
-        let currHA = localHAData.find((ha) => ha.key === name);
-        if (!currHA) {
-          currHA = {
-            key: name,
-            url: info_website_url,
-            cursor: '',
-          };
-          localHAData.push(currHA);
-        }
-        // start timestamp of the last stored cursor for this HA
-        const prevCursorStart = parseTimestampCursor(currHA.cursor)[0];
-
-        // Update the news array with the info from the authority
-        name_news.push({
-          name,
-          news_url: info_website_url,
-        });
-
-        for (const { startTimestamp, endTimestamp, filename } of pages) {
-          // skip pages we read before
-          if (prevCursorStart >= startTimestamp) continue;
-          // fetch non-analyzed page
-          const concernPointsPage = await retrieveUrlAsJson(
-            `${api_endpoint_url}${filename}`,
-          );
-
-          // check if any of local points hashes are contained in this page
-          updateMatchFlags(
-            locationArray,
-            new Set(concernPointsPage.concern_point_hashes),
-          );
-
-          currHA.cursor = `${startTimestamp}_${endTimestamp}`;
-        }
-
-        const timeFrameMS = notification_threshold_timeframe * 60e3;
-        const matchRate = notification_threshold_percent / 100;
-        tempDayBins = fillDayBins(
-          tempDayBins,
-          locationArray,
-          timeFrameMS,
-          matchRate,
-          gpsPeriodMS,
-        );
+      let currHA = localHAData.find((ha) => ha.key === name);
+      if (!currHA) {
+        currHA = {
+          key: name,
+          url: info_website_url,
+          cursor: '',
+        };
+        localHAData.push(currHA);
       }
+      // start timestamp of the last stored cursor for this HA
+      const prevCursorStart = parseTimestampCursor(currHA.cursor)[0];
+
+      // Update the news array with the info from the authority
+      name_news.push({
+        name,
+        news_url: info_website_url,
+      });
+
+      for (const { startTimestamp, endTimestamp, filename } of pages) {
+        // skip pages we read before
+        if (prevCursorStart >= startTimestamp) continue;
+        // fetch non-analyzed page
+        const concernPointsPage = await retrieveUrlAsJson(
+          `${api_endpoint_url}${filename}`,
+        );
+
+        // check if any of local points hashes are contained in this page
+        updateMatchFlags(
+          locationArray,
+          new Set(concernPointsPage.concern_point_hashes),
+        );
+
+        currHA.cursor = `${startTimestamp}_${endTimestamp}`;
+      }
+
+      const timeFrameMS = notification_threshold_timeframe * 60e3;
+      const matchRate = notification_threshold_percent / 100;
+      tempDayBins = fillDayBins(
+        tempDayBins,
+        locationArray,
+        timeFrameMS,
+        matchRate,
+        gpsPeriodMS,
+      );
+    } catch (error) {
+      // TODO: We silently fail.  Could be a JSON parsing issue, could be a network issue, etc.
+      //       Should do better than this.
+      console.log('[authority] fetch/parse error :', error);
     }
-  } catch (error) {
-    // TODO: We silently fail.  Could be a JSON parsing issue, could be a network issue, etc.
-    //       Should do better than this.
-    console.log('[authority] fetch/parse error :', error);
   }
 
   // Update each day's bin with the result from the intersection.  To keep the

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -33,7 +33,7 @@ import {
 import { MIN_LOCATION_UPDATE_MS } from '../services/LocationService';
 import languages from '../locales/languages';
 
-import { store } from '../store'
+import { store } from '../store';
 
 import getCursor from '../api/healthcareAuthorities/getCursorApi';
 
@@ -382,7 +382,7 @@ async function asyncCheckIntersect() {
   if (!localHAData) localHAData = [];
 
   const { selectedAuthorities } = store.getState().healthcareAuthorities;
-  
+
   for (const authority of selectedAuthorities) {
     try {
       let {

--- a/jest/setupFile.js
+++ b/jest/setupFile.js
@@ -38,6 +38,22 @@ jest.mock('react-native-popup-menu', () => ({
   MenuTrigger: 'MenuTrigger',
 }));
 
+jest.mock('redux', () => ({
+  createStore: () => {},
+  combineReducers: () => {},
+  applyMiddleware: () => {},
+}));
+
+jest.mock('redux-persist', () => ({
+  createMigrate: () => {},
+  persistReducer: () => {},
+  persistStore: () => {},
+}));
+
+jest.mock('redux-devtools-extension', () => ({
+  composeWithDevTools: () => {},
+}));
+
 jest.mock('@react-navigation/native', () => {
   return {
     createAppContainer: jest


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
This PR updates the intersection logic to load the list of selected health authorities from redux instead of fetching the full list of available HAs on every intersection check cycle. 

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### How to test:
- Select one of available HAs from the list
- Home screen should perform the intersection check on the data from the newly selected HA
<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
