### PR TITLE
Instead of turning the date object into a string, use toDateString

### DIFF
--- a/app/views/assessment/Option.js
+++ b/app/views/assessment/Option.js
@@ -59,7 +59,7 @@ export const Option = ({
       let date = new Date();
       setDate(date);
       setShowDatePicker(true);
-      if (isPlatformiOS()) onSelect(String(date));
+      if (isPlatformiOS()) onSelect(date.toDateString());
       return;
     }
     onSelect(option.value);
@@ -68,7 +68,7 @@ export const Option = ({
   const handleDateTimePickerSelect = (e, date) => {
     if (date) {
       if (isPlatformAndroid()) setShowDatePicker(false);
-      onSelect(String(date));
+      onSelect(date.toDateString());
       setDate(date);
     }
   };

--- a/app/views/assessment/__tests__/Option.spec.js
+++ b/app/views/assessment/__tests__/Option.spec.js
@@ -55,26 +55,26 @@ describe('SCREEN_TYPE_DATE', () => {
     );
     expect(getByTestId('label').children).toEqual(['Label']);
   });
-  // test('on iOS, selecting the date picker immediatley invokes the onSelect handler with the current date', () => {
-  //   jest.doMock('../../../Util', () => ({
-  //     isPlatformIOS: () => true,
-  //   }));
-  //   let onSelect = jest.fn();
-  //   const { getByTestId } = render(
-  //     <Option
-  //       index={0}
-  //       onSelect={onSelect}
-  //       option={{
-  //         label: 'Label',
-  //         value: 'Value',
-  //       }}
-  //       type={SCREEN_TYPE_DATE}
-  //     />,
-  //   );
-  //   fireEvent.press(getByTestId('option'));
-  //   expect(onSelect).toHaveBeenCalledWith(String(Date()));
-  //   expect(getByTestId('label').children[0]).toMatch(/\d\d?\/\d\d?\/\d\d\d\d/);
-  // });
+  test('on iOS, selecting the date picker immediatley invokes the onSelect handler with the current date', () => {
+    jest.doMock('../../../Util', () => ({
+      isPlatformIOS: () => true,
+    }));
+    let onSelect = jest.fn();
+    const { getByTestId } = render(
+      <Option
+        index={0}
+        onSelect={onSelect}
+        option={{
+          label: 'Label',
+          value: 'Value',
+        }}
+        type={SCREEN_TYPE_DATE}
+      />,
+    );
+    fireEvent.press(getByTestId('option'));
+    expect(onSelect).toHaveBeenCalledWith(new Date().toDateString());
+    expect(getByTestId('label').children[0]).toMatch(/\d\d?\/\d\d?\/\d\d\d\d/);
+  });
   test('shows the date picker', () => {
     const { getByTestId } = render(
       <Option


### PR DESCRIPTION
#### Description:

The current implementation led to a flakey test that failed when the seconds were off by 1. Using the toDateString function removes the timestamp, which is not needed in this particular
instance (date only).

