### PR TITLE
Update copy for BT Tracing Off

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -132,11 +132,11 @@
     "bluetooth": {
       "all_services_on_header": "PathCheck",
       "all_services_on_subheader": "Exposure notifications are on",
-      "tracing_off_header": "Notifications Disabled",
-      "tracing_off_subheader": "You will not receive notifications about possible exposures",
-      "tracing_off_button": "Allow Notifications",
+      "tracing_off_header": "Exposure Notifications Disabled",
+      "tracing_off_subheader": "Enable Exposure Notifications to receive information about possible exposures",
+      "tracing_off_button": "Allow Exposure Notifications",
       "unavailable_header": "Exposure history notifications are not yet available",
-      "unavailable_subheader": "Your phone is not currently covered by Healthcare Authorities using PathCheck."
+      "unavailable_subheader": "Your phone is not currently covered by Healthcare Authorities using PathCheck"
     },
     "shared": {
       "notifications_off_header": "Notifications Disabled",

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -75,7 +75,7 @@ export const Main = () => {
     return <TracingOffScreen />;
   } else if (notification.status === PermissionStatus.DENIED) {
     return <NotificationsOffScreen />;
-  } else if (hasSelectedAuthorities === false) {
+  } else if (hasSelectedAuthorities === false && isGPS) {
     return <SelectAuthorityScreen />;
   } else {
     return <AllServicesOnScreen />;

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/ExposureNotificationNotAvailable.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/ExposureNotificationNotAvailable.spec.js.snap
@@ -152,7 +152,7 @@ exports[`exposure notifications not available screen matches snapshot 1`] = `
             ]
           }
         >
-          Your phone is not currently covered by Healthcare Authorities using PathCheck.
+          Your phone is not currently covered by Healthcare Authorities using PathCheck
         </Text>
       </View>
     </View>


### PR DESCRIPTION
#### Description:

Small copy change for the BT exposure notifications off.
Also, added in a change to hide the Select HA indicator for BT only.

#### Screenshots:

![Screen Shot 2020-06-16 at 2 06 59 PM](https://user-images.githubusercontent.com/5807753/84817483-a5f13080-afda-11ea-91a0-c1147915c15f.png)
