### PR TITLE
Build exposure history from raw exposures

### DIFF
--- a/app/ExposureNotificationContext.tsx
+++ b/app/ExposureNotificationContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState } from 'react';
 
-import * as ExposureNotifications from './exposureNotificationsNativeModule';
+import { BTNativeModule } from './bt';
 
 export type ENAuthorizationStatus = 'authorized' | 'notAuthorized';
 
@@ -35,7 +35,7 @@ const ExposureNotificationsProvider = ({
     const cb = (authorizationStatus: ENAuthorizationStatus) => {
       setAuthorizationStatus(authorizationStatus);
     };
-    ExposureNotifications.requestAuthorization(cb);
+    BTNativeModule.requestAuthorization(cb);
   };
 
   return (

--- a/app/bt/exposureNotifications.spec.ts
+++ b/app/bt/exposureNotifications.spec.ts
@@ -1,0 +1,98 @@
+import dayjs from 'dayjs';
+
+import { DateTimeUtils } from '../helpers';
+import { Possible, ExposureDatum } from '../exposureHistory';
+import { toExposureHistory, RawExposure } from './exposureNotifications';
+
+describe('toExposureHistory', () => {
+  describe('when there are no exposure notifications', () => {
+    it('returns a history of NoKnown Exposures for the past 21 days', () => {
+      const rawExposures: RawExposure[] = [];
+      const today = Date.now();
+      const twentyDaysAgo = dayjs(today).subtract(20, 'day').valueOf();
+
+      const result = toExposureHistory(rawExposures);
+
+      const lastDay = result[result.length - 1].date;
+      const firstDay = result[0].date;
+      expect(result.length).toBe(21);
+      expect(
+        result.every((datum: ExposureDatum) => datum.kind === 'NoKnown'),
+      ).toBe(true);
+      expect(dayjs(lastDay).isSame(today, 'day')).toBe(true);
+      expect(dayjs(firstDay).isSame(twentyDaysAgo, 'day')).toBe(true);
+    });
+  });
+
+  describe('when there was a possible exposure two days ago', () => {
+    it('returns a history with a PossibleExposure 2 days ago', () => {
+      const today = Date.now();
+      const twoDaysAgo = dayjs(today).subtract(2, 'day').valueOf();
+      const duration = 30 * 60 * 1000;
+      const rawExposures: RawExposure[] = [
+        {
+          id: 'ABCD-EFGH',
+          date: twoDaysAgo,
+          duration,
+          totalRiskScore: 2,
+          transmissionRiskLevel: 3,
+        },
+      ];
+      const expected: Possible = {
+        kind: 'Possible',
+        date: DateTimeUtils.beginningOfDay(twoDaysAgo),
+        duration: duration,
+        totalRiskScore: 2,
+        transmissionRiskLevel: 3,
+      };
+
+      const result = toExposureHistory(rawExposures);
+
+      expect(result[result.length - 3]).toEqual(expected);
+    });
+  });
+
+  describe('when there are multiple raw exposures on the same day', () => {
+    it('combines the raw exposure into a single possible exposure with the sum of duration and max of risk', () => {
+      const today = Date.now();
+      const beginningOfDay = DateTimeUtils.beginningOfDay(today);
+      const duration1 = 30 * 60 * 1000;
+      const duration2 = 10 * 60 * 1000;
+      const duration3 = 25 * 60 * 1000;
+      const rawExposures: RawExposure[] = [
+        {
+          id: 'raw-exposure-1',
+          date: beginningOfDay + 1000,
+          duration: duration1,
+          totalRiskScore: 1,
+          transmissionRiskLevel: 3,
+        },
+        {
+          id: 'raw-exposure-2',
+          date: beginningOfDay + 18000,
+          duration: duration2,
+          totalRiskScore: 7,
+          transmissionRiskLevel: 2,
+        },
+        {
+          id: 'raw-exposure-3',
+          date: beginningOfDay + 36000,
+          duration: duration3,
+          totalRiskScore: 4,
+          transmissionRiskLevel: 5,
+        },
+      ];
+      const expected: Possible = {
+        kind: 'Possible',
+        date: DateTimeUtils.beginningOfDay(today),
+        duration: duration1 + duration2 + duration3,
+        totalRiskScore: 7,
+        transmissionRiskLevel: 5,
+      };
+
+      const result = toExposureHistory(rawExposures);
+
+      expect(result[result.length - 1]).toEqual(expected);
+    });
+  });
+});

--- a/app/bt/exposureNotifications.ts
+++ b/app/bt/exposureNotifications.ts
@@ -1,0 +1,75 @@
+import dayjs from 'dayjs';
+
+import {
+  Possible,
+  NoKnown,
+  ExposureHistory,
+  blankHistory,
+} from '../exposureHistory';
+
+type UUID = string;
+type Posix = number;
+
+export interface RawExposure {
+  id: UUID;
+  date: Posix;
+  duration: number;
+  totalRiskScore: number;
+  transmissionRiskLevel: number;
+}
+
+export const toExposureHistory = (
+  rawExposures: RawExposure[],
+): ExposureHistory => {
+  const possibleExposures = rawExposures.map(toPossible);
+  const byDate = groupedByDate(possibleExposures, combinePossibles);
+
+  const base = blankHistory();
+
+  return base.map((datum: NoKnown) => {
+    const date = datum.date;
+    if (byDate[date]) {
+      return byDate[date];
+    } else {
+      return datum;
+    }
+  });
+};
+
+const toPossible = (r: RawExposure): Possible => {
+  const beginngingOfDay = (date: Posix) => dayjs(date).startOf('day');
+  return {
+    kind: 'Possible',
+    date: beginngingOfDay(r.date).valueOf(),
+    duration: r.duration,
+    transmissionRiskLevel: r.transmissionRiskLevel,
+    totalRiskScore: r.totalRiskScore,
+  };
+};
+
+const combinePossibles = (a: Possible, b: Possible): Possible => {
+  return {
+    ...a,
+    duration: a.duration + b.duration,
+    totalRiskScore: Math.max(a.totalRiskScore, b.totalRiskScore),
+    transmissionRiskLevel: Math.max(
+      a.transmissionRiskLevel,
+      b.transmissionRiskLevel,
+    ),
+  };
+};
+
+const groupedByDate = (
+  exposures: Possible[],
+  combine: (a: Possible, b: Possible) => Possible,
+): Record<Posix, Possible> => {
+  return exposures.reduce<Record<Posix, Possible>>((result, exposure) => {
+    const date = exposure.date;
+    if (result[date]) {
+      result[date] = combine(result[date], exposure);
+    } else {
+      result[date] = exposure;
+    }
+    return result;
+  }, {});
+};

--- a/app/bt/index.ts
+++ b/app/bt/index.ts
@@ -1,0 +1,3 @@
+import * as BTNativeModule from './nativeModule';
+
+export { BTNativeModule };

--- a/app/exposureHistory.ts
+++ b/app/exposureHistory.ts
@@ -1,0 +1,39 @@
+import dayjs from 'dayjs';
+
+export type Posix = number;
+
+export interface Possible {
+  kind: 'Possible';
+  date: Posix;
+  duration: number;
+  totalRiskScore: number;
+  transmissionRiskLevel: number;
+}
+
+export interface NoKnown {
+  kind: 'NoKnown';
+  date: Posix;
+}
+
+export type ExposureDatum = Possible | NoKnown;
+
+export type ExposureHistory = ExposureDatum[];
+
+const HISTORY_LENGTH = 21;
+
+export const blankHistory = (): NoKnown[] => {
+  const now = Date.now();
+  const daysAgo = [...Array(HISTORY_LENGTH)].map((_v, idx: number) => {
+    return HISTORY_LENGTH - 1 - idx;
+  });
+
+  return daysAgo.map(
+    (daysAgo: number): NoKnown => {
+      const date = dayjs(now).subtract(daysAgo, 'day').startOf('day').valueOf();
+      return {
+        kind: 'NoKnown',
+        date,
+      };
+    },
+  );
+};

--- a/app/helpers/dateTimeUtils.ts
+++ b/app/helpers/dateTimeUtils.ts
@@ -3,7 +3,10 @@ import dayjs from 'dayjs';
 type Posix = number;
 
 export const isToday = (date: Posix): boolean => {
-  const beginningOfDay = dayjs(Date.now()).startOf('day').valueOf();
   const endOfDay = dayjs(Date.now()).endOf('day').valueOf();
-  return beginningOfDay <= date && endOfDay >= date;
+  return beginningOfDay(date) <= date && endOfDay >= date;
+};
+
+export const beginningOfDay = (date: Posix): Posix => {
+  return dayjs(date).startOf('day').valueOf();
 };

--- a/app/views/ExposureHistory/Calendar.tsx
+++ b/app/views/ExposureHistory/Calendar.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
 import dayjs from 'dayjs';
 
+import { ExposureHistory, ExposureDatum } from '../../exposureHistory';
 import { Typography } from '../../components/Typography';
 import ExposureDatumIndicator from './ExposureDatumIndicator';
-import { ExposureHistory, ExposureDatum } from '../../ExposureHistoryContext';
 
 import { Spacing } from '../../styles';
 
 interface CalendarProps {
   exposureHistory: ExposureHistory;
   onSelectDate: (exposureDatum: ExposureDatum) => void;
-  selectedDatum: ExposureDatum;
+  selectedDatum: ExposureDatum | null;
 }
 
 const Calendar = ({
@@ -39,7 +39,9 @@ const Calendar = ({
               key={`calendar-day-${datum.date}`}
               onPress={() => onSelectDate(datum)}>
               <ExposureDatumIndicator
-                isSelected={datum.id === selectedDatum.id}
+                isSelected={
+                  selectedDatum ? datum.date === selectedDatum.date : false
+                }
                 exposureDatum={datum}
               />
             </TouchableOpacity>

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -3,12 +3,7 @@ import { TouchableOpacity, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import dayjs from 'dayjs';
 
-import {
-  ExposureDatum,
-  Possible,
-  Unknown,
-  NoKnown,
-} from '../../ExposureHistoryContext';
+import { ExposureDatum, Possible, NoKnown } from '../../exposureHistory';
 import { Typography } from '../../components/Typography';
 import { TimeHelpers } from '../utils';
 import { Screens } from '../../navigation';
@@ -32,9 +27,6 @@ const ExposureDatumDetail = ({
     case 'Possible': {
       return <PossibleExposureDetail datum={exposureDatum} />;
     }
-    case 'Unknown': {
-      return <UnknownExposureDetail datum={exposureDatum} />;
-    }
     case 'NoKnown': {
       return <NoKnownExposureDetail datum={exposureDatum} />;
     }
@@ -46,15 +38,12 @@ interface PossibleExposureDetailProps {
 }
 
 const PossibleExposureDetail = ({
-  datum: { date, possibleExposureTimeInMin, currentDailyReports },
+  datum: { date, duration },
 }: PossibleExposureDetailProps) => {
-  const exposureDurationText = TimeHelpers.durationMsToString(
-    possibleExposureTimeInMin * 60 * 1000,
-  );
+  const exposureDurationText = TimeHelpers.durationMsToString(duration);
   const navigation = useNavigation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
   const exposureTime = `Possible Exposure Time: ${exposureDurationText}`;
-  const dailyReports = `Current daily reports: ${currentDailyReports}`;
   const explainationContent = `For ${exposureDurationText}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.`;
 
   const handleOnPressNextSteps = () => {
@@ -68,7 +57,6 @@ const PossibleExposureDetail = ({
       <View style={styles.container}>
         <Typography style={styles.date}>{exposureDate}</Typography>
         <Typography style={styles.info}>{exposureTime}</Typography>
-        <Typography style={styles.info}>{dailyReports}</Typography>
         <View style={styles.contentContainer}>
           <Typography style={styles.content}>{explainationContent}</Typography>
         </View>
@@ -101,28 +89,6 @@ const NoKnownExposureDetail = ({
     <View style={styles.container}>
       <Typography style={styles.date}>{exposureDate}</Typography>
       <Typography style={styles.info}>{dailyReports}</Typography>
-      <View style={styles.contentContainer}>
-        <Typography style={styles.content}>{explainationContent}</Typography>
-      </View>
-    </View>
-  );
-};
-
-interface UnknownExposureDetailProps {
-  datum: Unknown;
-}
-
-const UnknownExposureDetail = ({
-  datum: { date },
-}: UnknownExposureDetailProps) => {
-  const exposureDate = dayjs(date).format('dddd, MMM DD');
-  const subTitleText = 'Exposure notifications disabled';
-  const explainationContent =
-    'You did not have exposure notifications enabled on this day.';
-  return (
-    <View style={styles.container}>
-      <Typography style={styles.date}>{exposureDate}</Typography>
-      <Typography style={styles.info}>{subTitleText}</Typography>
       <View style={styles.contentContainer}>
         <Typography style={styles.content}>{explainationContent}</Typography>
       </View>

--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -3,7 +3,7 @@ import { View, Text, ViewStyle, TextStyle, StyleSheet } from 'react-native';
 import dayjs from 'dayjs';
 
 import { DateTimeUtils } from '../../helpers';
-import { ExposureDatum } from '../../ExposureHistoryContext';
+import { ExposureDatum } from '../../exposureHistory';
 import { Outlines, Colors, Typography } from '../../styles';
 
 interface ExposureDatumIndicatorProps {
@@ -22,12 +22,6 @@ const ExposureDatumIndicator = ({
     textStyle,
   ]: IndicatorStyle): IndicatorStyle => {
     switch (exposureDatum.kind) {
-      case 'Unknown': {
-        return [
-          { ...circleStyle },
-          { ...textStyle, color: Colors.tertiaryViolet },
-        ];
-      }
       case 'NoKnown': {
         return [
           { ...circleStyle },

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -3,9 +3,8 @@ import { StyleSheet, View, BackHandler, ScrollView } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
-import ExposureHistoryContext, {
-  ExposureDatum,
-} from '../../ExposureHistoryContext';
+import ExposureHistoryContext from '../../ExposureHistoryContext';
+import { ExposureDatum } from '../../exposureHistory';
 import ExposureDatumDetail from './ExposureDatumDetail';
 import Calendar from './Calendar';
 import { NavigationProp } from '../../navigation';
@@ -21,9 +20,11 @@ const ExposureHistoryScreen = ({
 }: ExposureHistoryScreenProps): JSX.Element => {
   const { t } = useTranslation();
   const { exposureHistory } = useContext(ExposureHistoryContext);
-  const [selectedExposureDatum, setSelectedExposureDatum] = useState(
-    exposureHistory[exposureHistory.length - 1],
-  );
+  const [
+    selectedExposureDatum,
+    setSelectedExposureDatum,
+  ] = useState<ExposureDatum | null>(null);
+
   useEffect(() => {
     const handleBackPress = () => {
       navigation.goBack();
@@ -55,7 +56,9 @@ const ExposureHistoryScreen = ({
           />
         </View>
         <View style={styles.detailsContainer}>
-          <ExposureDatumDetail exposureDatum={selectedExposureDatum} />
+          {selectedExposureDatum ? (
+            <ExposureDatumDetail exposureDatum={selectedExposureDatum} />
+          ) : null}
         </View>
       </ScrollView>
     </NavigationBarWrapper>

--- a/app/views/Settings/ENDebugMenu.tsx
+++ b/app/views/Settings/ENDebugMenu.tsx
@@ -11,18 +11,7 @@ import {
 
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
 import { Typography } from '../../components/Typography';
-import {
-  detectExposuresNow,
-  simulateExposure,
-  simulatePositiveDiagnosis,
-  toggleExposureNotifications,
-  resetExposureDetectionError,
-  resetUserENState,
-  resetExposures,
-  getAndPostDiagnosisKeys,
-  simulateExposureDetectionError,
-  getExposureConfiguration,
-} from '../../exposureNotificationsNativeModule';
+import { BTNativeModule } from '../../bt';
 import { NavigationProp, Screens } from '../../navigation';
 
 import { Colors, Spacing } from '../../styles';
@@ -91,7 +80,7 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
   };
 
   const handleOnPressToggleExposureNotifications = () => {
-    handleOnPressSimulationButton(toggleExposureNotifications)();
+    handleOnPressSimulationButton(BTNativeModule.toggleExposureNotifications)();
     global.ExposureNotificationsOn = !global.ExposureNotificationsOn;
   };
 
@@ -123,31 +112,41 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
           <DebugMenuListItem
             label='Reset Exposures'
             style={styles.lastListItem}
-            onPress={handleOnPressSimulationButton(resetExposures)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.resetExposures,
+            )}
           />
         </View>
         <View style={styles.section}>
           <DebugMenuListItem
             label='Detect Exposures Now'
-            onPress={handleOnPressSimulationButton(detectExposuresNow)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.detectExposuresNow,
+            )}
           />
           <DebugMenuListItem
             label='Get Exposure Configuration'
-            onPress={handleOnPressSimulationButton(getExposureConfiguration)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.getExposureConfiguration,
+            )}
           />
           <DebugMenuListItem
             label='Simulate Exposure Detection Error'
             onPress={handleOnPressSimulationButton(
-              simulateExposureDetectionError,
+              BTNativeModule.simulateExposureDetectionError,
             )}
           />
           <DebugMenuListItem
             label='Simulate Exposure'
-            onPress={handleOnPressSimulationButton(simulateExposure)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.simulateExposure,
+            )}
           />
           <DebugMenuListItem
             label='Simulate Positive Diagnosis'
-            onPress={handleOnPressSimulationButton(simulatePositiveDiagnosis)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.simulatePositiveDiagnosis,
+            )}
           />
           <DebugMenuListItem
             label='Toggle Exposure Notifications'
@@ -155,12 +154,16 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
           />
           <DebugMenuListItem
             label='Reset Exposure Detection Error'
-            onPress={handleOnPressSimulationButton(resetExposureDetectionError)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.resetExposureDetectionError,
+            )}
           />
           <DebugMenuListItem
             label='Reset User EN State'
             style={styles.lastListItem}
-            onPress={handleOnPressSimulationButton(resetUserENState)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.resetUserENState,
+            )}
           />
         </View>
         <View style={styles.section}>
@@ -173,7 +176,9 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
           <DebugMenuListItem
             label='Get and Post Diagnosis Keys'
             style={styles.lastListItem}
-            onPress={handleOnPressSimulationButton(getAndPostDiagnosisKeys)}
+            onPress={handleOnPressSimulationButton(
+              BTNativeModule.getAndPostDiagnosisKeys,
+            )}
           />
         </View>
       </ScrollView>

--- a/app/views/Settings/ENLocalDiagnosisKeyScreen.tsx
+++ b/app/views/Settings/ENLocalDiagnosisKeyScreen.tsx
@@ -12,7 +12,7 @@ import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
 import { Typography } from '../../components/Typography';
 import { NavigationProp } from '../../navigation';
 
-import * as ExposureNotifications from './../../../app/exposureNotificationsNativeModule';
+import { BTNativeModule } from './../../../app/bt';
 
 export type ENDiagnosisKey = {
   rollingStartNumber: number;
@@ -34,7 +34,7 @@ export const ENLocalDiagnosisKeyScreen = ({
       }
       setDiagnosisKeys(diagnosisKeys);
     };
-    ExposureNotifications.fetchDiagnosisKeys(cb);
+    BTNativeModule.fetchDiagnosisKeys(cb);
   };
 
   const [diagnosisKeys, setDiagnosisKeys] = useState<ENDiagnosisKey[]>(

--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -166,12 +166,18 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
           />
         </View>
 
-        {__DEV__ ? (
+        {!isGPS ? (
           <View style={styles.section}>
             <SettingsListItem
               label='EN Debug Menu'
               onPress={navigateTo(Screens.ENDebugMenu)}
+              style={styles.lastListItem}
             />
+          </View>
+        ) : null}
+
+        {__DEV__ ? (
+          <View style={styles.section}>
             <SettingsListItem
               label='Feature Flags (Dev mode only)'
               onPress={navigateTo(Screens.FeatureFlags)}

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -475,42 +475,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
             isTVSelectable={true}
             style={
               Object {
-                "borderBottomWidth": 1,
-                "borderColor": "#a5affb",
-                "flex": 1,
-                "opacity": 1,
-                "paddingVertical": 20,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2e2e2e",
-                    "fontSize": 17,
-                    "lineHeight": 28,
-                  },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Object {
-                    "color": "#4051db",
-                    "fontSize": 17,
-                    "lineHeight": 28,
-                  },
-                ]
-              }
-            >
-              EN Debug Menu
-            </Text>
-          </View>
-          <View
-            accessible={true}
-            focusable={true}
-            isTVSelectable={true}
-            style={
-              Object {
                 "borderBottomWidth": 0,
                 "borderColor": "#a5affb",
                 "flex": 1,
@@ -879,42 +843,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
             }
           }
         >
-          <View
-            accessible={true}
-            focusable={true}
-            isTVSelectable={true}
-            style={
-              Object {
-                "borderBottomWidth": 1,
-                "borderColor": "#a5affb",
-                "flex": 1,
-                "opacity": 1,
-                "paddingVertical": 20,
-              }
-            }
-          >
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2e2e2e",
-                    "fontSize": 17,
-                    "lineHeight": 28,
-                  },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Object {
-                    "color": "#4051db",
-                    "fontSize": 17,
-                    "lineHeight": 28,
-                  },
-                ]
-              }
-            >
-              EN Debug Menu
-            </Text>
-          </View>
           <View
             accessible={true}
             focusable={true}

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -211,8 +211,8 @@ final class ExposureManager: NSObject {
       completion([NSNull(), "Exposure deteaction error message: \(BTSecureStorage.shared.exposureDetectionErrorLocalizedDescription)"])
     case .simulateExposure:
       let exposure = Exposure(id: UUID().uuidString,
-                              date: Date().posixRepresentation - Int(TimeInterval.random(in: 1...4)) * 24 * 60 * 60 * 1000,
-                              duration: TimeInterval(Int.random(in: 1...5) * 60 * 5 * 1000),
+                              date: Date().posixRepresentation - Int(TimeInterval.random(in: 0...13)) * 24 * 60 * 60 * 1000,
+                              duration: TimeInterval(Int.random(in: 1...10) * 60 * 5 * 1000),
                               totalRiskScore: .random(in: 1...8),
                               transmissionRiskLevel: .random(in: 0...7))
       let exposures = BTSecureStorage.shared.exposures

--- a/ios/BT/Extensions/Notification+Extensions.swift
+++ b/ios/BT/Extensions/Notification+Extensions.swift
@@ -2,6 +2,6 @@ extension Notification.Name {
   public static let StorageTestResultsDidChange = Notification.Name(rawValue: "BTSecureStorageTestResultsDidChange")
   public static let StorageExposureDetectionErrorLocalizedDescriptionDidChange = Notification.Name(rawValue: "BTSecureStorageExposureDetectionErrorLocalizedDescriptionDidChange")
   public static let DateLastPerformedExposureDetectionDidChange = Notification.Name(rawValue: "BTSecureStorageDateLastPerformedExposureDetectionDidChange")
-  public static let ExposuresDidChange = Notification.Name(rawValue: "EXPOSURES_CHANGED")
+  public static let ExposuresDidChange = Notification.Name(rawValue: "onExposureRecordUpdated")
   public static let NextDiagnosisKeyFileIndexDidChange = Notification.Name(rawValue: "BTSecureStorageNextDiagnosisKeyFileIndexDidChange")
 }

--- a/ios/BT/bridge/ExposureEventEmitter.m
+++ b/ios/BT/bridge/ExposureEventEmitter.m
@@ -2,12 +2,17 @@
 #import <React/RCTEventEmitter.h>
 
 // Notification/Event Names
-NSString *const onExposuresChanged = @"EXPOSURES_CHANGED";
+NSString *const onExposuresChanged = @"onExposureRecordUpdated";
 
 @interface ExposureEventEmitter : RCTEventEmitter <RCTBridgeModule>
 @end
 
 @implementation ExposureEventEmitter
+
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;  // only do this if your module initialization relies on calling UIKit!
+}
 
 RCT_EXPORT_MODULE();
 


### PR DESCRIPTION
Why:
We would like to be creating an exposure history for the user based off
of data received from the Exposure Notification Server data which is
passed to the JavaScript layer from the native layer.

This commit:
Introduces the logic for converting a list of raw Exposures sent from
the native side to an ExposureHistory. Additionally we refactored the
NativeModule a bit and exposed the debug screen to the production build
so that users can test in test flight.

Currently we are not receiving data from the GAEN server, but we do have
mocked data coming from the native layer. A user can tap 'simulate
exposure' on the debug screen to create a new simulated exposure.

#### Gif

![faked-exposures](https://user-images.githubusercontent.com/16049495/84922845-6edf5580-b094-11ea-8b40-46effe7d3c36.gif)
