### PR TITLE
Hotfix: Migrate Redux Store for HA Custom URL

### DIFF
--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -12,7 +12,7 @@ const enhancers = composeWithDevTools(
   applyMiddleware(thunk, createImmutableStateInvariantMiddleware()),
 );
 
-export const STORE_VERSION = 0;
+export const STORE_VERSION = 1;
 const persistConfig = {
   key: 'root',
   storage: AsyncStorage,

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -1,7 +1,1 @@
-import type { MigrationManifest, PersistedState } from 'redux-persist';
-
-const migrations: MigrationManifest = {
-  0: (prevState: PersistedState) => prevState,
-};
-
-export default migrations;
+export { default } from './migrations';

--- a/app/store/migrations/migrations.js
+++ b/app/store/migrations/migrations.js
@@ -1,0 +1,13 @@
+// Intentionally in JS to allow ensuring we can directly edit state between migrations.
+const migrations = {
+  0: (prevState) => prevState,
+  // Migration 1: We introduce the "availableCustomAuthorities" property to the "healthcareAuthorities" slice
+  1: (prevState) => {
+    if (prevState && prevState.healthcareAuthorities) {
+      prevState.healthcareAuthorities.availableCustomAuthorities = [];
+    }
+    return prevState;
+  },
+};
+
+export default migrations;

--- a/app/store/migrations/migrations.ts
+++ b/app/store/migrations/migrations.ts
@@ -1,0 +1,5 @@
+import type { MigrationManifest } from 'redux-persist';
+import { default as untypedMigrations } from './migrations';
+
+const migrations: MigrationManifest = untypedMigrations;
+export default migrations;


### PR DESCRIPTION
Adds a migration step to add an initial empty array for the custom urls. This should fix any issues of a migrated app crashing on the URL entry screen

Also converts the migrations from js to ts, with a declarations file.
Typing migrations correctly is inherently problematic, as it requires storing previous state shapes, which gets very messy. Conditional safe edits and type assertion on the declaration is a better move imo. If this causes issues with improper state shapes in the future, we can look into migration unit tests.

We were previously not running any transformative migrations, which is why this is coming up now.