### PR TITLE
Export Upload Code Input Validation Error Message

### DIFF
--- a/app/api/export/exportCodeApi.ts
+++ b/app/api/export/exportCodeApi.ts
@@ -14,7 +14,9 @@ const exportCodeApi = async (
   });
   const success = res.status === 200;
   if (!success) {
-    throw res.status;
+    throw new Error(
+      `Export code validation API failed with status code: ${res.status}`,
+    );
   }
   return await res.json();
 };

--- a/app/views/Export/ExportCodeInput.js
+++ b/app/views/Export/ExportCodeInput.js
@@ -149,7 +149,7 @@ export const ExportSelectHA = ({ route, navigation }) => {
       }
       setIsCheckingCode(false);
     } catch (e) {
-      Alert.alert(t('common.something_went_wrong'));
+      Alert.alert(t('common.something_went_wrong'), e.message);
       setIsCheckingCode(false);
     }
   };


### PR DESCRIPTION
Adds an error body message to the alert shown on code input failure during export.
This is to assist in debugging issues in testing, where it's unknown if the server is failing or the mobile client.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85035332-0904d380-b151-11ea-84d8-fe2541a01de3.png">

^ The above error was forced by changing the url, disregard the 404 specifics
