### PR TITLE
Remove Auto Start Debug Logic

### DIFF
--- a/scripts/node-modules/react-native-background-geolocation/BackgroundGeolocationModule.java
+++ b/scripts/node-modules/react-native-background-geolocation/BackgroundGeolocationModule.java
@@ -470,7 +470,7 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
 
         Log.e("isAutoStartEnabled===", IS_AUTO_START_ENABLED + "");
 
-        if(true) {
+        if(!isAutoStartEnabled) {
             addAutoStartup(autoStartDialogueTitle, autoStartDialogueText);
         }
     }
@@ -493,7 +493,7 @@ public class BackgroundGeolocationModule extends ReactContextBaseJavaModule impl
             }
 
             List<ResolveInfo> list = getCurrentActivity().getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-            if  (true) {
+             if  (list.size() > 0) {
                 new Handler(Looper.getMainLooper()).post(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
#### Description:
This removes debug logic I accidentally left in #1046. Prevent auto start dialog from showing unnecessarily.

#### Linked issues:

[SAF-718](https://pathcheck.atlassian.net/browse/SAF-718)

#### How to test:

Fresh install app and complete onboarding. At the end of onboarding, an auto start dialog WILL NOT show for devices that don't require this extra permission.
