### PR TITLE
Loading Indicator for Debug Screen

### DIFF
--- a/app/views/Settings/ENDebugMenu.tsx
+++ b/app/views/Settings/ENDebugMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View,
   ViewStyle,
@@ -7,6 +7,7 @@ import {
   Alert,
   BackHandler,
   ScrollView,
+  ActivityIndicator,
 } from 'react-native';
 
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
@@ -24,6 +25,7 @@ type ENDebugMenuProps = {
 const DEBUG_VERIFICATION_CODE = '111111';
 
 const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
+  const [loading, setLoading] = useState(false);
   useEffect(() => {
     const handleBackPress = () => {
       navigation.goBack();
@@ -66,7 +68,13 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
     ) => void,
   ) => {
     return () => {
+      // Update loading state
+      setLoading(true);
+
       const cb = (errorString: string | null, successString: string | null) => {
+        // Update loading state
+        setLoading(false);
+
         if (errorString) {
           showErrorAlert(errorString);
         } else if (successString) {
@@ -119,72 +127,78 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
       includeBottomNav
       title={'EN Debug Menu'}
       onBackPress={backToSettings}>
-      <ScrollView>
-        <View style={styles.section}>
-          <DebugMenuListItem
-            label='Reset Exposures'
-            style={styles.lastListItem}
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.resetExposures,
-            )}
-          />
+      {loading ? (
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <ActivityIndicator size={'large'} />
         </View>
-        <View style={styles.section}>
-          <DebugMenuListItem
-            label='Detect Exposures Now'
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.detectExposuresNow,
-            )}
-          />
-          <DebugMenuListItem
-            label='Get Exposure Configuration'
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.getExposureConfiguration,
-            )}
-          />
-          <DebugMenuListItem
-            label='Simulate Exposure Detection Error'
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.simulateExposureDetectionError,
-            )}
-          />
-          <DebugMenuListItem
-            label='Simulate Exposure'
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.simulateExposure,
-            )}
-          />
-          <DebugMenuListItem
-            label='Show Debug Verification Code'
-            onPress={showDebugVerificationCode}
-          />
-          <DebugMenuListItem
-            label='Toggle Exposure Notifications'
-            onPress={handleOnPressToggleExposureNotifications}
-          />
-          <DebugMenuListItem
-            label='Reset Exposure Detection Error'
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.resetExposureDetectionError,
-            )}
-          />
-        </View>
-        <View style={styles.section}>
-          <DebugMenuListItem
-            label='Show Local Diagnosis Keys'
-            onPress={() => {
-              navigation.navigate(Screens.ENLocalDiagnosisKey);
-            }}
-          />
-          <DebugMenuListItem
-            label='Get and Post Diagnosis Keys'
-            style={styles.lastListItem}
-            onPress={handleOnPressSimulationButton(
-              BTNativeModule.getAndPostDiagnosisKeys,
-            )}
-          />
-        </View>
-      </ScrollView>
+      ) : (
+        <ScrollView>
+          <View style={styles.section}>
+            <DebugMenuListItem
+              label='Reset Exposures'
+              style={styles.lastListItem}
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.resetExposures,
+              )}
+            />
+          </View>
+          <View style={styles.section}>
+            <DebugMenuListItem
+              label='Detect Exposures Now'
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.detectExposuresNow,
+              )}
+            />
+            <DebugMenuListItem
+              label='Get Exposure Configuration'
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.getExposureConfiguration,
+              )}
+            />
+            <DebugMenuListItem
+              label='Simulate Exposure Detection Error'
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.simulateExposureDetectionError,
+              )}
+            />
+            <DebugMenuListItem
+              label='Simulate Exposure'
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.simulateExposure,
+              )}
+            />
+            <DebugMenuListItem
+              label='Show Debug Verification Code'
+              onPress={showDebugVerificationCode}
+            />
+            <DebugMenuListItem
+              label='Toggle Exposure Notifications'
+              onPress={handleOnPressToggleExposureNotifications}
+            />
+            <DebugMenuListItem
+              label='Reset Exposure Detection Error'
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.resetExposureDetectionError,
+              )}
+            />
+          </View>
+          <View style={styles.section}>
+            <DebugMenuListItem
+              label='Show Local Diagnosis Keys'
+              onPress={() => {
+                navigation.navigate(Screens.ENLocalDiagnosisKey);
+              }}
+            />
+            <DebugMenuListItem
+              label='Get and Post Diagnosis Keys'
+              style={styles.lastListItem}
+              onPress={handleOnPressSimulationButton(
+                BTNativeModule.getAndPostDiagnosisKeys,
+              )}
+            />
+          </View>
+        </ScrollView>
+      )}
     </NavigationBarWrapper>
   );
 };


### PR DESCRIPTION
### Why
We'd like to provide developers and testers with a visual indication that their intended action is being carried out on the native layer, so that they don't continue tapping the button and thus executing multiple actions unintentionally.

### This Commit
This commit displays an activity indicator when any button on the debug menu is pressed, and hides it when the relevant callback returns.

![Jun-18-2020 19-19-38](https://user-images.githubusercontent.com/2637355/85080986-afc09280-b198-11ea-9a39-86b9b4023899.gif)
