### PR TITLE
Introduce more info screen

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -32,7 +32,8 @@ import {
 } from './views/Export';
 import ExposureHistoryScreen from './views/ExposureHistory';
 import Assessment from './views/assessment';
-import NextSteps from './views/NextSteps';
+import NextSteps from './views/ExposureHistory/NextSteps';
+import MoreInfo from './views/ExposureHistory/MoreInfo';
 import ENDebugMenu from './views/Settings/ENDebugMenu';
 import { ENLocalDiagnosisKeyScreen } from './views/Settings/ENLocalDiagnosisKeyScreen';
 import { FeatureFlagsScreen } from './views/FeatureFlagToggles';
@@ -117,6 +118,7 @@ const ExposureHistoryStack = ({ navigation }) => {
         component={ExposureHistoryScreen}
       />
       <Stack.Screen name={Screens.NextSteps} component={NextSteps} />
+      <Stack.Screen name={Screens.MoreInfo} component={MoreInfo} />
     </Stack.Navigator>
   );
 };

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -104,7 +104,11 @@
   },
   "exposure_history": {
     "legend_button": "LEGEND",
-    "last_days": "Last 21 days"
+    "last_days": "Last 21 days",
+    "why_did_i_get_an_en": "Why did I get an exposure notification?",
+    "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later recieves a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others",
+    "how_does_this_work": "How does this work?",
+    "how_does_this_work_para": "When Exposure Notifications are on, your phone uses Bluetooth to swap and save random number strings (called ramdom IDs) from any phones it encounters that also have Exposure Notifications enabled. Random IDs won’t identify you personally to other users and change many times a day to protect your privacy. Date and duration of the encounter are recorded along with an estimate of how close the two phones may have been. When a person reports a positive diagnosis, their phone’s recent random IDs are flagged to anonymously notify others. No locations or personal info is shared."
   },
   "import": {
     "button_text": "Import past locations",

--- a/app/navigation/index.ts
+++ b/app/navigation/index.ts
@@ -26,6 +26,7 @@ export type Screen =
   | 'ExportComplete'
   | 'ExposureHistory'
   | 'NextSteps'
+  | 'MoreInfo'
   | 'ENDebugMenu'
   | 'ENLocalDiagnosisKey'
   | 'Settings'
@@ -57,6 +58,7 @@ export const Screens: { [key in Screen]: Screen } = {
   ExportComplete: 'ExportComplete',
   ExposureHistory: 'ExposureHistory',
   NextSteps: 'NextSteps',
+  MoreInfo: 'MoreInfo',
   ENDebugMenu: 'ENDebugMenu',
   ENLocalDiagnosisKey: 'ENLocalDiagnosisKey',
   Settings: 'Settings',

--- a/app/views/ExposureHistory/MoreInfo.tsx
+++ b/app/views/ExposureHistory/MoreInfo.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { View, ScrollView, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useTranslation } from 'react-i18next';
+
+import { Typography } from '../../components/Typography';
+import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
+import { useStatusBarEffect } from '../../navigation';
+
+import { Spacing, Typography as TypographyStyles } from '../../styles';
+
+const MoreInfo = (): JSX.Element => {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+  useStatusBarEffect('light-content');
+
+  const handleOnBackPress = () => {
+    navigation.goBack();
+  };
+
+  const headerTextOne = t('exposure_history.why_did_i_get_an_en');
+  const contentTextOne = t('exposure_history.why_did_i_get_an_en_para');
+
+  const headerTextTwo = t('exposure_history.how_does_this_work');
+  const contentTextTwo = t('exposure_history.how_does_this_work_para');
+
+  const title = 'More Info';
+
+  return (
+    <NavigationBarWrapper
+      includeBottomNav
+      title={title}
+      onBackPress={handleOnBackPress}>
+      <ScrollView
+        style={styles.container}
+        contentInset={{ top: 0, bottom: 140 }}>
+        <View style={styles.contentContainer}>
+          <Typography style={styles.headerText}>{headerTextOne}</Typography>
+          <Typography style={styles.contentText}>{contentTextOne}</Typography>
+        </View>
+        <View style={styles.contentContainer}>
+          <Typography style={styles.headerText}>{headerTextTwo}</Typography>
+          <Typography style={styles.contentText}>{contentTextTwo}</Typography>
+        </View>
+      </ScrollView>
+    </NavigationBarWrapper>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.medium,
+  },
+  headerText: {
+    ...TypographyStyles.header3,
+  },
+  contentContainer: {
+    paddingBottom: Spacing.xLarge,
+  },
+  contentText: {
+    ...TypographyStyles.mainContent,
+    paddingTop: Spacing.small,
+  },
+});
+
+export default MoreInfo;

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { TouchableOpacity, View, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
 import { Typography } from '../../components/Typography';
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
-import { NavigationProp, Screens, useStatusBarEffect } from '../../navigation';
+import { Screens, useStatusBarEffect } from '../../navigation';
 
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 
-interface NextStepsProps {
-  navigation: NavigationProp;
-}
-
-const NextSteps = ({ navigation }: NextStepsProps): JSX.Element => {
+const NextSteps = (): JSX.Element => {
+  const navigation = useNavigation();
   useStatusBarEffect('light-content');
 
   const handleOnBackPress = () => {

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -10,25 +10,21 @@ import {
 } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 import { useTranslation } from 'react-i18next';
+import { useNavigation } from '@react-navigation/native';
 
 import ExposureHistoryContext from '../../ExposureHistoryContext';
 import { ExposureDatum } from '../../exposureHistory';
 import { Typography } from '../../components/Typography';
 import ExposureDatumDetail from './ExposureDatumDetail';
 import Calendar from './Calendar';
-import { useStatusBarEffect, NavigationProp } from '../../navigation';
+import { Screens, useStatusBarEffect } from '../../navigation';
 
 import { Icons } from '../../assets';
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 
-interface ExposureHistoryScreenProps {
-  navigation: NavigationProp;
-}
-
-const ExposureHistoryScreen = ({
-  navigation,
-}: ExposureHistoryScreenProps): JSX.Element => {
+const ExposureHistoryScreen = (): JSX.Element => {
   const { t } = useTranslation();
+  const navigation = useNavigation();
   const { exposureHistory } = useContext(ExposureHistoryContext);
   const [
     selectedExposureDatum,
@@ -54,7 +50,9 @@ const ExposureHistoryScreen = ({
     setSelectedExposureDatum(datum);
   };
 
-  const handleOnPressMoreInfo = () => {};
+  const handleOnPressMoreInfo = () => {
+    navigation.navigate(Screens.MoreInfo);
+  };
 
   const titleText = t('screen_titles.exposure_history');
   const lastDaysText = t('exposure_history.last_days');


### PR DESCRIPTION
Why:
We would like to show the user a screen that provides more information
about the exposure history screen

This commit:
Introduces the more info screen and moves the NextSteps screen into the
exposure history feature folder.

![more-info](https://user-images.githubusercontent.com/16049495/85081548-46418380-b19a-11ea-8c16-cfa8600a6b52.gif)
