### PR TITLE
Show future days on calendar

### DIFF
--- a/app/ExposureHistoryContext.tsx
+++ b/app/ExposureHistoryContext.tsx
@@ -2,7 +2,12 @@ import React, { createContext, useState, useEffect } from 'react';
 
 import { isGPS } from './COVIDSafePathsConfig';
 import { BTNativeModule } from './bt';
-import { ExposureHistory, blankHistory } from './exposureHistory';
+import {
+  ExposureInfo,
+  ExposureHistory,
+  calendarDays,
+  toExposureHistory,
+} from './exposureHistory';
 
 interface ExposureHistoryState {
   exposureHistory: ExposureHistory;
@@ -28,18 +33,22 @@ interface ExposureHistoryProps {
   children: JSX.Element;
 }
 
+const blankHistory = toExposureHistory({}, calendarDays(Date.now(), 21));
+
 const ExposureHistoryProvider = ({
   children,
 }: ExposureHistoryProps): JSX.Element => {
   const [exposureHistory, setExposureHistory] = useState<ExposureHistory>(
-    blankHistory(),
+    blankHistory,
   );
   const [userHasNewExposure, setUserHasNewExposure] = useState<boolean>(true);
 
   useEffect(() => {
     if (!isGPS) {
       const subscription = BTNativeModule.subscribeToExposureEvents(
-        (exposureHistory: ExposureHistory) => {
+        (exposureInfo: ExposureInfo) => {
+          const days = calendarDays(Date.now(), 21);
+          const exposureHistory = toExposureHistory(exposureInfo, days);
           setExposureHistory(exposureHistory);
         },
       );

--- a/app/bt/exposureNotifications.spec.ts
+++ b/app/bt/exposureNotifications.spec.ts
@@ -1,33 +1,25 @@
 import dayjs from 'dayjs';
 
 import { DateTimeUtils } from '../helpers';
-import { Possible, ExposureDatum } from '../exposureHistory';
-import { toExposureHistory, RawExposure } from './exposureNotifications';
+import { Possible } from '../exposureHistory';
+import { toExposureInfo, RawExposure } from './exposureNotifications';
 
 describe('toExposureHistory', () => {
   describe('when there are no exposure notifications', () => {
-    it('returns a history of NoKnown Exposures for the past 21 days', () => {
+    it('returns an empty ExposureInfo', () => {
       const rawExposures: RawExposure[] = [];
-      const today = Date.now();
-      const twentyDaysAgo = dayjs(today).subtract(20, 'day').valueOf();
 
-      const result = toExposureHistory(rawExposures);
+      const result = toExposureInfo(rawExposures);
 
-      const lastDay = result[result.length - 1].date;
-      const firstDay = result[0].date;
-      expect(result.length).toBe(21);
-      expect(
-        result.every((datum: ExposureDatum) => datum.kind === 'NoKnown'),
-      ).toBe(true);
-      expect(dayjs(lastDay).isSame(today, 'day')).toBe(true);
-      expect(dayjs(firstDay).isSame(twentyDaysAgo, 'day')).toBe(true);
+      expect(result).toEqual({});
     });
   });
 
   describe('when there was a possible exposure two days ago', () => {
-    it('returns a history with a PossibleExposure 2 days ago', () => {
+    it('returns an ExposureInfo with a PossibleExposure at the correct date', () => {
       const today = Date.now();
       const twoDaysAgo = dayjs(today).subtract(2, 'day').valueOf();
+      const beginningOfTwoDaysAgo = DateTimeUtils.beginningOfDay(twoDaysAgo);
       const duration = 30 * 60 * 1000;
       const rawExposures: RawExposure[] = [
         {
@@ -46,9 +38,10 @@ describe('toExposureHistory', () => {
         transmissionRiskLevel: 3,
       };
 
-      const result = toExposureHistory(rawExposures);
+      const result = toExposureInfo(rawExposures);
 
-      expect(result[result.length - 3]).toEqual(expected);
+      expect(Object.keys(result).length).toEqual(1);
+      expect(result[beginningOfTwoDaysAgo]).toEqual(expected);
     });
   });
 
@@ -90,9 +83,9 @@ describe('toExposureHistory', () => {
         transmissionRiskLevel: 5,
       };
 
-      const result = toExposureHistory(rawExposures);
+      const result = toExposureInfo(rawExposures);
 
-      expect(result[result.length - 1]).toEqual(expected);
+      expect(result[beginningOfDay]).toEqual(expected);
     });
   });
 });

--- a/app/bt/exposureNotifications.ts
+++ b/app/bt/exposureNotifications.ts
@@ -1,11 +1,6 @@
 import dayjs from 'dayjs';
 
-import {
-  Possible,
-  NoKnown,
-  ExposureHistory,
-  blankHistory,
-} from '../exposureHistory';
+import { Possible, ExposureInfo } from '../exposureHistory';
 
 type UUID = string;
 type Posix = number;
@@ -18,22 +13,9 @@ export interface RawExposure {
   transmissionRiskLevel: number;
 }
 
-export const toExposureHistory = (
-  rawExposures: RawExposure[],
-): ExposureHistory => {
+export const toExposureInfo = (rawExposures: RawExposure[]): ExposureInfo => {
   const possibleExposures = rawExposures.map(toPossible);
-  const byDate = groupedByDate(possibleExposures, combinePossibles);
-
-  const base = blankHistory();
-
-  return base.map((datum: NoKnown) => {
-    const date = datum.date;
-    if (byDate[date]) {
-      return byDate[date];
-    } else {
-      return datum;
-    }
-  });
+  return groupedByDate(possibleExposures, combinePossibles);
 };
 
 const toPossible = (r: RawExposure): Possible => {

--- a/app/bt/nativeModule.ts
+++ b/app/bt/nativeModule.ts
@@ -5,12 +5,12 @@ import {
 } from 'react-native';
 
 import { DeviceStatus } from '../ExposureNotificationContext';
-import { ExposureHistory } from '../exposureHistory';
+import { ExposureInfo } from '../exposureHistory';
 import { ENDiagnosisKey } from '../views/Settings/ENLocalDiagnosisKeyScreen';
-import { RawExposure, toExposureHistory } from './exposureNotifications';
+import { RawExposure, toExposureInfo } from './exposureNotifications';
 
 export const subscribeToExposureEvents = (
-  cb: (exposureHistory: ExposureHistory) => void,
+  cb: (exposureInfo: ExposureInfo) => void,
 ): EventSubscription => {
   const ExposureEvents = new NativeEventEmitter(
     NativeModules.ExposureEventEmitter,
@@ -19,7 +19,7 @@ export const subscribeToExposureEvents = (
     'onExposureRecordUpdated',
     (rawExposure: string) => {
       const rawExposures: RawExposure[] = JSON.parse(rawExposure);
-      cb(toExposureHistory(rawExposures));
+      cb(toExposureInfo(rawExposures));
     },
   );
 };

--- a/app/exposureHistory.spec.ts
+++ b/app/exposureHistory.spec.ts
@@ -1,0 +1,104 @@
+import dayjs from 'dayjs';
+
+import { DateTimeUtils } from './helpers';
+import {
+  calendarDays,
+  toExposureHistory,
+  ExposureDatum,
+  ExposureInfo,
+} from './exposureHistory';
+
+describe('toExposureHistory', () => {
+  describe('when given a 21 day calendar', () => {
+    describe('when given an ExposureInfo with no exposures', () => {
+      it('it returns a 21 day history of NoKnown Exposures', () => {
+        const today = dayjs('2020-06-26').valueOf();
+        const calendar = calendarDays(today, 21);
+        const exposureInfo: ExposureInfo = {};
+
+        const result = toExposureHistory(exposureInfo, calendar);
+
+        expect(result.length).toBe(21);
+        expect(
+          result.every((datum: ExposureDatum) => datum.kind === 'NoKnown'),
+        ).toBe(true);
+      });
+    });
+
+    describe('when given an ExposureInfo with a possible exposure today', () => {
+      it('returns an exposure history with the exposures on the correct days', () => {
+        const tuesday = dayjs('2020-06-23').valueOf();
+        const friday = dayjs('2020-06-26').valueOf();
+
+        const today = friday;
+        const calendar = calendarDays(today, 21);
+
+        const tuesdayExposure: ExposureDatum = {
+          kind: 'Possible',
+          date: tuesday,
+          duration: 600000,
+          totalRiskScore: 3,
+          transmissionRiskLevel: 3,
+        };
+        const fridayExposure: ExposureDatum = {
+          kind: 'Possible',
+          date: friday,
+          duration: 300000,
+          totalRiskScore: 4,
+          transmissionRiskLevel: 7,
+        };
+
+        const exposureInfo: ExposureInfo = {
+          [tuesday]: tuesdayExposure,
+          [friday]: fridayExposure,
+        };
+
+        const result = toExposureHistory(exposureInfo, calendar);
+
+        const tuesdayResult = result[result.length - 5];
+        const wednesdayResult = result[result.length - 4];
+        const fridayResult = result[result.length - 2];
+        const saturdayResult = result[result.length - 1];
+
+        expect(tuesdayResult).toEqual(tuesdayExposure);
+        expect(wednesdayResult.kind).toBe('NoKnown');
+        expect(fridayResult).toEqual(fridayExposure);
+        expect(saturdayResult.kind).toBe('NoKnown');
+      });
+    });
+  });
+});
+
+describe('calendarDays', () => {
+  describe('when today is monday and 21 days are requested', () => {
+    it('returns a list of 21 consecutive days, ending at the next saturday', () => {
+      const monday = dayjs('2020-06-22').valueOf();
+
+      const result = calendarDays(monday, 21);
+
+      const lastDay = result[result.length - 1];
+      const firstDay = result[0];
+      expect(result.length).toBe(21);
+      expect(posixToString(lastDay)).toBe('2020-06-27');
+      expect(posixToString(firstDay)).toBe('2020-06-07');
+    });
+  });
+
+  describe('when today is saturday and 21 days are requested', () => {
+    it('returns a list of 21 consecutive days, ending on today', () => {
+      const saturday = dayjs('2020-06-27').valueOf();
+
+      const result = calendarDays(saturday, 21);
+
+      const lastDay = result[result.length - 1];
+      const firstDay = result[0];
+      expect(result.length).toBe(21);
+      expect(posixToString(lastDay)).toBe('2020-06-27');
+      expect(posixToString(firstDay)).toBe('2020-06-07');
+    });
+  });
+});
+
+const posixToString = (date: DateTimeUtils.Posix): string => {
+  return dayjs(date).format('YYYY-MM-DD');
+};

--- a/app/exposureHistory.ts
+++ b/app/exposureHistory.ts
@@ -17,23 +17,43 @@ export interface NoKnown {
 
 export type ExposureDatum = Possible | NoKnown;
 
+export type ExposureInfo = Record<Posix, ExposureDatum>;
+
 export type ExposureHistory = ExposureDatum[];
 
-const HISTORY_LENGTH = 21;
-
-export const blankHistory = (): NoKnown[] => {
-  const now = Date.now();
-  const daysAgo = [...Array(HISTORY_LENGTH)].map((_v, idx: number) => {
-    return HISTORY_LENGTH - 1 - idx;
-  });
-
-  return daysAgo.map(
-    (daysAgo: number): NoKnown => {
-      const date = dayjs(now).subtract(daysAgo, 'day').startOf('day').valueOf();
+export const toExposureHistory: (
+  exposureInfo: ExposureInfo,
+  calendary: Posix[],
+) => ExposureHistory = (exposureInfo, calendar) => {
+  return calendar.map((date: Posix) => {
+    if (exposureInfo[date]) {
+      return exposureInfo[date];
+    } else {
       return {
         kind: 'NoKnown',
         date,
       };
+    }
+  });
+};
+
+export const calendarDays = (today: Posix, totalDays: number): Posix[] => {
+  const saturday = nextSaturday(today);
+
+  const daysAgo = [...Array(totalDays)].map((_v, idx: number) => {
+    return totalDays - 1 - idx;
+  });
+
+  return daysAgo.map(
+    (daysAgo: number): Posix => {
+      return dayjs(saturday).subtract(daysAgo, 'day').startOf('day').valueOf();
     },
   );
+};
+
+const nextSaturday = (date: Posix): Posix => {
+  const saturdayDayOfWeek = 6;
+  const dayOfWeek = dayjs(date).day();
+  const daysUntilNextSaturday = saturdayDayOfWeek - dayOfWeek;
+  return dayjs(date).add(daysUntilNextSaturday, 'day').valueOf();
 };

--- a/app/helpers/dateTimeUtils.spec.ts
+++ b/app/helpers/dateTimeUtils.spec.ts
@@ -1,0 +1,33 @@
+import { isToday } from './dateTimeUtils';
+
+describe('isToday', () => {
+  describe('when provided a posix that is today', () => {
+    it('returns true', () => {
+      const date = Date.now() + 1000;
+
+      const result = isToday(date);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when provided a posix from a few days ago', () => {
+    it('returns false', () => {
+      const date = Date.now() - 24 * 60 * 60 * 1000;
+
+      const result = isToday(date);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when provided a posix from a few days from now', () => {
+    it('returns false', () => {
+      const date = Date.now() + 24 * 60 * 60 * 1000;
+
+      const result = isToday(date);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/helpers/dateTimeUtils.ts
+++ b/app/helpers/dateTimeUtils.ts
@@ -12,3 +12,7 @@ export const isToday = (date: Posix): boolean => {
 export const beginningOfDay = (date: Posix): Posix => {
   return dayjs(date).startOf('day').valueOf();
 };
+
+export const isInFuture = (date: Posix): boolean => {
+  return date > Date.now();
+};

--- a/app/helpers/dateTimeUtils.ts
+++ b/app/helpers/dateTimeUtils.ts
@@ -1,10 +1,12 @@
 import dayjs from 'dayjs';
 
-type Posix = number;
+export type Posix = number;
 
 export const isToday = (date: Posix): boolean => {
-  const endOfDay = dayjs(Date.now()).endOf('day').valueOf();
-  return beginningOfDay(date) <= date && endOfDay >= date;
+  const now = Date.now();
+  const beginningOfToday = beginningOfDay(now);
+  const endOfToday = dayjs(now).endOf('day').valueOf();
+  return beginningOfToday <= date && endOfToday >= date;
 };
 
 export const beginningOfDay = (date: Posix): Posix => {

--- a/app/styles/affordances.ts
+++ b/app/styles/affordances.ts
@@ -1,3 +1,5 @@
+import { ViewStyle } from 'react-native';
+
 import * as Colors from './colors';
 
 export const iconBadge = {
@@ -10,4 +12,17 @@ export const iconBadge = {
   height: 12,
   justifyContent: 'center',
   alignItems: 'center',
+};
+
+export const bottomDotBadge = (color: string): ViewStyle => {
+  return {
+    position: 'absolute',
+    bottom: -4,
+    backgroundColor: color,
+    borderRadius: 6,
+    width: 6,
+    height: 6,
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
 };

--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 
 import { DateTimeUtils } from '../../helpers';
 import { ExposureDatum } from '../../exposureHistory';
-import { Outlines, Colors, Typography } from '../../styles';
+import { Affordances, Outlines, Colors, Typography } from '../../styles';
 
 interface ExposureDatumIndicatorProps {
   exposureDatum: ExposureDatum;
@@ -17,6 +17,17 @@ const ExposureDatumIndicator = ({
   exposureDatum,
   isSelected,
 }: ExposureDatumIndicatorProps): JSX.Element => {
+  const isToday = DateTimeUtils.isToday(exposureDatum.date);
+
+  const applyBadge = (indicator: JSX.Element) => {
+    return (
+      <>
+        {indicator}
+        <View style={styles.selectedBadge} />
+      </>
+    );
+  };
+
   const applyRiskStyle = ([
     circleStyle,
     textStyle,
@@ -45,9 +56,11 @@ const ExposureDatumIndicator = ({
     circleStyle,
     textStyle,
   ]: IndicatorStyle): IndicatorStyle => {
-    if (DateTimeUtils.isToday(exposureDatum.date)) {
+    if (isToday) {
       return [
-        circleStyle,
+        {
+          ...circleStyle,
+        },
 
         {
           ...textStyle,
@@ -85,9 +98,11 @@ const ExposureDatumIndicator = ({
 
   const dayNumber = dayjs(exposureDatum.date).format('D');
 
+  const indicator = <Text style={textStyle}>{dayNumber}</Text>;
+
   return (
     <View style={circleStyle}>
-      <Text style={textStyle}>{dayNumber}</Text>
+      {isToday ? applyBadge(indicator) : indicator}
     </View>
   );
 };
@@ -104,7 +119,11 @@ const styles = StyleSheet.create({
     borderWidth: Outlines.thick,
   },
   textBase: {
-    ...Typography.label,
+    ...Typography.smallFont,
+    color: Colors.primaryText,
+  },
+  selectedBadge: {
+    ...Affordances.bottomDotBadge(Colors.primaryText),
   },
 });
 

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -15,6 +15,7 @@ import ExposureHistoryContext from '../../ExposureHistoryContext';
 import { ExposureDatum } from '../../exposureHistory';
 import { Typography } from '../../components/Typography';
 import ExposureDatumDetail from './ExposureDatumDetail';
+import { DateTimeUtils } from '../../helpers';
 import Calendar from './Calendar';
 import { useStatusBarEffect, NavigationProp } from '../../navigation';
 
@@ -30,10 +31,9 @@ const ExposureHistoryScreen = ({
 }: ExposureHistoryScreenProps): JSX.Element => {
   const { t } = useTranslation();
   const { exposureHistory } = useContext(ExposureHistoryContext);
-  const [
-    selectedExposureDatum,
-    setSelectedExposureDatum,
-  ] = useState<ExposureDatum | null>(null);
+  const [selectedDatum, setSelectedDatum] = useState<ExposureDatum | null>(
+    null,
+  );
 
   useStatusBarEffect('dark-content');
 
@@ -51,7 +51,7 @@ const ExposureHistoryScreen = ({
   }, [navigation]);
 
   const handleOnSelectDate = (datum: ExposureDatum) => {
-    setSelectedExposureDatum(datum);
+    setSelectedDatum(datum);
   };
 
   const handleOnPressMoreInfo = () => {};
@@ -59,6 +59,9 @@ const ExposureHistoryScreen = ({
   const titleText = t('screen_titles.exposure_history');
   const lastDaysText = t('exposure_history.last_days');
   const lastUpdatedText = 'Updated 6 hours ago';
+
+  const showExposureDetail =
+    selectedDatum && !DateTimeUtils.isInFuture(selectedDatum.date);
 
   return (
     <SafeAreaView>
@@ -84,12 +87,12 @@ const ExposureHistoryScreen = ({
           <Calendar
             exposureHistory={exposureHistory}
             onSelectDate={handleOnSelectDate}
-            selectedDatum={selectedExposureDatum}
+            selectedDatum={selectedDatum}
           />
         </View>
         <View style={styles.detailsContainer}>
-          {selectedExposureDatum ? (
-            <ExposureDatumDetail exposureDatum={selectedExposureDatum} />
+          {selectedDatum && showExposureDetail ? (
+            <ExposureDatumDetail exposureDatum={selectedDatum} />
           ) : null}
         </View>
       </ScrollView>


### PR DESCRIPTION
Why:
Currently we would like to show days in the future on the calendar such
that the day labels line up with the correct day number.

This commit:
Introduces the logic to build the correct days in the ExposureHistory
list, that is, we determine when the next saturday is and pad out the
history such that the last day in the history is the up coming
staturday.

We separated out the concept of building an ExposureHistory as a list,
and building out the ExpousreHistory as a Map of days to exposures,
which we are calling an ExposureInfo. This will allow us flexibility in
presenting the exposure history in any calendar format a bit more easily
moving forward, for example other communities may not use the gregorian
calendar or we may discover that users would benefit from not seeing
this info in a calendar view at all.

This has a consequence to any tracing strategy that wants to be consumed
by the calendar view ui, as it is expected to now provide an
ExposureInfo rather than an ExposureHistory.

### Before

<img width="584" alt="Screen Shot 2020-06-19 at 6 46 59 AM" src="https://user-images.githubusercontent.com/16049495/85124981-cf87a300-b1f8-11ea-8ff1-7865c2a28e44.png">

### After

<img width="584" alt="Screen Shot 2020-06-19 at 6 45 08 AM" src="https://user-images.githubusercontent.com/16049495/85124960-c7c7fe80-b1f8-11ea-83c3-889846849b8d.png">
