### PR TITLE
Migrate Realm, remove unused notification extension.

### DIFF
--- a/ios/BT/Extensions/Notification+Extensions.swift
+++ b/ios/BT/Extensions/Notification+Extensions.swift
@@ -4,5 +4,4 @@ extension Notification.Name {
   public static let DateLastPerformedExposureDetectionDidChange = Notification.Name(rawValue: "BTSecureStorageDateLastPerformedExposureDetectionDidChange")
   public static let ExposuresDidChange = Notification.Name(rawValue: "onExposureRecordUpdated")
   public static let AuthorizationStatusDidChange = Notification.Name(rawValue: "onEnabledStatusUpdated")
-  public static let NextDiagnosisKeyFileIndexDidChange = Notification.Name(rawValue: "BTSecureStorageNextDiagnosisKeyFileIndexDidChange")
 }

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -20,10 +20,10 @@ final class BTSecureStorage: SafePathsSecureStorage {
   override func getRealmConfig() -> Realm.Configuration? {
     if let key = getEncyrptionKey() {
       if (inMemory) {
-        return Realm.Configuration(inMemoryIdentifier: "temp", encryptionKey: key as Data, schemaVersion: 1,
+        return Realm.Configuration(inMemoryIdentifier: "temp", encryptionKey: key as Data, schemaVersion: 2,
                                    migrationBlock: { _, _ in }, objectTypes: [UserState.self, Exposure.self])
       } else {
-        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 1,
+        return Realm.Configuration(encryptionKey: key as Data, schemaVersion: 2,
                                    migrationBlock: { _, _ in }, objectTypes: [UserState.self, Exposure.self])
       }
     } else {


### PR DESCRIPTION
### Why
We'd like the app not to crash due to a mismatched `Realm` schema

### This Commit
This commit migrates realm on iOS and also removes the `NextDiagnosisKeyFileIndexDidChange` extension on `Notification.Name`, which is no longer used