### PR TITLE
Remove unfinished calendar features for gps demo

### DIFF
--- a/app/views/ExposureHistory/Calendar.tsx
+++ b/app/views/ExposureHistory/Calendar.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
-import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 
 import { ExposureHistory, ExposureDatum } from '../../exposureHistory';
 import { Typography } from '../../components/Typography';
 import ExposureDatumIndicator from './ExposureDatumIndicator';
 
-import {
-  Colors,
-  Buttons,
-  Spacing,
-  Typography as TypographyStyles,
-} from '../../styles';
+import { Colors, Spacing, Typography as TypographyStyles } from '../../styles';
 
 interface CalendarProps {
   exposureHistory: ExposureHistory;
@@ -25,7 +19,6 @@ const Calendar = ({
   onSelectDate,
   selectedDatum,
 }: CalendarProps): JSX.Element => {
-  const { t } = useTranslation();
   const lastMonth = dayjs().subtract(1, 'month');
   const title = `${lastMonth.format('MMMM')} | ${dayjs().format(
     'MMMM',
@@ -75,20 +68,10 @@ const Calendar = ({
     );
   };
 
-  const handleOnPressLegend = () => {};
-  const legendButtonText = t('exposure_history.legend_button');
-
   return (
     <View style={styles.container}>
       <View style={styles.header}>
         <Typography style={styles.monthText}>{title}</Typography>
-        <TouchableOpacity
-          onPress={handleOnPressLegend}
-          style={styles.legendButton}>
-          <Typography style={styles.legendButtonText}>
-            {legendButtonText}
-          </Typography>
-        </TouchableOpacity>
       </View>
       <View style={styles.calendarContainer}>
         <DayLabels />
@@ -111,13 +94,6 @@ const styles = StyleSheet.create({
   monthText: {
     ...TypographyStyles.label,
     color: Colors.secondaryHeaderText,
-  },
-  legendButton: {
-    ...Buttons.tinyTeritiaryRounded,
-    borderWidth: 1,
-  },
-  legendButtonText: {
-    ...TypographyStyles.buttonTextTinyDark,
   },
   calendarContainer: { flex: 1, paddingVertical: Spacing.small },
   calendarRow: {

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react';
 import {
-  Text,
   StyleSheet,
   TouchableOpacity,
   View,
@@ -19,6 +18,7 @@ import ExposureDatumDetail from './ExposureDatumDetail';
 import { DateTimeUtils } from '../../helpers';
 import Calendar from './Calendar';
 import { Screens, useStatusBarEffect } from '../../navigation';
+import { isGPS } from '../../COVIDSafePathsConfig';
 
 import { Icons } from '../../assets';
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
@@ -56,30 +56,33 @@ const ExposureHistoryScreen = (): JSX.Element => {
 
   const titleText = t('screen_titles.exposure_history');
   const lastDaysText = t('exposure_history.last_days');
-  const lastUpdatedText = 'Updated 6 hours ago';
 
   const showExposureDetail =
     selectedDatum && !DateTimeUtils.isInFuture(selectedDatum.date);
 
   return (
     <SafeAreaView>
-      <ScrollView style={styles.container}>
+      <ScrollView
+        style={styles.container}
+        contentInset={{ top: 0, bottom: 140 }}>
         <View style={styles.header}>
           <View style={styles.headerRow}>
             <Typography style={styles.headerText}>{titleText}</Typography>
-            <TouchableOpacity
-              onPress={handleOnPressMoreInfo}
-              style={styles.moreInfoButton}>
-              <SvgXml xml={Icons.IconQuestionMark} />
-            </TouchableOpacity>
+            {!isGPS ? (
+              <TouchableOpacity
+                onPress={handleOnPressMoreInfo}
+                style={styles.moreInfoButton}>
+                <SvgXml xml={Icons.IconQuestionMark} />
+              </TouchableOpacity>
+            ) : null}
           </View>
-          <View style={styles.headerRow}>
-            <Typography style={styles.subHeaderText}>{lastDaysText}</Typography>
-            <Text style={styles.subHeaderText}>{' \u2022 '}</Text>
-            <Typography style={styles.subHeaderText}>
-              {lastUpdatedText}
-            </Typography>
-          </View>
+          {!isGPS ? (
+            <View style={styles.headerRow}>
+              <Typography style={styles.subHeaderText}>
+                {lastDaysText}
+              </Typography>
+            </View>
+          ) : null}
         </View>
         <View style={styles.calendarContainer}>
           <Calendar


### PR DESCRIPTION
Why:
Currently there are a handful of unfinished features in the exposure
history screen. We would like to be able to ship a demo build today so
we would like to remove those features and add them back at a later
date.

Co-Authored-By: jacobjaffe <jacobmaxjaffe@gmail.com>
Co-Authored-By: jennifer schnidman