### PR TITLE
Clean up next steps screen

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -52,7 +52,7 @@ import isOnboardingCompleteSelector from './store/selectors/isOnboardingComplete
 import { isGPS } from './COVIDSafePathsConfig';
 import * as Icons from './assets/svgs/TabBarNav';
 
-import { Affordances, Spacing, Colors, Layout } from './styles';
+import { Layout, Affordances, Spacing, Colors } from './styles';
 
 const Tab = createBottomTabNavigator();
 const Stack = createStackNavigator();
@@ -178,9 +178,9 @@ const MainAppTabs = () => {
         inactiveTintColor: Colors.primaryViolet,
         style: {
           backgroundColor: Colors.navBar,
+          borderTopColor: Colors.navBar,
           paddingTop: Spacing.xSmall,
           height: Layout.navBar,
-          borderTopColor: Colors.navBar,
         },
       }}>
       <Tab.Screen

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -40,8 +40,6 @@ const NextSteps = (): JSX.Element => {
       <View style={styles.container}>
         <View style={styles.headerContainer}>
           <Typography style={styles.headerText}>{headerText}</Typography>
-        </View>
-        <View style={styles.contentContainer}>
           <Typography style={styles.contentText}>{contentTextOne}</Typography>
           <Typography style={styles.contentText}>{contentTextTwo}</Typography>
         </View>
@@ -60,17 +58,13 @@ const NextSteps = (): JSX.Element => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'space-between',
     padding: Spacing.medium,
   },
   headerContainer: {
     flex: 1,
   },
   headerText: {
-    ...TypographyStyles.header1,
-  },
-  contentContainer: {
-    flex: 2,
+    ...TypographyStyles.header2,
   },
   contentText: {
     ...TypographyStyles.mainContent,


### PR DESCRIPTION
This commit is a minor clean up of some visual issues on the
'Next Steps' screen.

### Before
 
<img width="584" alt="Screen Shot 2020-06-19 at 12 55 09 PM" src="https://user-images.githubusercontent.com/16049495/85160605-90734500-b22c-11ea-84e7-243e65389168.png">

### After

<img width="584" alt="Screen Shot 2020-06-19 at 12 51 07 PM" src="https://user-images.githubusercontent.com/16049495/85160638-949f6280-b22c-11ea-8755-669c84285761.png">

