### PR TITLE
Release Screens Cleanup

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -110,8 +110,6 @@ const ExposureHistoryStack = ({ navigation }) => {
       mode='modal'
       screenOptions={{
         ...SCREEN_OPTIONS,
-        cardStyleInterpolator: fade,
-        gestureEnabled: false,
       }}>
       <Stack.Screen
         name={Screens.ExposureHistory}

--- a/app/TracingStrategyAssets.ts
+++ b/app/TracingStrategyAssets.ts
@@ -124,6 +124,10 @@ export function useAssets(): Record<string, Asset> {
   const allServicesOnScreenSubheader = isGPS
     ? t('home.gps.all_services_on_subheader')
     : t('home.bluetooth.all_services_on_subheader');
+  // This is just for release without HAs enabled. GPS only.
+  const allServicesOnNoHaAvailableSubHeader = isGPS
+    ? t('home.gps.all_services_on_no_ha_available')
+    : '';
 
   // Export Intro/Start
   const exportStartTitle = isGPS
@@ -186,6 +190,7 @@ export function useAssets(): Record<string, Asset> {
     tracingOffScreenButton,
     allServicesOnScreenHeader,
     allServicesOnScreenSubheader,
+    allServicesOnNoHaAvailableSubHeader,
     exposureNotificationsNotAvailableHeader,
     exposureNotificationsNotAvailableSubheader,
     notificationsOffScreenHeader,

--- a/app/components/NavigationBarWrapper.tsx
+++ b/app/components/NavigationBarWrapper.tsx
@@ -12,7 +12,6 @@ interface NavigationBarWrapperProps {
   children: React.ReactNode;
   title: string;
   onBackPress?: () => void;
-  includeBottomNav?: boolean;
   includeBackButton?: boolean;
 }
 

--- a/app/components/NavigationBarWrapper.tsx
+++ b/app/components/NavigationBarWrapper.tsx
@@ -12,7 +12,6 @@ interface NavigationBarWrapperProps {
   children: React.ReactNode;
   title: string;
   onBackPress?: () => void;
-  includeBottomNav?: boolean;
   includeBackButton?: boolean;
 }
 
@@ -43,19 +42,19 @@ export const NavigationBarWrapper = ({
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.headerContainer}>
-        <View style={styles.leftContent}>
-          {includeBackButton ? (
+      {includeBackButton ? (
+        <View style={styles.headerContainer}>
+          <View style={styles.leftContent}>
             <TouchableOpacity onPress={handleOnPressBack}>
               <SvgXml xml={Icons.BackArrow} color={Colors.white} />
             </TouchableOpacity>
-          ) : null}
+          </View>
+          <View style={styles.middleContent}>
+            <Typography style={styles.headerText}>{title}</Typography>
+          </View>
+          <View style={styles.rightContent} />
         </View>
-        <View style={styles.middleContent}>
-          <Typography style={styles.headerText}>{title}</Typography>
-        </View>
-        <View style={styles.rightContent} />
-      </View>
+      ) : null}
       <View style={styles.contentContainer}>{children}</View>
     </SafeAreaView>
   );

--- a/app/components/NavigationBarWrapper.tsx
+++ b/app/components/NavigationBarWrapper.tsx
@@ -12,6 +12,7 @@ interface NavigationBarWrapperProps {
   children: React.ReactNode;
   title: string;
   onBackPress?: () => void;
+  includeBottomNav?: boolean;
   includeBackButton?: boolean;
 }
 
@@ -42,19 +43,19 @@ export const NavigationBarWrapper = ({
 
   return (
     <SafeAreaView style={styles.container}>
-      {includeBackButton ? (
-        <View style={styles.headerContainer}>
-          <View style={styles.leftContent}>
+      <View style={styles.headerContainer}>
+        <View style={styles.leftContent}>
+          {includeBackButton ? (
             <TouchableOpacity onPress={handleOnPressBack}>
               <SvgXml xml={Icons.BackArrow} color={Colors.white} />
             </TouchableOpacity>
-          </View>
-          <View style={styles.middleContent}>
-            <Typography style={styles.headerText}>{title}</Typography>
-          </View>
-          <View style={styles.rightContent} />
+          ) : null}
         </View>
-      ) : null}
+        <View style={styles.middleContent}>
+          <Typography style={styles.headerText}>{title}</Typography>
+        </View>
+        <View style={styles.rightContent} />
+      </View>
       <View style={styles.contentContainer}>{children}</View>
     </SafeAreaView>
   );

--- a/app/components/Typography.tsx
+++ b/app/components/Typography.tsx
@@ -12,6 +12,7 @@ interface TypographyProps {
   style?: TextStyle;
   testID?: string;
   children: JSX.Element | string;
+  onPress?: () => void;
 }
 
 export const Typography = ({
@@ -19,6 +20,7 @@ export const Typography = ({
   style,
   testID,
   children,
+  onPress,
 }: TypographyProps): JSX.Element => {
   const writingDirection = useLanguageDirection();
 
@@ -45,7 +47,10 @@ export const Typography = ({
   const textStyle = useToStyle();
 
   return (
-    <Text style={[textStyle, { writingDirection }, style]} testID={testID}>
+    <Text
+      onPress={onPress}
+      style={[textStyle, { writingDirection }, style]}
+      testID={testID}>
       {children}
     </Text>
   );

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -105,10 +105,18 @@
   "exposure_history": {
     "legend_button": "LEGEND",
     "last_days": "Last 21 days",
-    "why_did_i_get_an_en": "Why did I get an exposure notification?",
-    "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later recieves a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others",
-    "how_does_this_work": "How does this work?",
-    "how_does_this_work_para": "When Exposure Notifications are on, your phone uses Bluetooth to swap and save random number strings (called ramdom IDs) from any phones it encounters that also have Exposure Notifications enabled. Random IDs won’t identify you personally to other users and change many times a day to protect your privacy. Date and duration of the encounter are recorded along with an estimate of how close the two phones may have been. When a person reports a positive diagnosis, their phone’s recent random IDs are flagged to anonymously notify others. No locations or personal info is shared."
+    "more_info_bt": {
+      "why_did_i_get_an_en": "Why did I get an exposure notification?",
+      "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later recieves a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others",
+      "how_does_this_work": "How does this work?",
+      "how_does_this_work_para": "When Exposure Notifications are on, your phone uses Bluetooth to swap and save random number strings (called ramdom IDs) from any phones it encounters that also have Exposure Notifications enabled. Random IDs won’t identify you personally to other users and change many times a day to protect your privacy. Date and duration of the encounter are recorded along with an estimate of how close the two phones may have been. When a person reports a positive diagnosis, their phone’s recent random IDs are flagged to anonymously notify others. No locations or personal info is shared."
+    },
+    "more_info_gps": {
+      "why_did_i_get_an_en": "Why did I get an exposure notification?",
+      "why_did_i_get_an_en_para": "You will receive exposure notifications whenever your PathCheck app estimates that your phone was within 100 feet of another member of your community who later received a positive diagnosis and chose to share their location diary with their local Health Department.",
+      "how_does_this_work": "How does this work?",
+      "how_does_this_work_para": "Your PathCheck app saves the places you’ve taken your phone for the past 14 days into an encrypted list, whenever location access is turned on. This list is comprised of just GPS coordinates, dates, and times, and is only stored on your phone. Your local and regional Health Departments on PathCheck can send your app encrypted collections of anonymized GPS coordinates, dates, and times gathered from their community members who later received positive diagnoses and chose to share. Your phone then compares your location history to that sent by your local Health Department to determine if you should receive an exposure notification."
+    }
   },
   "import": {
     "button_text": "Import past locations",
@@ -135,7 +143,8 @@
       "tracing_off_subheader": "PathCheck needs location access in Settings to privately save the places you visit",
       "tracing_off_button": "Allow Location Access",
       "all_services_on_header": "PathCheck",
-      "all_services_on_subheader": "PathCheck is privately saving the places you visit and comparing your locations to data from your local Health Department",
+      "all_services_on_subheader": "PathCheck is saving the places you visit to create your private location diary",
+      "all_services_on_no_ha_available": "Your phone is currently outside any areas covered by Health Departments",
       "auto_start_header": "Auto Start Disabled",
       "auto_start_subheader": "PathCheck needs to be able to auto start to privately save the places you visit. Please enable it in your app settings"
     },

--- a/app/views/About.js
+++ b/app/views/About.js
@@ -122,7 +122,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     flexDirection: 'column',
     backgroundColor: Colors.primaryBackground,
-    paddingHorizontal: 24,
+    paddingHorizontal: Spacing.medium,
   },
   hyperlink: {
     color: Colors.linkText,

--- a/app/views/About.js
+++ b/app/views/About.js
@@ -16,7 +16,7 @@ import fontFamily from './../constants/fonts';
 import { NavigationBarWrapper, Typography } from '../components';
 import { useAssets } from '../TracingStrategyAssets';
 
-import { Colors } from '../styles';
+import { Colors, Spacing } from '../styles';
 
 export const AboutScreen = ({ navigation }) => {
   const { t } = useTranslation();

--- a/app/views/About.js
+++ b/app/views/About.js
@@ -10,11 +10,9 @@ import {
   View,
   Text,
 } from 'react-native';
-import { SvgXml } from 'react-native-svg';
 
 import packageJson from '../../package.json';
 import fontFamily from './../constants/fonts';
-import { Icons } from '../assets';
 import { NavigationBarWrapper, Typography } from '../components';
 import { useAssets } from '../TracingStrategyAssets';
 
@@ -44,17 +42,15 @@ export const AboutScreen = ({ navigation }) => {
     <NavigationBarWrapper
       title={t('screen_titles.about')}
       onBackPress={backToMain}>
-      <ScrollView contentContainerStyle={styles.contentContainer}>
+      <ScrollView
+        contentContainerStyle={styles.contentContainer}
+        alwaysBounceVertical={false}>
         <View style={styles.spacer} />
         <View style={styles.spacer} />
 
-        <View style={styles.aboutLabelContainer}>
-          <SvgXml style={styles.aboutSectionIconLock} xml={Icons.Lock} />
-          <Typography style={styles.aboutSectionTitles} use='headline2'>
-            {aboutHeader}
-          </Typography>
-        </View>
-        <Typography style={styles.aboutSectionPara}>
+        <Typography use='headline2'>{aboutHeader}</Typography>
+        <View style={{ height: 10 }} />
+        <Typography use='body2'>
           {t('label.about_para')}
           {/* Space between the copy & link*/}
           <Text> </Text>
@@ -125,38 +121,11 @@ export const AboutScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
   contentContainer: {
     flexDirection: 'column',
-    width: '100%',
     backgroundColor: Colors.primaryBackground,
-    paddingHorizontal: 40,
-    paddingBottom: 42,
-  },
-  aboutLabelContainer: {
-    flexDirection: 'column',
-  },
-  aboutSectionIconLock: {
-    width: 20,
-    height: 26.67,
-    marginTop: 36,
-  },
-  aboutSectionTitles: {
-    color: Colors.primaryText,
-    marginTop: 14,
-    lineHeight: 32,
-  },
-  aboutSectionPara: {
-    color: Colors.primaryText,
-    fontSize: 16,
-    lineHeight: 22.5,
-    marginTop: 12,
-    fontFamily: fontFamily.primaryRegular,
+    paddingHorizontal: 24,
   },
   hyperlink: {
     color: Colors.linkText,
-    fontSize: 16,
-    lineHeight: 22.5,
-    marginTop: 12,
-    alignSelf: 'center',
-    fontFamily: fontFamily.primaryRegular,
     textDecorationLine: 'underline',
   },
   aboutSectionParaBold: {

--- a/app/views/ExposureHistory/MoreInfo.tsx
+++ b/app/views/ExposureHistory/MoreInfo.tsx
@@ -8,6 +8,7 @@ import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
 import { useStatusBarEffect } from '../../navigation';
 
 import { Spacing, Typography as TypographyStyles } from '../../styles';
+import { isGPS } from '../../COVIDSafePathsConfig';
 
 const MoreInfo = (): JSX.Element => {
   const { t } = useTranslation();
@@ -18,22 +19,27 @@ const MoreInfo = (): JSX.Element => {
     navigation.goBack();
   };
 
-  const headerTextOne = t('exposure_history.why_did_i_get_an_en');
-  const contentTextOne = t('exposure_history.why_did_i_get_an_en_para');
+  const headerTextOne = isGPS
+    ? t('exposure_history.more_info_gps.why_did_i_get_an_en')
+    : t('exposure_history.more_info_bt.why_did_i_get_an_en');
 
-  const headerTextTwo = t('exposure_history.how_does_this_work');
-  const contentTextTwo = t('exposure_history.how_does_this_work_para');
+  const contentTextOne = isGPS
+    ? t('exposure_history.more_info_gps.why_did_i_get_an_en_para')
+    : t('exposure_history.more_info_bt.why_did_i_get_an_en_para');
+
+  const headerTextTwo = isGPS
+    ? t('exposure_history.more_info_gps.how_does_this_work')
+    : t('exposure_history.more_info_bt.how_does_this_work');
+
+  const contentTextTwo = isGPS
+    ? t('exposure_history.more_info_gps.how_does_this_work_para')
+    : t('exposure_history.more_info_bt.how_does_this_work_para');
 
   const title = 'More Info';
 
   return (
-    <NavigationBarWrapper
-      includeBottomNav
-      title={title}
-      onBackPress={handleOnBackPress}>
-      <ScrollView
-        style={styles.container}
-        contentInset={{ top: 0, bottom: 140 }}>
+    <NavigationBarWrapper title={title} onBackPress={handleOnBackPress}>
+      <ScrollView style={styles.container}>
         <View style={styles.contentContainer}>
           <Typography style={styles.headerText}>{headerTextOne}</Typography>
           <Typography style={styles.contentText}>{contentTextOne}</Typography>

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -33,10 +33,7 @@ const NextSteps = (): JSX.Element => {
   };
 
   return (
-    <NavigationBarWrapper
-      includeBottomNav
-      title={'Next Steps'}
-      onBackPress={handleOnBackPress}>
+    <NavigationBarWrapper title={'Next Steps'} onBackPress={handleOnBackPress}>
       <View style={styles.container}>
         <View style={styles.headerContainer}>
           <Typography style={styles.headerText}>{headerText}</Typography>

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -61,20 +61,16 @@ const ExposureHistoryScreen = (): JSX.Element => {
     selectedDatum && !DateTimeUtils.isInFuture(selectedDatum.date);
 
   return (
-    <SafeAreaView>
-      <ScrollView
-        style={styles.container}
-        contentInset={{ top: 0, bottom: 140 }}>
+    <SafeAreaView style={{ flex: 1 }}>
+      <ScrollView style={styles.container} alwaysBounceVertical={false}>
         <View style={styles.header}>
           <View style={styles.headerRow}>
             <Typography style={styles.headerText}>{titleText}</Typography>
-            {!isGPS ? (
-              <TouchableOpacity
-                onPress={handleOnPressMoreInfo}
-                style={styles.moreInfoButton}>
-                <SvgXml xml={Icons.IconQuestionMark} />
-              </TouchableOpacity>
-            ) : null}
+            <TouchableOpacity
+              onPress={handleOnPressMoreInfo}
+              style={styles.moreInfoButton}>
+              <SvgXml xml={Icons.IconQuestionMark} />
+            </TouchableOpacity>
           </View>
           {!isGPS ? (
             <View style={styles.headerRow}>

--- a/app/views/Licenses.tsx
+++ b/app/views/Licenses.tsx
@@ -16,7 +16,7 @@ import { Typography } from '../components/Typography';
 import { useAssets } from '../TracingStrategyAssets';
 import { NavigationProp } from '../navigation';
 
-import { Colors } from '../styles';
+import { Colors, Spacing } from '../styles';
 
 type LicensesScreenProps = {
   navigation: NavigationProp;
@@ -65,7 +65,8 @@ export const LicensesScreen = ({
         alwaysBounceVertical={false}>
         <View>
           <Typography use='headline2'>{legalHeaderText}</Typography>
-          <View style={{ paddingTop: Spacing.xSmall, paddingLeft: Spacing.medium }}>
+          <View
+            style={{ paddingTop: Spacing.xSmall, paddingLeft: Spacing.medium }}>
             <Typography use='body2'>{t('label.legal_page_address')}</Typography>
             <View style={{ height: 20 }} />
             <Typography

--- a/app/views/Licenses.tsx
+++ b/app/views/Licenses.tsx
@@ -65,7 +65,7 @@ export const LicensesScreen = ({
         alwaysBounceVertical={false}>
         <View>
           <Typography use='headline2'>{legalHeaderText}</Typography>
-          <View style={{ paddingTop: 10, paddingLeft: 24 }}>
+          <View style={{ paddingTop: Spacing.xSmall, paddingLeft: Spacing.medium }}>
             <Typography use='body2'>{t('label.legal_page_address')}</Typography>
             <View style={{ height: 20 }} />
             <Typography

--- a/app/views/Licenses.tsx
+++ b/app/views/Licenses.tsx
@@ -10,7 +10,6 @@ import {
   View,
 } from 'react-native';
 
-import fontFamily from '../constants/fonts';
 import { Images } from '../assets';
 import { NavigationBarWrapper } from '../components/NavigationBarWrapper';
 import { Typography } from '../components/Typography';
@@ -61,28 +60,35 @@ export const LicensesScreen = ({
     <NavigationBarWrapper
       title={t('screen_titles.legal')}
       onBackPress={backToMain}>
-      <ScrollView contentContainerStyle={styles.contentContainer}>
+      <ScrollView
+        contentContainerStyle={styles.contentContainer}
+        alwaysBounceVertical={false}>
         <View>
-          <Typography style={styles.heading} use='headline2'>
-            {legalHeaderText}
-          </Typography>
-          <Typography style={styles.body} use='body1'>
-            {t('label.legal_page_address')}
-          </Typography>
-          <TouchableOpacity
-            onPress={handleOnPressOpenUrl('mailto:info@pathcheck.org')}>
-            <Typography style={styles.hyperlink}>{infoAddress}</Typography>
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={handleOnPressOpenUrl('covidsafepaths.org')}>
-            <Typography style={styles.hyperlink}>{pathCheckAddress}</Typography>
-          </TouchableOpacity>
+          <Typography use='headline2'>{legalHeaderText}</Typography>
+          <View style={{ paddingTop: 10, paddingLeft: 24 }}>
+            <Typography use='body2'>{t('label.legal_page_address')}</Typography>
+            <View style={{ height: 20 }} />
+            <Typography
+              use='body2'
+              onPress={handleOnPressOpenUrl('mailto:info@pathcheck.org')}
+              style={styles.hyperlink}>
+              {infoAddress}
+            </Typography>
+            <Typography
+              use='body2'
+              onPress={handleOnPressOpenUrl('covidsafepaths.org')}
+              style={styles.hyperlink}>
+              {pathCheckAddress}
+            </Typography>
+          </View>
         </View>
       </ScrollView>
       <TouchableOpacity
         style={styles.termsInfoRow}
         onPress={handleOnPressOpenUrl(PRIVACY_POLICY_URL)}>
-        <Typography use='body1'>{t('label.privacy_policy')}</Typography>
+        <Typography style={{ color: Colors.white }} use='body1'>
+          {t('label.privacy_policy')}
+        </Typography>
         <View style={styles.arrowContainer}>
           <Image source={Images.ForeArrow} />
         </View>
@@ -92,31 +98,19 @@ export const LicensesScreen = ({
 };
 
 const styles = StyleSheet.create({
-  body: {
-    color: Colors.black,
-    marginBottom: 24,
-  },
   contentContainer: {
-    width: '100%',
     backgroundColor: Colors.primaryBackgroundFaintShade,
-    paddingHorizontal: 26,
-    paddingVertical: 40,
-  },
-  heading: {
-    color: Colors.black,
-    marginBottom: 12,
+    paddingHorizontal: 24,
+    paddingTop: 24,
   },
   hyperlink: {
     color: Colors.linkText,
-    fontSize: 16,
-    marginBottom: 12,
-    fontFamily: fontFamily.primaryRegular,
     textDecorationLine: 'underline',
   },
   termsInfoRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    backgroundColor: Colors.primaryViolet,
+    backgroundColor: Colors.primaryBlue,
     paddingVertical: 25,
     paddingHorizontal: 15,
   },

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -11,7 +11,7 @@ import { AllServicesOnScreen } from './main/AllServicesOn';
 import {
   TracingOffScreen,
   NotificationsOffScreen,
-  SelectAuthorityScreen,
+  // SelectAuthorityScreen,
 } from './main/ServiceOffScreens';
 import PermissionsContext, { PermissionStatus } from '../PermissionsContext';
 
@@ -71,7 +71,9 @@ export const Main = () => {
   } else if (notification.status === PermissionStatus.DENIED) {
     return <NotificationsOffScreen />;
   } else if (hasSelectedAuthorities === false && isGPS) {
-    return <SelectAuthorityScreen />;
+    // TODO: enable this for testing versions of app
+    // return <SelectAuthorityScreen />;
+    return <AllServicesOnScreen noHaAvailable />;
   } else {
     return <AllServicesOnScreen />;
   }

--- a/app/views/Partners/PartnersOverview.tsx
+++ b/app/views/Partners/PartnersOverview.tsx
@@ -79,24 +79,27 @@ const PartnersScreen = ({ navigation }: PartnersScreenProps): JSX.Element => {
         <View style={styles.divider} />
         <View style={{ height: 24 }} />
       </ScrollView>
-      <View style={styles.bottomSheet}>
-        <Typography
-          style={{
-            // Prevent from forcing overflow on parent
-            flex: 1,
-          }}>
-          {t('authorities.automatically_follow')}
-        </Typography>
-        <View style={{ width: 16 }} />
-        <Switch
-          trackColor={{
-            true: Colors.switchEnabled,
-            false: Colors.switchDisabled,
-          }}
-          value={toggleActive}
-          onValueChange={setToggleActive}
-        />
-      </View>
+      {/* UI is ready, this is currently not a feature though. */}
+      {__DEV__ && (
+        <View style={styles.bottomSheet}>
+          <Typography
+            style={{
+              // Prevent from forcing overflow on parent
+              flex: 1,
+            }}>
+            {t('authorities.automatically_follow')}
+          </Typography>
+          <View style={{ width: 16 }} />
+          <Switch
+            trackColor={{
+              true: Colors.switchEnabled,
+              false: Colors.switchDisabled,
+            }}
+            value={toggleActive}
+            onValueChange={setToggleActive}
+          />
+        </View>
+      )}
     </NavigationBarWrapper>
   );
 };

--- a/app/views/Settings/ENDebugMenu.tsx
+++ b/app/views/Settings/ENDebugMenu.tsx
@@ -123,10 +123,7 @@ const ENDebugMenu = ({ navigation }: ENDebugMenuProps): JSX.Element => {
   };
 
   return (
-    <NavigationBarWrapper
-      includeBottomNav
-      title={'EN Debug Menu'}
-      onBackPress={backToSettings}>
+    <NavigationBarWrapper title={'EN Debug Menu'} onBackPress={backToSettings}>
       {loading ? (
         <View style={{ flex: 1, justifyContent: 'center' }}>
           <ActivityIndicator size={'large'} />

--- a/app/views/Settings/ENLocalDiagnosisKeyScreen.tsx
+++ b/app/views/Settings/ENLocalDiagnosisKeyScreen.tsx
@@ -75,7 +75,6 @@ export const ENLocalDiagnosisKeyScreen = ({
 
   return (
     <NavigationBarWrapper
-      includeBottomNav
       title={'Local Diagnosis Keys'}
       onBackPress={backToDebugMenu}>
       <FlatList

--- a/app/views/Settings/GoogleMapsImport.tsx
+++ b/app/views/Settings/GoogleMapsImport.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { SvgXml } from 'react-native-svg';
 import {
@@ -12,7 +12,8 @@ import { Typography } from '../../components/Typography';
 import { Screens } from '../../navigation';
 
 import { Icons } from '../../assets';
-import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
+import { Spacing, Typography as TypographyStyles } from '../../styles';
+import { Button } from '../../components/Button';
 
 interface GoogleMapsImportProps {
   navigation: NavigationScreenProp<NavigationState, NavigationParams>;
@@ -36,21 +37,15 @@ const GoogleMapsImport = ({
         </Typography>
       </View>
 
-      <View style={styles.description}>
-        <Typography use='body2'>{t('import.subtitle')}</Typography>
+      <Typography use='body2'>{t('import.subtitle')}</Typography>
+
+      <View style={styles.buttonWrapper}>
+        <Button onPress={handleImportPressed} label={t('import.button_text')} />
       </View>
 
-      <TouchableOpacity style={styles.button} onPress={handleImportPressed}>
-        <Typography style={styles.buttonText}>
-          {t('import.button_text')}
-        </Typography>
-      </TouchableOpacity>
-
-      <View style={styles.description}>
-        <Typography style={styles.disclaimerText}>
-          {t('import.google.disclaimer')}
-        </Typography>
-      </View>
+      <Typography style={styles.disclaimerText}>
+        {t('import.google.disclaimer')}
+      </Typography>
     </>
   );
 };
@@ -59,16 +54,13 @@ const styles = StyleSheet.create({
   title: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingTop: Spacing.small,
+    paddingBottom: Spacing.xSmall,
   },
   titleText: {
-    marginLeft: Spacing.small,
+    marginLeft: Spacing.xxSmall,
   },
-  description: {
-    paddingVertical: Spacing.medium,
-  },
-  button: {
-    ...Buttons.largeBlueOutline,
+  buttonWrapper: {
+    marginVertical: Spacing.medium,
   },
   buttonText: {
     ...TypographyStyles.buttonTextDark,

--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import {
   ViewStyle,
-  TouchableOpacity,
   View,
   StyleSheet,
   ScrollView,
+  TouchableHighlight,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { SvgXml } from 'react-native-svg';
@@ -87,12 +87,15 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
     const flexDirection = i18n.dir() === 'rtl' ? 'row-reverse' : 'row';
 
     return (
-      <TouchableOpacity
-        style={[styles.languageSelectionListItem, { flexDirection }]}
+      <TouchableHighlight
+        underlayColor={Colors.underlayPrimaryBackground}
+        style={[styles.listItem]}
         onPress={onPress}>
-        <SvgXml xml={icon} style={[styles.icon, iconStyle]} />
-        <Typography use={'body1'}>{label}</Typography>
-      </TouchableOpacity>
+        <View style={{ flexDirection }}>
+          <SvgXml xml={icon} style={[styles.icon, iconStyle]} />
+          <Typography use={'body1'}>{label}</Typography>
+        </View>
+      </TouchableHighlight>
     );
   };
 
@@ -110,12 +113,19 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
     style,
   }: SettingsListItemProps) => {
     return (
-      <TouchableOpacity style={[styles.listItem, style]} onPress={onPress}>
-        <Typography style={styles.listItemText}>{label}</Typography>
-        {description ? (
-          <Typography style={styles.descriptionText}>{description}</Typography>
-        ) : null}
-      </TouchableOpacity>
+      <TouchableHighlight
+        underlayColor={Colors.underlayPrimaryBackground}
+        style={[styles.listItem, style]}
+        onPress={onPress}>
+        <View>
+          <Typography style={styles.listItemText}>{label}</Typography>
+          {description ? (
+            <Typography style={styles.descriptionText}>
+              {description}
+            </Typography>
+          ) : null}
+        </View>
+      </TouchableHighlight>
     );
   };
 
@@ -158,7 +168,8 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
 
         {isGPS ? (
           <FeatureFlag name={'google_import'}>
-            <View style={styles.section}>
+            <View
+              style={[styles.section, { paddingHorizontal: Spacing.small }]}>
               <GoogleMapsImport navigation={navigation} />
             </View>
           </FeatureFlag>
@@ -169,6 +180,7 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
             label={t('screen_titles.about')}
             onPress={navigateTo(Screens.About)}
           />
+          <Divider />
           <SettingsListItem
             label={t('screen_titles.legal')}
             onPress={() => navigation.navigate(Screens.Licenses)}
@@ -200,14 +212,21 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
   );
 };
 
+const Divider = () => <View style={styles.divider} />;
+
 const styles = StyleSheet.create({
   container: {
     backgroundColor: Colors.primaryBackgroundFaintShade,
   },
+  divider: {
+    marginHorizontal: Spacing.small,
+    flex: 1,
+    height: 1,
+    backgroundColor: Colors.tertiaryViolet,
+  },
   section: {
     flex: 1,
     backgroundColor: Colors.white,
-    paddingHorizontal: Spacing.small,
     marginBottom: Spacing.medium,
     borderTopWidth: 1,
     borderBottomWidth: 1,
@@ -219,16 +238,11 @@ const styles = StyleSheet.create({
   },
   listItem: {
     flex: 1,
+    paddingHorizontal: Spacing.small,
     paddingVertical: Spacing.medium,
-    borderBottomWidth: 1,
-    borderColor: Colors.tertiaryViolet,
   },
   listItemText: {
     ...TypographyStyles.tappableListItem,
-  },
-  languageSelectionListItem: {
-    flex: 1,
-    paddingVertical: Spacing.medium,
   },
   lastListItem: {
     borderBottomWidth: 0,

--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -168,9 +168,10 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
 
         {isGPS ? (
           <FeatureFlag name={'google_import'}>
-            <View
-              style={[styles.section, { paddingHorizontal: Spacing.small }]}>
-              <GoogleMapsImport navigation={navigation} />
+            <View style={styles.section}>
+              <View style={styles.listItem}>
+                <GoogleMapsImport navigation={navigation} />
+              </View>
             </View>
           </FeatureFlag>
         ) : null}

--- a/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -107,12 +107,12 @@ exports[`renders correctly 1`] = `
       }
     >
       <RCTScrollView
+        alwaysBounceVertical={false}
         contentContainerStyle={
           Object {
             "backgroundColor": "#f8f8f8",
-            "paddingHorizontal": 26,
-            "paddingVertical": 40,
-            "width": "100%",
+            "paddingHorizontal": 24,
+            "paddingTop": 24,
           }
         }
       >
@@ -131,45 +131,17 @@ exports[`renders correctly 1`] = `
                   Object {
                     "writingDirection": "ltr",
                   },
-                  Object {
-                    "color": "#000000",
-                    "marginBottom": 12,
-                  },
+                  undefined,
                 ]
               }
             >
               PathCheck GPS
             </Text>
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2e2e2e",
-                    "fontSize": 17,
-                    "lineHeight": 28,
-                  },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Object {
-                    "color": "#000000",
-                    "marginBottom": 24,
-                  },
-                ]
-              }
-            >
-              PathCheck
-58 Day Street
-Box 441621
-Somerville, MA 02144
-            </Text>
             <View
-              accessible={true}
-              focusable={true}
-              isTVSelectable={true}
               style={
                 Object {
-                  "opacity": 1,
+                  "paddingLeft": 24,
+                  "paddingTop": 10,
                 }
               }
             >
@@ -177,7 +149,34 @@ Somerville, MA 02144
                 style={
                   Array [
                     Object {
-                      "color": "#2e2e2e",
+                      "color": "#4e4e4e",
+                      "fontSize": 17,
+                      "lineHeight": 28,
+                    },
+                    Object {
+                      "writingDirection": "ltr",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                PathCheck
+58 Day Street
+Box 441621
+Somerville, MA 02144
+              </Text>
+              <View
+                style={
+                  Object {
+                    "height": 20,
+                  }
+                }
+              />
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#4e4e4e",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },
@@ -186,9 +185,6 @@ Somerville, MA 02144
                     },
                     Object {
                       "color": "#1f2c9b",
-                      "fontFamily": "IBMPlexSans",
-                      "fontSize": 16,
-                      "marginBottom": 12,
                       "textDecorationLine": "underline",
                     },
                   ]
@@ -196,22 +192,11 @@ Somerville, MA 02144
               >
                 info@pathcheck.org
               </Text>
-            </View>
-            <View
-              accessible={true}
-              focusable={true}
-              isTVSelectable={true}
-              style={
-                Object {
-                  "opacity": 1,
-                }
-              }
-            >
               <Text
                 style={
                   Array [
                     Object {
-                      "color": "#2e2e2e",
+                      "color": "#4e4e4e",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },
@@ -220,9 +205,6 @@ Somerville, MA 02144
                     },
                     Object {
                       "color": "#1f2c9b",
-                      "fontFamily": "IBMPlexSans",
-                      "fontSize": 16,
-                      "marginBottom": 12,
                       "textDecorationLine": "underline",
                     },
                   ]
@@ -240,7 +222,7 @@ Somerville, MA 02144
         isTVSelectable={true}
         style={
           Object {
-            "backgroundColor": "#1f2c9b",
+            "backgroundColor": "#4051db",
             "flexDirection": "row",
             "justifyContent": "space-between",
             "opacity": 1,
@@ -260,7 +242,9 @@ Somerville, MA 02144
               Object {
                 "writingDirection": "ltr",
               },
-              undefined,
+              Object {
+                "color": "#ffffff",
+              },
             ]
           }
         >

--- a/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -140,8 +140,8 @@ exports[`renders correctly 1`] = `
             <View
               style={
                 Object {
-                  "paddingLeft": 24,
-                  "paddingTop": 10,
+                  "paddingLeft": 20,
+                  "paddingTop": 12,
                 }
               }
             >

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -22,65 +22,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
     <View
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "#1f2c9b",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingHorizontal": 16,
-          "paddingVertical": 8,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 3,
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontSize": 17,
-                "lineHeight": 28,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans-Bold",
-                "fontSize": 19,
-                "fontWeight": "500",
-                "lineHeight": 40,
-              },
-            ]
-          }
-        >
-          More
-        </Text>
-      </View>
-      <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        Object {
           "backgroundColor": "#f8f8f8",
           "flex": 1,
         }
@@ -103,7 +44,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
                 "borderTopWidth": 1,
                 "flex": 1,
                 "marginBottom": 20,
-                "paddingHorizontal": 16,
               }
             }
           >
@@ -112,46 +52,55 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                ]
               }
             >
-              <SvgXml
+              <View
                 style={
-                  Array [
-                    Object {
-                      "maxHeight": 24,
-                      "maxWidth": 24,
-                    },
-                    Object {
-                      "marginRight": 12,
-                    },
-                  ]
-                }
-                xml="<?xml version=\\"1.0\\"?>
-<svg xmlns=\\"http://www.w3.org/2000/svg\\" id=\\"Layer_1\\" enable-background=\\"new 0 0 512.418 512.418\\" height=\\"512px\\" viewBox=\\"0 0 512.418 512.418\\" width=\\"512px\\"><g><path d=\\"m437.335 75.082c-100.1-100.102-262.136-100.118-362.252 0-100.103 100.102-100.118 262.136 0 362.253 100.1 100.102 262.136 100.117 362.252 0 100.103-100.102 100.117-262.136 0-362.253zm-10.706 325.739c-11.968-10.702-24.77-20.173-38.264-28.335 8.919-30.809 14.203-64.712 15.452-99.954h75.309c-3.405 47.503-21.657 92.064-52.497 128.289zm-393.338-128.289h75.309c1.249 35.242 6.533 69.145 15.452 99.954-13.494 8.162-26.296 17.633-38.264 28.335-30.84-36.225-49.091-80.786-52.497-128.289zm52.498-160.936c11.968 10.702 24.77 20.173 38.264 28.335-8.919 30.809-14.203 64.712-15.452 99.954h-75.31c3.406-47.502 21.657-92.063 52.498-128.289zm154.097 31.709c-26.622-1.904-52.291-8.461-76.088-19.278 13.84-35.639 39.354-78.384 76.088-88.977zm0 32.708v63.873h-98.625c1.13-29.812 5.354-58.439 12.379-84.632 27.043 11.822 56.127 18.882 86.246 20.759zm0 96.519v63.873c-30.119 1.877-59.203 8.937-86.246 20.759-7.025-26.193-11.249-54.82-12.379-84.632zm0 96.581v108.254c-36.732-10.593-62.246-53.333-76.088-88.976 23.797-10.817 49.466-17.374 76.088-19.278zm32.646 0c26.622 1.904 52.291 8.461 76.088 19.278-13.841 35.64-39.354 78.383-76.088 88.976zm0-32.708v-63.873h98.625c-1.13 29.812-5.354 58.439-12.379 84.632-27.043-11.822-56.127-18.882-86.246-20.759zm0-96.519v-63.873c30.119-1.877 59.203-8.937 86.246-20.759 7.025 26.193 11.249 54.82 12.379 84.632zm0-96.581v-108.254c36.734 10.593 62.248 53.338 76.088 88.977-23.797 10.816-49.466 17.373-76.088 19.277zm73.32-91.957c20.895 9.15 40.389 21.557 57.864 36.951-8.318 7.334-17.095 13.984-26.26 19.931-8.139-20.152-18.536-39.736-31.604-56.882zm-210.891 56.882c-9.165-5.947-17.941-12.597-26.26-19.931 17.475-15.394 36.969-27.801 57.864-36.951-13.068 17.148-23.465 36.732-31.604 56.882zm.001 295.958c8.138 20.151 18.537 39.736 31.604 56.882-20.895-9.15-40.389-21.557-57.864-36.951 8.318-7.334 17.095-13.984 26.26-19.931zm242.494 0c9.165 5.947 17.942 12.597 26.26 19.93-17.475 15.394-36.969 27.801-57.864 36.951 13.067-17.144 23.465-36.729 31.604-56.881zm26.362-164.302c-1.249-35.242-6.533-69.146-15.452-99.954 13.494-8.162 26.295-17.633 38.264-28.335 30.84 36.225 49.091 80.786 52.497 128.289z\\" data-original=\\"#000000\\" class=\\"active-path\\" data-old_color=\\"#000000\\" fill=\\"#3C4ED8\\"/></g> </svg>"
-              />
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    undefined,
-                  ]
+                  Object {
+                    "flexDirection": "row",
+                  }
                 }
               >
-                English
-              </Text>
+                <SvgXml
+                  style={
+                    Array [
+                      Object {
+                        "maxHeight": 24,
+                        "maxWidth": 24,
+                      },
+                      Object {
+                        "marginRight": 12,
+                      },
+                    ]
+                  }
+                  xml="<?xml version=\\"1.0\\"?>
+<svg xmlns=\\"http://www.w3.org/2000/svg\\" id=\\"Layer_1\\" enable-background=\\"new 0 0 512.418 512.418\\" height=\\"512px\\" viewBox=\\"0 0 512.418 512.418\\" width=\\"512px\\"><g><path d=\\"m437.335 75.082c-100.1-100.102-262.136-100.118-362.252 0-100.103 100.102-100.118 262.136 0 362.253 100.1 100.102 262.136 100.117 362.252 0 100.103-100.102 100.117-262.136 0-362.253zm-10.706 325.739c-11.968-10.702-24.77-20.173-38.264-28.335 8.919-30.809 14.203-64.712 15.452-99.954h75.309c-3.405 47.503-21.657 92.064-52.497 128.289zm-393.338-128.289h75.309c1.249 35.242 6.533 69.145 15.452 99.954-13.494 8.162-26.296 17.633-38.264 28.335-30.84-36.225-49.091-80.786-52.497-128.289zm52.498-160.936c11.968 10.702 24.77 20.173 38.264 28.335-8.919 30.809-14.203 64.712-15.452 99.954h-75.31c3.406-47.502 21.657-92.063 52.498-128.289zm154.097 31.709c-26.622-1.904-52.291-8.461-76.088-19.278 13.84-35.639 39.354-78.384 76.088-88.977zm0 32.708v63.873h-98.625c1.13-29.812 5.354-58.439 12.379-84.632 27.043 11.822 56.127 18.882 86.246 20.759zm0 96.519v63.873c-30.119 1.877-59.203 8.937-86.246 20.759-7.025-26.193-11.249-54.82-12.379-84.632zm0 96.581v108.254c-36.732-10.593-62.246-53.333-76.088-88.976 23.797-10.817 49.466-17.374 76.088-19.278zm32.646 0c26.622 1.904 52.291 8.461 76.088 19.278-13.841 35.64-39.354 78.383-76.088 88.976zm0-32.708v-63.873h98.625c-1.13 29.812-5.354 58.439-12.379 84.632-27.043-11.822-56.127-18.882-86.246-20.759zm0-96.519v-63.873c30.119-1.877 59.203-8.937 86.246-20.759 7.025 26.193 11.249 54.82 12.379 84.632zm0-96.581v-108.254c36.734 10.593 62.248 53.338 76.088 88.977-23.797 10.816-49.466 17.373-76.088 19.277zm73.32-91.957c20.895 9.15 40.389 21.557 57.864 36.951-8.318 7.334-17.095 13.984-26.26 19.931-8.139-20.152-18.536-39.736-31.604-56.882zm-210.891 56.882c-9.165-5.947-17.941-12.597-26.26-19.931 17.475-15.394 36.969-27.801 57.864-36.951-13.068 17.148-23.465 36.732-31.604 56.882zm.001 295.958c8.138 20.151 18.537 39.736 31.604 56.882-20.895-9.15-40.389-21.557-57.864-36.951 8.318-7.334 17.095-13.984 26.26-19.931zm242.494 0c9.165 5.947 17.942 12.597 26.26 19.93-17.475 15.394-36.969 27.801-57.864 36.951 13.067-17.144 23.465-36.729 31.604-56.881zm26.362-164.302c-1.249-35.242-6.533-69.146-15.452-99.954 13.494-8.162 26.295-17.633 38.264-28.335 30.84 36.225 49.091 80.786 52.497 128.289z\\" data-original=\\"#000000\\" class=\\"active-path\\" data-old_color=\\"#000000\\" fill=\\"#3C4ED8\\"/></g> </svg>"
+                />
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  English
+                </Text>
+              </View>
             </View>
             <Modal
               animationType="slide"
@@ -250,15 +199,19 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
           </View>
           <View
             style={
-              Object {
-                "backgroundColor": "#ffffff",
-                "borderBottomWidth": 1,
-                "borderColor": "#e5e7fa",
-                "borderTopWidth": 1,
-                "flex": 1,
-                "marginBottom": 20,
-                "paddingHorizontal": 16,
-              }
+              Array [
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "borderBottomWidth": 1,
+                  "borderColor": "#e5e7fa",
+                  "borderTopWidth": 1,
+                  "flex": 1,
+                  "marginBottom": 20,
+                },
+                Object {
+                  "paddingHorizontal": 16,
+                },
+              ]
             }
           >
             <View
@@ -408,7 +361,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
                 "borderTopWidth": 1,
                 "flex": 1,
                 "marginBottom": 20,
-                "paddingHorizontal": 16,
               }
             }
           >
@@ -417,72 +369,94 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "borderBottomWidth": 1,
-                  "borderColor": "#e5e7fa",
-                  "flex": 1,
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                  undefined,
+                ]
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                  ]
-                }
+              <View
+                style={null}
               >
-                About
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#1f2c9b",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                    ]
+                  }
+                >
+                  About
+                </Text>
+              </View>
             </View>
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#e5e7fa",
+                  "flex": 1,
+                  "height": 1,
+                  "marginHorizontal": 16,
+                }
+              }
+            />
             <View
               accessible={true}
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "borderBottomWidth": 0,
-                  "borderColor": "#e5e7fa",
-                  "flex": 1,
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                  Object {
+                    "borderBottomWidth": 0,
+                  },
+                ]
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                  ]
-                }
+              <View
+                style={null}
               >
-                Legal
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#1f2c9b",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                    ]
+                  }
+                >
+                  Legal
+                </Text>
+              </View>
             </View>
           </View>
           <View
@@ -494,7 +468,6 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
                 "borderTopWidth": 1,
                 "flex": 1,
                 "marginBottom": 20,
-                "paddingHorizontal": 16,
               }
             }
           >
@@ -503,36 +476,43 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "borderBottomWidth": 0,
-                  "borderColor": "#e5e7fa",
-                  "flex": 1,
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                  Object {
+                    "borderBottomWidth": 0,
+                  },
+                ]
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                  ]
-                }
+              <View
+                style={null}
               >
-                Feature Flags (Dev mode only)
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#1f2c9b",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                    ]
+                  }
+                >
+                  Feature Flags (Dev mode only)
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -564,65 +544,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
     <View
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "#1f2c9b",
-          "flexDirection": "row",
-          "justifyContent": "flex-start",
-          "paddingHorizontal": 16,
-          "paddingVertical": 8,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 3,
-          }
-        }
-      >
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontSize": 17,
-                "lineHeight": 28,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans-Bold",
-                "fontSize": 19,
-                "fontWeight": "500",
-                "lineHeight": 40,
-              },
-            ]
-          }
-        >
-          More
-        </Text>
-      </View>
-      <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
-      />
-    </View>
-    <View
-      style={
-        Object {
           "backgroundColor": "#f8f8f8",
           "flex": 1,
         }
@@ -645,7 +566,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
                 "borderTopWidth": 1,
                 "flex": 1,
                 "marginBottom": 20,
-                "paddingHorizontal": 16,
               }
             }
           >
@@ -654,46 +574,55 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "flex": 1,
-                  "flexDirection": "row",
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                ]
               }
             >
-              <SvgXml
+              <View
                 style={
-                  Array [
-                    Object {
-                      "maxHeight": 24,
-                      "maxWidth": 24,
-                    },
-                    Object {
-                      "marginRight": 12,
-                    },
-                  ]
-                }
-                xml="<?xml version=\\"1.0\\"?>
-<svg xmlns=\\"http://www.w3.org/2000/svg\\" id=\\"Layer_1\\" enable-background=\\"new 0 0 512.418 512.418\\" height=\\"512px\\" viewBox=\\"0 0 512.418 512.418\\" width=\\"512px\\"><g><path d=\\"m437.335 75.082c-100.1-100.102-262.136-100.118-362.252 0-100.103 100.102-100.118 262.136 0 362.253 100.1 100.102 262.136 100.117 362.252 0 100.103-100.102 100.117-262.136 0-362.253zm-10.706 325.739c-11.968-10.702-24.77-20.173-38.264-28.335 8.919-30.809 14.203-64.712 15.452-99.954h75.309c-3.405 47.503-21.657 92.064-52.497 128.289zm-393.338-128.289h75.309c1.249 35.242 6.533 69.145 15.452 99.954-13.494 8.162-26.296 17.633-38.264 28.335-30.84-36.225-49.091-80.786-52.497-128.289zm52.498-160.936c11.968 10.702 24.77 20.173 38.264 28.335-8.919 30.809-14.203 64.712-15.452 99.954h-75.31c3.406-47.502 21.657-92.063 52.498-128.289zm154.097 31.709c-26.622-1.904-52.291-8.461-76.088-19.278 13.84-35.639 39.354-78.384 76.088-88.977zm0 32.708v63.873h-98.625c1.13-29.812 5.354-58.439 12.379-84.632 27.043 11.822 56.127 18.882 86.246 20.759zm0 96.519v63.873c-30.119 1.877-59.203 8.937-86.246 20.759-7.025-26.193-11.249-54.82-12.379-84.632zm0 96.581v108.254c-36.732-10.593-62.246-53.333-76.088-88.976 23.797-10.817 49.466-17.374 76.088-19.278zm32.646 0c26.622 1.904 52.291 8.461 76.088 19.278-13.841 35.64-39.354 78.383-76.088 88.976zm0-32.708v-63.873h98.625c-1.13 29.812-5.354 58.439-12.379 84.632-27.043-11.822-56.127-18.882-86.246-20.759zm0-96.519v-63.873c30.119-1.877 59.203-8.937 86.246-20.759 7.025 26.193 11.249 54.82 12.379 84.632zm0-96.581v-108.254c36.734 10.593 62.248 53.338 76.088 88.977-23.797 10.816-49.466 17.373-76.088 19.277zm73.32-91.957c20.895 9.15 40.389 21.557 57.864 36.951-8.318 7.334-17.095 13.984-26.26 19.931-8.139-20.152-18.536-39.736-31.604-56.882zm-210.891 56.882c-9.165-5.947-17.941-12.597-26.26-19.931 17.475-15.394 36.969-27.801 57.864-36.951-13.068 17.148-23.465 36.732-31.604 56.882zm.001 295.958c8.138 20.151 18.537 39.736 31.604 56.882-20.895-9.15-40.389-21.557-57.864-36.951 8.318-7.334 17.095-13.984 26.26-19.931zm242.494 0c9.165 5.947 17.942 12.597 26.26 19.93-17.475 15.394-36.969 27.801-57.864 36.951 13.067-17.144 23.465-36.729 31.604-56.881zm26.362-164.302c-1.249-35.242-6.533-69.146-15.452-99.954 13.494-8.162 26.295-17.633 38.264-28.335 30.84 36.225 49.091 80.786 52.497 128.289z\\" data-original=\\"#000000\\" class=\\"active-path\\" data-old_color=\\"#000000\\" fill=\\"#3C4ED8\\"/></g> </svg>"
-              />
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    undefined,
-                  ]
+                  Object {
+                    "flexDirection": "row",
+                  }
                 }
               >
-                English
-              </Text>
+                <SvgXml
+                  style={
+                    Array [
+                      Object {
+                        "maxHeight": 24,
+                        "maxWidth": 24,
+                      },
+                      Object {
+                        "marginRight": 12,
+                      },
+                    ]
+                  }
+                  xml="<?xml version=\\"1.0\\"?>
+<svg xmlns=\\"http://www.w3.org/2000/svg\\" id=\\"Layer_1\\" enable-background=\\"new 0 0 512.418 512.418\\" height=\\"512px\\" viewBox=\\"0 0 512.418 512.418\\" width=\\"512px\\"><g><path d=\\"m437.335 75.082c-100.1-100.102-262.136-100.118-362.252 0-100.103 100.102-100.118 262.136 0 362.253 100.1 100.102 262.136 100.117 362.252 0 100.103-100.102 100.117-262.136 0-362.253zm-10.706 325.739c-11.968-10.702-24.77-20.173-38.264-28.335 8.919-30.809 14.203-64.712 15.452-99.954h75.309c-3.405 47.503-21.657 92.064-52.497 128.289zm-393.338-128.289h75.309c1.249 35.242 6.533 69.145 15.452 99.954-13.494 8.162-26.296 17.633-38.264 28.335-30.84-36.225-49.091-80.786-52.497-128.289zm52.498-160.936c11.968 10.702 24.77 20.173 38.264 28.335-8.919 30.809-14.203 64.712-15.452 99.954h-75.31c3.406-47.502 21.657-92.063 52.498-128.289zm154.097 31.709c-26.622-1.904-52.291-8.461-76.088-19.278 13.84-35.639 39.354-78.384 76.088-88.977zm0 32.708v63.873h-98.625c1.13-29.812 5.354-58.439 12.379-84.632 27.043 11.822 56.127 18.882 86.246 20.759zm0 96.519v63.873c-30.119 1.877-59.203 8.937-86.246 20.759-7.025-26.193-11.249-54.82-12.379-84.632zm0 96.581v108.254c-36.732-10.593-62.246-53.333-76.088-88.976 23.797-10.817 49.466-17.374 76.088-19.278zm32.646 0c26.622 1.904 52.291 8.461 76.088 19.278-13.841 35.64-39.354 78.383-76.088 88.976zm0-32.708v-63.873h98.625c-1.13 29.812-5.354 58.439-12.379 84.632-27.043-11.822-56.127-18.882-86.246-20.759zm0-96.519v-63.873c30.119-1.877 59.203-8.937 86.246-20.759 7.025 26.193 11.249 54.82 12.379 84.632zm0-96.581v-108.254c36.734 10.593 62.248 53.338 76.088 88.977-23.797 10.816-49.466 17.373-76.088 19.277zm73.32-91.957c20.895 9.15 40.389 21.557 57.864 36.951-8.318 7.334-17.095 13.984-26.26 19.931-8.139-20.152-18.536-39.736-31.604-56.882zm-210.891 56.882c-9.165-5.947-17.941-12.597-26.26-19.931 17.475-15.394 36.969-27.801 57.864-36.951-13.068 17.148-23.465 36.732-31.604 56.882zm.001 295.958c8.138 20.151 18.537 39.736 31.604 56.882-20.895-9.15-40.389-21.557-57.864-36.951 8.318-7.334 17.095-13.984 26.26-19.931zm242.494 0c9.165 5.947 17.942 12.597 26.26 19.93-17.475 15.394-36.969 27.801-57.864 36.951 13.067-17.144 23.465-36.729 31.604-56.881zm26.362-164.302c-1.249-35.242-6.533-69.146-15.452-99.954 13.494-8.162 26.295-17.633 38.264-28.335 30.84 36.225 49.091 80.786 52.497 128.289z\\" data-original=\\"#000000\\" class=\\"active-path\\" data-old_color=\\"#000000\\" fill=\\"#3C4ED8\\"/></g> </svg>"
+                />
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  English
+                </Text>
+              </View>
             </View>
             <Modal
               animationType="slide"
@@ -799,7 +728,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
                 "borderTopWidth": 1,
                 "flex": 1,
                 "marginBottom": 20,
-                "paddingHorizontal": 16,
               }
             }
           >
@@ -808,72 +736,94 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "borderBottomWidth": 1,
-                  "borderColor": "#e5e7fa",
-                  "flex": 1,
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                  undefined,
+                ]
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                  ]
-                }
+              <View
+                style={null}
               >
-                About
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#1f2c9b",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                    ]
+                  }
+                >
+                  About
+                </Text>
+              </View>
             </View>
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#e5e7fa",
+                  "flex": 1,
+                  "height": 1,
+                  "marginHorizontal": 16,
+                }
+              }
+            />
             <View
               accessible={true}
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "borderBottomWidth": 0,
-                  "borderColor": "#e5e7fa",
-                  "flex": 1,
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                  Object {
+                    "borderBottomWidth": 0,
+                  },
+                ]
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                  ]
-                }
+              <View
+                style={null}
               >
-                Legal
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#1f2c9b",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                    ]
+                  }
+                >
+                  Legal
+                </Text>
+              </View>
             </View>
           </View>
           <View
@@ -885,7 +835,6 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
                 "borderTopWidth": 1,
                 "flex": 1,
                 "marginBottom": 20,
-                "paddingHorizontal": 16,
               }
             }
           >
@@ -894,36 +843,43 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
               focusable={true}
               isTVSelectable={true}
               style={
-                Object {
-                  "borderBottomWidth": 0,
-                  "borderColor": "#e5e7fa",
-                  "flex": 1,
-                  "opacity": 1,
-                  "paddingVertical": 20,
-                }
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 20,
+                  },
+                  Object {
+                    "borderBottomWidth": 0,
+                  },
+                ]
               }
             >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                  ]
-                }
+              <View
+                style={null}
               >
-                Feature Flags (Dev mode only)
-              </Text>
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#1f2c9b",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                    ]
+                  }
+                >
+                  Feature Flags (Dev mode only)
+                </Text>
+              </View>
             </View>
           </View>
         </View>

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -258,32 +258,36 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
           </View>
           <View
             style={
-              Array [
-                Object {
-                  "backgroundColor": "#ffffff",
-                  "borderBottomWidth": 1,
-                  "borderColor": "#e5e7fa",
-                  "borderTopWidth": 1,
-                  "flex": 1,
-                  "marginBottom": 20,
-                },
-                Object {
-                  "paddingHorizontal": 16,
-                },
-              ]
+              Object {
+                "backgroundColor": "#ffffff",
+                "borderBottomWidth": 1,
+                "borderColor": "#e5e7fa",
+                "borderTopWidth": 1,
+                "flex": 1,
+                "marginBottom": 20,
+              }
             }
           >
             <View
               style={
                 Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "paddingTop": 16,
+                  "flex": 1,
+                  "paddingHorizontal": 16,
+                  "paddingVertical": 20,
                 }
               }
             >
-              <SvgXml
-                xml="<svg width=\\"27\\" height=\\"34\\" viewBox=\\"0 0 27 34\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingBottom": 12,
+                  }
+                }
+              >
+                <SvgXml
+                  xml="<svg width=\\"27\\" height=\\"34\\" viewBox=\\"0 0 27 34\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
 <rect width=\\"27\\" height=\\"34\\" fill=\\"url(#pattern0)\\"/>
 <defs>
 <pattern id=\\"pattern0\\" patternContentUnits=\\"objectBoundingBox\\" width=\\"1\\" height=\\"1\\">
@@ -293,34 +297,27 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
 </defs>
 </svg>
 "
-              />
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "marginLeft": 16,
-                    },
-                  ]
-                }
-              >
-                Google Maps
-              </Text>
-            </View>
-            <View
-              style={
-                Object {
-                  "paddingVertical": 20,
-                }
-              }
-            >
+                />
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontSize": 17,
+                        "lineHeight": 28,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "marginLeft": 8,
+                      },
+                    ]
+                  }
+                >
+                  Google Maps
+                </Text>
+              </View>
               <Text
                 style={
                   Array [
@@ -338,55 +335,63 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
               >
                 To see if you encountered someone with COVID-19 prior to downloading this app, you can import your personal location history.
               </Text>
-            </View>
-            <View
-              accessible={true}
-              focusable={true}
-              isTVSelectable={true}
-              style={
-                Object {
-                  "alignItems": "center",
-                  "backgroundColor": "rgba(0, 0, 0, 0)",
-                  "borderColor": "#4051db",
-                  "borderRadius": 8,
-                  "borderWidth": 1,
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "paddingBottom": 25,
-                  "paddingTop": 24,
-                }
-              }
-            >
-              <Text
+              <View
                 style={
-                  Array [
-                    Object {
-                      "color": "#2e2e2e",
-                      "fontSize": 17,
-                      "lineHeight": 28,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "fontSize": 19,
-                      "fontWeight": "500",
-                    },
-                  ]
+                  Object {
+                    "marginVertical": 20,
+                  }
                 }
               >
-                Import past locations
-              </Text>
-            </View>
-            <View
-              style={
-                Object {
-                  "paddingVertical": 20,
-                }
-              }
-            >
+                <View
+                  accessibilityLabel="Import past locations"
+                  accessibilityRole="button"
+                  accessible={true}
+                  focusable={true}
+                  isTVSelectable={true}
+                  style={
+                    Object {
+                      "alignContent": "center",
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "borderBottomLeftRadius": 8,
+                      "borderBottomRightRadius": 8,
+                      "borderColor": "transparent",
+                      "borderStyle": "solid",
+                      "borderTopLeftRadius": 8,
+                      "borderTopRightRadius": 8,
+                      "borderWidth": 2,
+                      "flexDirection": "row",
+                      "height": 72,
+                      "justifyContent": "center",
+                      "opacity": 1,
+                      "paddingHorizontal": 16,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#2e2e2e",
+                          "fontSize": 17,
+                          "lineHeight": 28,
+                        },
+                        Object {
+                          "writingDirection": "ltr",
+                        },
+                        Object {
+                          "fontFamily": "IBMPlexSans-Medium",
+                          "fontSize": 20,
+                          "fontWeight": "normal",
+                          "lineHeight": 40,
+                        },
+                      ]
+                    }
+                  >
+                    Import past locations
+                  </Text>
+                </View>
+              </View>
               <Text
                 style={
                   Array [

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -22,6 +22,65 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
     <View
       style={
         Object {
+          "alignItems": "center",
+          "backgroundColor": "#1f2c9b",
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 3,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontSize": 17,
+                "lineHeight": 28,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "IBMPlexSans-Bold",
+                "fontSize": 19,
+                "fontWeight": "500",
+                "lineHeight": 40,
+              },
+            ]
+          }
+        >
+          More
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
           "backgroundColor": "#f8f8f8",
           "flex": 1,
         }
@@ -541,6 +600,65 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
       }
     }
   >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#1f2c9b",
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+          "paddingHorizontal": 16,
+          "paddingVertical": 8,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 3,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontSize": 17,
+                "lineHeight": 28,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#ffffff",
+                "fontFamily": "IBMPlexSans-Bold",
+                "fontSize": 19,
+                "fontWeight": "500",
+                "lineHeight": 40,
+              },
+            ]
+          }
+        >
+          More
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
     <View
       style={
         Object {

--- a/app/views/main/AllServicesOn.tsx
+++ b/app/views/main/AllServicesOn.tsx
@@ -12,15 +12,23 @@ import { styles } from './style';
 
 import { Colors } from '../../styles';
 
-export const AllServicesOnScreen = (): JSX.Element => {
+type AllServicesOnProps = {
+  noHaAvailable: boolean;
+};
+
+export const AllServicesOnScreen = ({
+  noHaAvailable,
+}: AllServicesOnProps): JSX.Element => {
   const {
     allServicesOnScreenHeader,
     allServicesOnScreenSubheader,
+    allServicesOnNoHaAvailableSubHeader,
   } = useAssets();
   const size = Dimensions.get('window').height;
 
   const allServicesOnScreenHeaderText: string = allServicesOnScreenHeader as string;
   const allServicesOnScreenSubheaderText: string = allServicesOnScreenSubheader as string;
+  const allServicesOnNoHaAvailableSubHeaderText: string = allServicesOnNoHaAvailableSubHeader as string;
 
   return (
     <Theme use='violet'>
@@ -59,6 +67,11 @@ export const AllServicesOnScreen = (): JSX.Element => {
             <Typography style={styles.subheaderText}>
               {allServicesOnScreenSubheaderText}
             </Typography>
+            {noHaAvailable && (
+              <Typography style={styles.subheaderText}>
+                {allServicesOnNoHaAvailableSubHeaderText}
+              </Typography>
+            )}
           </View>
         </View>
       </ImageBackground>

--- a/app/views/main/__tests__/__snapshots__/AllServicesOn.spec.js.snap
+++ b/app/views/main/__tests__/__snapshots__/AllServicesOn.spec.js.snap
@@ -162,7 +162,7 @@ exports[`all services on matches snapshot 1`] = `
             ]
           }
         >
-          PathCheck is privately saving the places you visit and comparing your locations to data from your local Health Department
+          PathCheck is saving the places you visit to create your private location diary
         </Text>
       </View>
     </View>


### PR DESCRIPTION
A lot of coupled styling changes, so a few different cosmetic updates are bundled here. 
Major changes:
- adds GPS flavors for the 'More info' screen for the calendar / exposure diary 
- Changes TouchableOpacities to TouchableHighlights where they were used on white background. This is a more accessible contrast on our listview buttons, and is now consistent across settings & ha selection pages.
- Changes the exposure diary stack to have a slide animation, for consistency on these flows. LMK if this was intentionally a modal fade style. The code this was based off of (export flow) used the modal / fade flow specifically for a 1 directional page transition flow / combining screens which are conceptually the _same_ screen states. Other stacks that allow going back in the app are using standard stack behaviors, so this is more consistent imo. 
- Standardizes About / Legal pages to our typography system, matches them to figma, and fixes linkable text to use onPress text, vs. wrapping in a toucahble. 
- Adds a specific GPS release state for the main page with no HAs selected, as no HAs will be available immediately. 

<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85169839-7c364480-b23a-11ea-974f-040b147d7583.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85169949-a6880200-b23a-11ea-96f2-90fc53e13dc4.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85170101-e51dbc80-b23a-11ea-9c83-bf90177898bf.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85170125-ed75f780-b23a-11ea-9b49-97c9ee8445ce.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85170144-f5359c00-b23a-11ea-85df-03ce59b8925b.png">
