### PR TITLE
changed app name from 'PathCheck BT' to 'PathCheck'

### DIFF
--- a/android/app/src/gps/res/values/strings.xml
+++ b/android/app/src/gps/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <!-- Shown on app info, app switcher, etc -->
-  <string name="app_name" translatable="false">PathCheck BT</string>
+  <string name="app_name" translatable="false">PathCheck</string>
   <!-- Shown below icon on launcher only -->
-  <string name="app_name_short" translatable="false">PathCheck BT</string>
+  <string name="app_name_short" translatable="false">PathCheck</string>
   <!-- Channel label for notifications shown in App > Notifications > Path Check BT -->
-  <string name="notification_channel_description">PathCheck BT notifications</string>
+  <string name="notification_channel_description">PathCheck notifications</string>
 </resources>


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
The GPS app was named "PathCheck BT".  I changed it to "Path Check"


#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
Fixes #1051 

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->
![image](https://user-images.githubusercontent.com/134657/85183935-b9f79500-b25b-11ea-8c33-bdbc6c144f01.png)


#### How to test:
<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
Go through the onboarding process and you will see the dialog above -- the 'BT' has been removed

