### PR TITLE
Download and unarchive key files (iOS only)

### DIFF
--- a/ios/BT/API/Requests/IndexFileRequests.swift
+++ b/ios/BT/API/Requests/IndexFileRequests.swift
@@ -14,7 +14,7 @@ enum IndexFileRequest: APIRequest {
   }
 
   var path: String {
-    "exposure-notification-export-svhfv/spl-be/index.txt"
+    "spl-be/index.txt"
   }
 
 }

--- a/ios/BT/Extensions/Foundation/Array+URLExtensions.swift
+++ b/ios/BT/Extensions/Foundation/Array+URLExtensions.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SSZipArchive
+
+extension Array where Element == URL {
+
+  func decompress(_ completion: @escaping (([URL]) -> Void)) {
+    var uncompressedFileUrls = [URL]()
+    for idx in (0..<count) {
+      let url = self[idx]
+
+      if let uncompressedUrl = APIClient.documentsDirectory?.appendingPathComponent("\(idx)"),
+        let filePath = URL(string: "\(uncompressedUrl.path)\(String.binPath)") {
+        SSZipArchive.unzipFile(atPath: url.path, toDestination: uncompressedUrl.path)
+
+        uncompressedFileUrls.append(filePath)
+      }
+      if idx == count - 1 {
+        completion(uncompressedFileUrls)
+      }
+    }
+
+  }
+
+  func cleanup() throws {
+    do {
+      try forEach { try FileManager.default.removeItem(at: $0) }
+    } catch {
+      throw GenericError.unknown
+    }
+  }
+
+}
+
+private extension String {
+  static let binPath: String = "/export.bin"
+}

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		B576CC4424993F5200CDD9D9 /* Encodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B576CC4024993F4C00CDD9D9 /* Encodable+Extensions.swift */; };
 		B596C0722488127D00943B79 /* PTCExposureManagerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B596C0712488127D00943B79 /* PTCExposureManagerModule.m */; };
 		B5E29D54249E3BE100E686DC /* ExposureManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E29D53249E3BE100E686DC /* ExposureManager+Extensions.swift */; };
+		B5E79437249E666B00BD8596 /* Array+URLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E79436249E666B00BD8596 /* Array+URLExtensions.swift */; };
 		B5FB3B43248BD61A001DB1D5 /* DebugMenuModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB3B42248BD61A001DB1D5 /* DebugMenuModule.m */; };
 		B5FBB0BD2490339900433980 /* DiagnosisKeyUrlRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FBB0BC2490339900433980 /* DiagnosisKeyUrlRequests.swift */; };
 		B5FBB0CF24916A4C00433980 /* DebugAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FBB0CE24916A4C00433980 /* DebugAction.swift */; };
@@ -333,6 +334,7 @@
 		B596C0712488127D00943B79 /* PTCExposureManagerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PTCExposureManagerModule.m; sourceTree = "<group>"; };
 		B5C490A72498F84000588A5F /* Region.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
 		B5E29D53249E3BE100E686DC /* ExposureManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExposureManager+Extensions.swift"; sourceTree = "<group>"; };
+		B5E79436249E666B00BD8596 /* Array+URLExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+URLExtensions.swift"; sourceTree = "<group>"; };
 		B5FB3B42248BD61A001DB1D5 /* DebugMenuModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DebugMenuModule.m; sourceTree = "<group>"; };
 		B5FBB0BC2490339900433980 /* DiagnosisKeyUrlRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosisKeyUrlRequests.swift; sourceTree = "<group>"; };
 		B5FBB0CE24916A4C00433980 /* DebugAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugAction.swift; sourceTree = "<group>"; };
@@ -737,6 +739,7 @@
 			isa = PBXGroup;
 			children = (
 				B5FBB0D224916B3600433980 /* String+Extensions.swift */,
+				B5E79436249E666B00BD8596 /* Array+URLExtensions.swift */,
 				B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */,
 				B576CC4024993F4C00CDD9D9 /* Encodable+Extensions.swift */,
 				B5FBB0D624916DE100433980 /* Notification+Extensions.swift */,
@@ -1374,6 +1377,7 @@
 				B5FC37E1248A7EED006474EB /* ExposureConfigurationRequests.swift in Sources */,
 				B5FC37DD248A78D2006474EB /* ExposureKey.swift in Sources */,
 				B5FC37DF248A78FC006474EB /* ExposureConfiguration.swift in Sources */,
+				B5E79437249E666B00BD8596 /* Array+URLExtensions.swift in Sources */,
 				B5FC37CA2489B1C1006474EB /* JSON.swift in Sources */,
 				B5FC37D02489B3DE006474EB /* StructuredError.swift in Sources */,
 			);

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -58,6 +58,7 @@ def bt_pods
   permissions_path = '../node_modules/react-native-permissions/ios'
   pod 'Permission-LocationAlways', :path => "#{permissions_path}/LocationAlways.podspec"
   pod 'Alamofire', '~> 4.9.1'
+  pod 'SSZipArchive'
 end
 
 target 'GPS' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -343,6 +343,7 @@ DEPENDENCIES:
   - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNZipArchive (from `../node_modules/react-native-zip-archive`)
+  - SSZipArchive
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:


### PR DESCRIPTION
### Why
We'd like to download and unarchive exposure keys from the `GAEN` server

### This Commit
This commit creates infrastructure to fetch archives from the `GAEN` server, and unarchive each one in order to submit them to the `Exposure Notifications` framework 

** Note: the `Exposure Notifications` framework will error out because the keys are currently unsigned. In order to complete the end-to-end flow, the `GAEN` server must return signed keys 