### PR TITLE
Introduce tracing strategy provider

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import Config from 'react-native-config';
 import { MenuProvider } from 'react-native-popup-menu';
 import SplashScreen from 'react-native-splash-screen';
 import { Provider } from 'react-redux';
@@ -6,25 +7,37 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 import { Theme } from './app/constants/themes';
 import { Entry } from './app/Entry';
-import { ExposureNotificationsProvider } from './app/ExposureNotificationContext';
-import { ExposureHistoryProvider } from './app/ExposureHistoryContext';
+import { TracingStrategyProvider } from './app/TracingStrategyContext';
 import { FlagsProvider } from './app/helpers/Flags';
-import { PermissionsProvider } from './app/PermissionsContext';
 import VersionCheckService from './app/services/VersionCheckService';
 import { store, persistor } from './app/store';
+import btStrategy from './app/bt';
+import gpsStrategy from './app/gps';
+
+const determineTracingStrategy = () => {
+  switch (Config.TRACING_STRATEGY) {
+    case 'gps': {
+      return gpsStrategy;
+    }
+    case 'bt': {
+      return btStrategy;
+    }
+    default: {
+      throw new Error('Unsupported Tracing Strategy');
+    }
+  }
+};
+
+const strategy = determineTracingStrategy();
 
 // For snapshot testing. In tests, we provide a mock store wrapper if needed.
 export const UnconnectedApp = () => (
   <FlagsProvider>
     <MenuProvider>
       <Theme use='default'>
-        <PermissionsProvider>
-          <ExposureNotificationsProvider>
-            <ExposureHistoryProvider>
-              <Entry />
-            </ExposureHistoryProvider>
-          </ExposureNotificationsProvider>
-        </PermissionsProvider>
+        <TracingStrategyProvider strategy={strategy}>
+          <Entry />
+        </TracingStrategyProvider>
       </Theme>
     </MenuProvider>
   </FlagsProvider>

--- a/app/TracingStrategyContext.spec.tsx
+++ b/app/TracingStrategyContext.spec.tsx
@@ -1,0 +1,61 @@
+import React, { useContext } from 'react';
+import { View, Text } from 'react-native';
+import { render, cleanup } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import TracingStrategyContext, {
+  TracingStrategyProvider,
+} from './TracingStrategyContext';
+import { TracingStrategy } from './tracingStrategy';
+
+afterEach(cleanup);
+
+const renderTracingStrategyProvider = (strategy: TracingStrategy) => {
+  const TestTracingStrategyConsumer = () => {
+    const { name } = useContext(TracingStrategyContext);
+    return (
+      <View>
+        <Text testID={'tracing-strategy-name'}>{name}</Text>
+      </View>
+    );
+  };
+
+  return render(
+    <TracingStrategyProvider strategy={strategy}>
+      <TestTracingStrategyConsumer />
+    </TracingStrategyProvider>,
+  );
+};
+
+describe('TracingStrategyProvider', () => {
+  describe('when given a tracing strategy with a permissions provider, expsoureInfo subscription, and a name', () => {
+    it('renders with the correct name, mounts the permssions provider, and subscribes to the exspousre info events', async () => {
+      const removeSubscriptionMock = jest.fn();
+      const FakePermissionsProvider = ({
+        children,
+      }: {
+        children: JSX.Element;
+      }): JSX.Element => {
+        return <View testID={'fake-permissions-provider'}>{children}</View>;
+      };
+
+      const strategy: TracingStrategy = {
+        name: 'test-strategy',
+        exposureInfoSubscription: () => {
+          return { remove: removeSubscriptionMock };
+        },
+        permissionsProvider: FakePermissionsProvider,
+      };
+
+      const { getByTestId, unmount } = renderTracingStrategyProvider(strategy);
+
+      const name = getByTestId('tracing-strategy-name');
+      const permissionsProvider = getByTestId('fake-permissions-provider');
+
+      expect(name).toHaveTextContent('test-strategy');
+      expect(permissionsProvider).toBeTruthy();
+      unmount();
+      expect(removeSubscriptionMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/TracingStrategyContext.tsx
+++ b/app/TracingStrategyContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext } from 'react';
+import { TracingStrategy } from './tracingStrategy';
+import { ExposureHistoryProvider } from './ExposureHistoryContext';
+
+interface TracingStrategyContextState {
+  name: string;
+}
+
+const defaultState = {
+  name: 'initializingTracingStrategy',
+};
+
+const TracingStrategyContext = createContext<TracingStrategyContextState>(
+  defaultState,
+);
+
+interface TracingStrategyProps {
+  children: JSX.Element;
+  strategy: TracingStrategy;
+}
+
+const TracingStrategyProvider = ({
+  children,
+  strategy,
+}: TracingStrategyProps): JSX.Element => {
+  const StrategyPermissionsProvider = strategy.permissionsProvider;
+
+  return (
+    <TracingStrategyContext.Provider
+      value={{
+        name: strategy.name,
+      }}>
+      <StrategyPermissionsProvider>
+        <ExposureHistoryProvider
+          exposureInfoSubscription={strategy.exposureInfoSubscription}>
+          {children}
+        </ExposureHistoryProvider>
+      </StrategyPermissionsProvider>
+    </TracingStrategyContext.Provider>
+  );
+};
+
+export { TracingStrategyProvider };
+export default TracingStrategyContext;

--- a/app/bt/ExposureNotificationContext.tsx
+++ b/app/bt/ExposureNotificationContext.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useState, useEffect } from 'react';
 
-import { isGPS } from './COVIDSafePathsConfig';
-import { BTNativeModule } from './bt';
+import * as BTNativeModule from './nativeModule';
 
 type Enablement = `DISABLED` | `ENABLED`;
 type Authorization = `UNAUTHORIZED` | `AUTHORIZED`;
@@ -36,19 +35,15 @@ const ExposureNotificationsProvider = ({
   );
 
   useEffect(() => {
-    if (!isGPS) {
-      const subscription = BTNativeModule.subscribeToEnabledStatusEvents(
-        (status: DeviceStatus) => {
-          setAuthorizationStatus(status);
-        },
-      );
+    const subscription = BTNativeModule.subscribeToEnabledStatusEvents(
+      (status: DeviceStatus) => {
+        setAuthorizationStatus(status);
+      },
+    );
 
-      return () => {
-        subscription?.remove();
-      };
-    } else {
-      return () => {};
-    }
+    return () => {
+      subscription?.remove();
+    };
   }, []);
 
   const requestENAuthorization = () => {

--- a/app/bt/index.ts
+++ b/app/bt/index.ts
@@ -1,3 +1,12 @@
+import { TracingStrategy } from '../tracingStrategy';
 import * as BTNativeModule from './nativeModule';
+import { ExposureNotificationsProvider } from './ExposureNotificationContext';
+
+const btStrategy: TracingStrategy = {
+  name: 'bt',
+  exposureInfoSubscription: BTNativeModule.subscribeToExposureEvents,
+  permissionsProvider: ExposureNotificationsProvider,
+};
 
 export { BTNativeModule };
+export default btStrategy;

--- a/app/bt/nativeModule.ts
+++ b/app/bt/nativeModule.ts
@@ -4,7 +4,7 @@ import {
   EventSubscription,
 } from 'react-native';
 
-import { DeviceStatus } from '../ExposureNotificationContext';
+import { DeviceStatus } from './ExposureNotificationContext';
 import { ExposureInfo } from '../exposureHistory';
 import { ENDiagnosisKey } from '../views/Settings/ENLocalDiagnosisKeyScreen';
 import { RawExposure, toExposureInfo } from './exposureNotifications';

--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -9,8 +9,7 @@ import {
   Permission,
 } from 'react-native-permissions';
 
-import { isGPS } from './COVIDSafePathsConfig';
-import { HCAService } from './services/HCAService.js';
+import { HCAService } from '../services/HCAService.js';
 
 export enum PermissionStatus {
   UNKNOWN,
@@ -96,7 +95,7 @@ const PermissionsProvider = ({
       const isiOS = Platform.OS === 'ios';
       const isDev = __DEV__;
       await Promise.all([
-        isGPS ? checkLocationPermission() : null,
+        checkLocationPermission(),
         isiOS ? checkNotificationPermission() : null,
         // TODO(https://pathcheck.atlassian.net/browse/SAF-232): Put HCA auto sub logic behind a feature flag
         isDev && isiOS ? checkAuthSubscriptionPermission() : null,

--- a/app/gps/index.ts
+++ b/app/gps/index.ts
@@ -1,0 +1,14 @@
+import { TracingStrategy } from '../tracingStrategy';
+import { PermissionsProvider } from './PermissionsContext';
+
+const gpsStrategy: TracingStrategy = {
+  name: 'bt',
+  exposureInfoSubscription: () => {
+    return {
+      remove: () => {},
+    };
+  },
+  permissionsProvider: PermissionsProvider,
+};
+
+export default gpsStrategy;

--- a/app/tracingStrategy.ts
+++ b/app/tracingStrategy.ts
@@ -1,0 +1,7 @@
+import { ExposureInfoSubscription } from './ExposureHistoryContext';
+
+export interface TracingStrategy {
+  name: string;
+  exposureInfoSubscription: ExposureInfoSubscription;
+  permissionsProvider: ({ children }: { children: JSX.Element }) => JSX.Element;
+}

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -13,7 +13,9 @@ import {
   NotificationsOffScreen,
   // SelectAuthorityScreen,
 } from './main/ServiceOffScreens';
-import PermissionsContext, { PermissionStatus } from '../PermissionsContext';
+import PermissionsContext, {
+  PermissionStatus,
+} from '../gps/PermissionsContext';
 
 import { useSelector } from 'react-redux';
 import selectedHealthcareAuthoritiesSelector from '../store/selectors/selectedHealthcareAuthoritiesSelector';

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -11,7 +11,7 @@ import { SvgXml } from 'react-native-svg';
 
 import { Typography } from '../../components/Typography';
 import { Theme } from '../../constants/themes';
-import ExposureNotificationContext from '../../ExposureNotificationContext';
+import ExposureNotificationContext from '../../bt/ExposureNotificationContext';
 import { useDispatch } from 'react-redux';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
 

--- a/app/views/onboarding/OnboardingPermissions.js
+++ b/app/views/onboarding/OnboardingPermissions.js
@@ -15,7 +15,9 @@ import { PARTICIPATE } from '../../constants/storage';
 import { Theme } from '../../constants/themes';
 import { SetStoreData } from '../../helpers/General';
 import languages from '../../locales/languages';
-import PermissionsContext, { PermissionStatus } from '../../PermissionsContext';
+import PermissionsContext, {
+  PermissionStatus,
+} from '../../gps/PermissionsContext';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
 
 import { sharedStyles } from './styles';

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@babel/runtime": "^7.8.4",
     "@jumpn/react-native-jetifier": "^0.1.4",
     "@react-native-community/eslint-config": "^0.0.7",
+    "@testing-library/jest-native": "^3.1.0",
     "@testing-library/react-native": "^5.0.3",
     "@types/jest": "^25.2.3",
     "@types/react": "^16.9.35",
@@ -152,7 +153,7 @@
     "prettier": "^2.0.5",
     "react-native-svg-transformer": "^0.14.3",
     "react-native-version": "^4.0.0",
-    "react-test-renderer": "16.9.0",
+    "react-test-renderer": "^16.13.1",
     "typescript": "^3.9.3"
   },
   "importSort": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,9 +1271,22 @@
     merge-deep "^3.0.2"
     svgo "^1.2.2"
 
+"@testing-library/jest-native@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-3.1.0.tgz#414c834dfb524ca82b86509d5479e365d4d5bbec"
+  integrity sha512-MZdsTsD6xrP5V0FTz2gVPG00ZMoKn4WniRitUH40zZTQ0DfMa5CVDpkAd5ed6qX1coDwS8vSCZS/JGMIDYjRQQ==
+  dependencies:
+    chalk "^2.4.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    pretty-format "^24.0.0"
+    ramda "^0.26.1"
+    redent "^2.0.0"
+
 "@testing-library/react-native@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-5.0.3.tgz#8821dcf7fe7364bc7f427d853cd96e4407d88a4f"
+  integrity sha512-lQH7vUgwESfagFw4BlKsfpX7Rv/m7h2NYfubY0aoQromSwI1slCxrhwZws8gABTXweob/DyLATsOamHsWdwDnA==
   dependencies:
     pretty-format "^24.9.0"
     wait-for-expect "^3.0.0"
@@ -1416,6 +1429,7 @@
 "@types/react-test-renderer@^16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
+  integrity sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
   dependencies:
     "@types/react" "*"
 
@@ -3039,6 +3053,11 @@ diagnostics@1.0.x:
 didyoumean@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
+
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -4911,6 +4930,16 @@ jest-config@^25.5.4:
     pretty-format "^25.5.0"
     realpath-native "^2.0.0"
 
+jest-diff@^24.0.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^25.2.1, jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -5035,6 +5064,16 @@ jest-leak-detector@^25.5.0:
   dependencies:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-matcher-utils@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-matcher-utils@^25.5.0:
   version "25.5.0"
@@ -6925,7 +6964,7 @@ prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
 
-pretty-format@^24.7.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   dependencies:
@@ -7064,6 +7103,11 @@ ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
 
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -7086,7 +7130,7 @@ react-i18next@^11.4.0:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
 
@@ -7295,14 +7339,15 @@ react-refresh@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.2.tgz#54a277a6caaac2803d88f1d6f13c1dcfbd81e334"
 
-react-test-renderer@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
+react-test-renderer@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
+  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    react-is "^16.9.0"
-    scheduler "^0.15.0"
+    react-is "^16.8.6"
+    scheduler "^0.19.1"
 
 react@16.9.0:
   version "16.9.0"
@@ -7769,9 +7814,17 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@0.15.0, scheduler@^0.15.0:
+scheduler@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Why:
Currently we do not have much protection against one version of the app
accessing functionality intended to only be used another version. For
example, in the BT build of the app, any component could request
location permissions, which would cause the app to error. Given that
situations like these could be grounds for violating compliance, we
would like to introduce a better strategy for providing tracing strategy
specific logic and functionality.

Additionally, the application has many conditional checks of the tracing
strategy scattered throughout the code base (`isGPS` and `!isGPS`). This
is prone to human error, is likely to be forgotten, and introduces
significant cognitive noise while reading the implementation of a
feature. Given that near term product goals include introducing more
tracing strategies, this is also prime for a combinatoric explosion of
complexity. We would like to reduce the number of sites in which we need
to be conditionally checking the tracing strategy, ideally to only one.

This commit:
Introduces the concept of a TracingStrategy as an interface, which can
be used as the common schema to which all tracing strategies can be
built against. And which UI application code can rely on to provide a
functional user interface for that tracing strategy.

We check the tracing strategy in the root App component and provide the
strategy specific functionality to the rest of the application via a
context. This removes the need of child components to need to check the
current strategy and makes it inconvenient and unlikely for a child
component to access functionality belonging to a different strategy.

Note that this commit does not remove every instance of isGPS from the
code base to reduce the size of this commit. Future commits should
include introducing the strategy specific content, assets, and routes to
the tracing strategy interface.

Finally by having a notion of a TracingStrategy in the type system it
becomes significantly easier to reason about the portions of the which
are different between the strategies and ideally we will be able to keep
the interface as small as possible to maximize the amount of common code
between the strategies.

