### PR TITLE
Export Template | StatusBar Hook

### DIFF
--- a/app/views/Export/ExportTemplate.js
+++ b/app/views/Export/ExportTemplate.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import {
   ScrollView,
-  StatusBar,
   StyleSheet,
   View,
   TouchableOpacity,
@@ -18,19 +17,11 @@ import { Theme } from '../../constants/themes';
 
 import { Icons } from '../../assets';
 import { Colors, Typography as TypographyStyles } from '../../styles';
+import { useStatusBarEffect } from '../../navigation';
 
 const BackgroundContainer = ({ lightTheme, children }) => {
   if (lightTheme) {
-    return (
-      <View style={styles.container}>
-        <StatusBar
-          barStyle={'dark-content'}
-          backgroundColor={Colors.faintGray}
-          translucent={false}
-        />
-        {children}
-      </View>
-    );
+    return <View style={styles.container}>{children}</View>;
   }
   return (
     <LinearGradient
@@ -38,11 +29,6 @@ const BackgroundContainer = ({ lightTheme, children }) => {
       end={{ x: 0, y: 1 }}
       colors={[Colors.secondaryBlue, Colors.primaryBlue]}
       style={styles.container}>
-      <StatusBar
-        barStyle={'light-content'}
-        backgroundColor={Colors.secondaryBlue}
-        translucent={false}
-      />
       {children}
     </LinearGradient>
   );
@@ -65,6 +51,7 @@ export const ExportTemplate = ({
   bodyLinkOnPress,
   ignoreModalStyling, // So first screen can be slightly different in tabs
 }) => {
+  useStatusBarEffect(lightTheme ? 'dark-content' : 'light-content');
   useEffect(() => {
     function handleBackPress() {
       onClose();


### PR DESCRIPTION
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85298133-b3db0180-b471-11ea-82d7-7a4de7693ecd.png">

`useStatusBarEffect` for export template, so that switching tabs doesn't overwrite status bar state (now that the first screen is a tab this matters). 