### PR TITLE
Add accessibilityRole for checkbox component

### DIFF
--- a/app/components/Checkbox.js
+++ b/app/components/Checkbox.js
@@ -12,6 +12,7 @@ export const Checkbox = ({ label, onPress, checked }) => {
       style={styles.checkbox}
       onPress={onPress}
       accessible
+      accessibilityRole={'checkbox'}
       accessibilityLabel={label}>
       <Image
         source={checked ? Images.BoxCheckedIcon : Images.BoxUncheckedIcon}

--- a/app/components/Checkbox.js
+++ b/app/components/Checkbox.js
@@ -12,7 +12,7 @@ export const Checkbox = ({ label, onPress, checked }) => {
       style={styles.checkbox}
       onPress={onPress}
       accessible
-      accessibilityRole={'checkbox'}
+      accessibilityRole='checkbox'
       accessibilityLabel={label}>
       <Image
         source={checked ? Images.BoxCheckedIcon : Images.BoxUncheckedIcon}


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
There was no accessibilityRole defined for the checkbox component, so that Voiceover did not announce that a checkbox was there -- this was added

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
Fixes #1085 

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
Use AccessibilityInspector. In EULA onboarding screen, when you click on the checkbox you should see "checkbox" in the value field in the AccessibilityInspector