### PR TITLE
Main Screen | Small Screen Fixes

### DIFF
--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -61,7 +61,6 @@ const ExposureDatumIndicator = ({
         {
           ...circleStyle,
         },
-
         {
           ...textStyle,
           fontWeight: Typography.heaviestWeight,

--- a/app/views/main/AllServicesOn.tsx
+++ b/app/views/main/AllServicesOn.tsx
@@ -57,24 +57,24 @@ export const AllServicesOnScreen = ({
             height={size ? size : 80}
           />
         </View>
-
-        <View style={styles.mainContainer}>
-          <View style={styles.contentAbovePulse} />
-          <View style={styles.contentBelowPulse}>
-            <Typography style={styles.mainTextBelow}>
-              {allServicesOnScreenHeaderText}
-            </Typography>
-            <Typography style={styles.subheaderText}>
-              {allServicesOnScreenSubheaderText}
-            </Typography>
-            {noHaAvailable && (
-              <Typography style={styles.subheaderText}>
-                {allServicesOnNoHaAvailableSubHeaderText}
-              </Typography>
-            )}
-          </View>
-        </View>
       </ImageBackground>
+
+      <View style={styles.mainContainer}>
+        <View style={styles.contentAbovePulse} />
+        <View style={styles.contentBelowPulse}>
+          <Typography style={styles.mainTextBelow}>
+            {allServicesOnScreenHeaderText}
+          </Typography>
+          <Typography style={styles.subheaderText}>
+            {allServicesOnScreenSubheaderText}
+          </Typography>
+          {noHaAvailable && (
+            <Typography style={styles.subheaderText}>
+              {allServicesOnNoHaAvailableSubHeaderText}
+            </Typography>
+          )}
+        </View>
+      </View>
     </Theme>
   );
 };

--- a/app/views/main/ServiceOffScreens/Base.tsx
+++ b/app/views/main/ServiceOffScreens/Base.tsx
@@ -48,24 +48,22 @@ export const ServiceOffScreen = ({
             height={size ? size : 80}
           />
         </View>
-
-        <View style={styles.mainContainer}>
-          <View style={styles.contentAbovePulse} />
-          <View style={styles.contentBelowPulse}>
-            <Text style={styles.mainTextBelow}>{header}</Text>
-            <Typography style={styles.subheaderText}>
-              {subheaderText}
-            </Typography>
-            {button && (
-              <Button
-                label={button.label}
-                onPress={button.onPress}
-                style={styles.buttonContainer}
-              />
-            )}
-          </View>
-        </View>
       </ImageBackground>
+
+      <View style={styles.mainContainer}>
+        <View style={styles.contentAbovePulse} />
+        <View style={styles.contentBelowPulse}>
+          <Text style={styles.mainTextBelow}>{header}</Text>
+          <Typography style={styles.subheaderText}>{subheaderText}</Typography>
+          {button && (
+            <Button
+              label={button.label}
+              onPress={button.onPress}
+              style={styles.buttonContainer}
+            />
+          )}
+        </View>
+      </View>
     </Theme>
   );
 };

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/ExposureNotificationNotAvailable.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/ExposureNotificationNotAvailable.spec.js.snap
@@ -15,9 +15,10 @@ exports[`exposure notifications not available screen matches snapshot 1`] = `
     style={
       Object {
         "flex": 1,
-        "height": "100%",
+        "height": "110%",
         "justifyContent": "flex-end",
         "resizeMode": "cover",
+        "top": 0,
         "width": "100%",
       }
     }
@@ -38,7 +39,7 @@ exports[`exposure notifications not available screen matches snapshot 1`] = `
             "top": 0,
           },
           Object {
-            "height": "100%",
+            "height": "110%",
             "width": "100%",
           },
           undefined,
@@ -83,78 +84,78 @@ exports[`exposure notifications not available screen matches snapshot 1`] = `
 </svg>"
       />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "paddingBottom": 12,
+        "paddingHorizontal": 24,
+        "position": "absolute",
+        "right": 0,
+        "top": "-10%",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "height": "100%",
-          "left": 0,
-          "paddingBottom": 12,
-          "paddingHorizontal": "12%",
-          "position": "absolute",
-          "right": 0,
-          "top": "-10%",
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "paddingBottom": 40,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-start",
+          "paddingTop": 80,
         }
       }
     >
-      <View
+      <Text
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-end",
-            "paddingBottom": 40,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-start",
-            "paddingTop": 80,
+            "color": "#ffffff",
+            "fontFamily": "IBMPlexSans-Medium",
+            "fontSize": 26,
+            "lineHeight": 34,
+            "marginBottom": 24,
+            "textAlign": "center",
           }
         }
       >
-        <Text
-          style={
+        Exposure history notifications are not yet available
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
             Object {
               "color": "#ffffff",
-              "fontFamily": "IBMPlexSans-Medium",
-              "fontSize": 26,
-              "lineHeight": 34,
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "lineHeight": 24.5,
               "marginBottom": 24,
               "textAlign": "center",
-            }
-          }
-        >
-          Exposure history notifications are not yet available
-        </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontSize": 17,
-                "lineHeight": 28,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 18,
-                "lineHeight": 24.5,
-                "marginBottom": 24,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          Your phone is not currently covered by Healthcare Authorities using PathCheck
-        </Text>
-      </View>
+            },
+          ]
+        }
+      >
+        Your phone is not currently covered by Healthcare Authorities using PathCheck
+      </Text>
     </View>
   </View>
 </View>

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NoAuthorities.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NoAuthorities.spec.js.snap
@@ -15,9 +15,10 @@ exports[`no authorities screen matches snapshot 1`] = `
     style={
       Object {
         "flex": 1,
-        "height": "100%",
+        "height": "110%",
         "justifyContent": "flex-end",
         "resizeMode": "cover",
+        "top": 0,
         "width": "100%",
       }
     }
@@ -38,7 +39,7 @@ exports[`no authorities screen matches snapshot 1`] = `
             "top": 0,
           },
           Object {
-            "height": "100%",
+            "height": "110%",
             "width": "100%",
           },
           undefined,
@@ -83,80 +84,80 @@ exports[`no authorities screen matches snapshot 1`] = `
 </svg>"
       />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "paddingBottom": 12,
+        "paddingHorizontal": 24,
+        "position": "absolute",
+        "right": 0,
+        "top": "-10%",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "height": "100%",
-          "left": 0,
-          "paddingBottom": 12,
-          "paddingHorizontal": "12%",
-          "position": "absolute",
-          "right": 0,
-          "top": "-10%",
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "paddingBottom": 40,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-start",
+          "paddingTop": 80,
         }
       }
     >
-      <View
+      <Text
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-end",
-            "paddingBottom": 40,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-start",
-            "paddingTop": 80,
+            "color": "#ffffff",
+            "fontFamily": "IBMPlexSans-Medium",
+            "fontSize": 26,
+            "lineHeight": 34,
+            "marginBottom": 24,
+            "textAlign": "center",
           }
         }
       >
-        <Text
-          style={
+        No local Health Department
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
             Object {
               "color": "#ffffff",
-              "fontFamily": "IBMPlexSans-Medium",
-              "fontSize": 26,
-              "lineHeight": 34,
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "lineHeight": 24.5,
               "marginBottom": 24,
               "textAlign": "center",
-            }
-          }
-        >
-          No local Health Department
-        </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontSize": 17,
-                "lineHeight": 28,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 18,
-                "lineHeight": 24.5,
-                "marginBottom": 24,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          Your phone is outside any areas covered by Health Department on PathCheck 
+            },
+          ]
+        }
+      >
+        Your phone is outside any areas covered by Health Department on PathCheck 
 
  You will be notified when Health Departments are added near you
-        </Text>
-      </View>
+      </Text>
     </View>
   </View>
 </View>

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NotificationsOff.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NotificationsOff.spec.js.snap
@@ -15,9 +15,10 @@ exports[`notifications off screen matches snapshot 1`] = `
     style={
       Object {
         "flex": 1,
-        "height": "100%",
+        "height": "110%",
         "justifyContent": "flex-end",
         "resizeMode": "cover",
+        "top": 0,
         "width": "100%",
       }
     }
@@ -38,7 +39,7 @@ exports[`notifications off screen matches snapshot 1`] = `
             "top": 0,
           },
           Object {
-            "height": "100%",
+            "height": "110%",
             "width": "100%",
           },
           undefined,
@@ -83,53 +84,106 @@ exports[`notifications off screen matches snapshot 1`] = `
 </svg>"
       />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "paddingBottom": 12,
+        "paddingHorizontal": 24,
+        "position": "absolute",
+        "right": 0,
+        "top": "-10%",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "height": "100%",
-          "left": 0,
-          "paddingBottom": 12,
-          "paddingHorizontal": "12%",
-          "position": "absolute",
-          "right": 0,
-          "top": "-10%",
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "paddingBottom": 40,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-start",
+          "paddingTop": 80,
         }
       }
     >
-      <View
+      <Text
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-end",
-            "paddingBottom": 40,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-start",
-            "paddingTop": 80,
+            "color": "#ffffff",
+            "fontFamily": "IBMPlexSans-Medium",
+            "fontSize": 26,
+            "lineHeight": 34,
+            "marginBottom": 24,
+            "textAlign": "center",
           }
         }
       >
-        <Text
-          style={
+        Notifications Disabled
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
             Object {
               "color": "#ffffff",
-              "fontFamily": "IBMPlexSans-Medium",
-              "fontSize": 26,
-              "lineHeight": 34,
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "lineHeight": 24.5,
               "marginBottom": 24,
               "textAlign": "center",
-            }
+            },
+          ]
+        }
+      >
+        You will not receive notifications about possible exposures nor when new Health Departments are added in your area
+      </Text>
+      <View
+        accessibilityLabel="Allow Notifications"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        isTVSelectable={true}
+        style={
+          Object {
+            "alignContent": "center",
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#ffffff",
+            "borderBottomLeftRadius": 8,
+            "borderBottomRightRadius": 8,
+            "borderColor": "transparent",
+            "borderStyle": "solid",
+            "borderTopLeftRadius": 8,
+            "borderTopRightRadius": 8,
+            "borderWidth": 2,
+            "flexDirection": "row",
+            "height": 54,
+            "justifyContent": "center",
+            "marginTop": 24,
+            "opacity": 1,
+            "paddingHorizontal": 16,
           }
-        >
-          Notifications Disabled
-        </Text>
+        }
+      >
         <Text
           style={
             Array [
@@ -142,70 +196,17 @@ exports[`notifications off screen matches snapshot 1`] = `
                 "writingDirection": "ltr",
               },
               Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 18,
-                "lineHeight": 24.5,
-                "marginBottom": 24,
-                "textAlign": "center",
+                "color": "#1f2c9b",
+                "fontFamily": "IBMPlexSans-Medium",
+                "fontSize": 20,
+                "fontWeight": "normal",
+                "lineHeight": 40,
               },
             ]
           }
         >
-          You will not receive notifications about possible exposures nor when new Health Departments are added in your area
+          Allow Notifications
         </Text>
-        <View
-          accessibilityLabel="Allow Notifications"
-          accessibilityRole="button"
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "alignContent": "center",
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "backgroundColor": "#ffffff",
-              "borderBottomLeftRadius": 8,
-              "borderBottomRightRadius": 8,
-              "borderColor": "transparent",
-              "borderStyle": "solid",
-              "borderTopLeftRadius": 8,
-              "borderTopRightRadius": 8,
-              "borderWidth": 2,
-              "flexDirection": "row",
-              "height": 54,
-              "justifyContent": "center",
-              "marginTop": 24,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontSize": 17,
-                  "lineHeight": 28,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#1f2c9b",
-                  "fontFamily": "IBMPlexSans-Medium",
-                  "fontSize": 20,
-                  "fontWeight": "normal",
-                  "lineHeight": 40,
-                },
-              ]
-            }
-          >
-            Allow Notifications
-          </Text>
-        </View>
       </View>
     </View>
   </View>

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/SelectAuthority.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/SelectAuthority.spec.js.snap
@@ -15,9 +15,10 @@ exports[`select authority screen matches snapshot 1`] = `
     style={
       Object {
         "flex": 1,
-        "height": "100%",
+        "height": "110%",
         "justifyContent": "flex-end",
         "resizeMode": "cover",
+        "top": 0,
         "width": "100%",
       }
     }
@@ -38,7 +39,7 @@ exports[`select authority screen matches snapshot 1`] = `
             "top": 0,
           },
           Object {
-            "height": "100%",
+            "height": "110%",
             "width": "100%",
           },
           undefined,
@@ -83,53 +84,106 @@ exports[`select authority screen matches snapshot 1`] = `
 </svg>"
       />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "paddingBottom": 12,
+        "paddingHorizontal": 24,
+        "position": "absolute",
+        "right": 0,
+        "top": "-10%",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "height": "100%",
-          "left": 0,
-          "paddingBottom": 12,
-          "paddingHorizontal": "12%",
-          "position": "absolute",
-          "right": 0,
-          "top": "-10%",
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "paddingBottom": 40,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-start",
+          "paddingTop": 80,
         }
       }
     >
-      <View
+      <Text
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-end",
-            "paddingBottom": 40,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-start",
-            "paddingTop": 80,
+            "color": "#ffffff",
+            "fontFamily": "IBMPlexSans-Medium",
+            "fontSize": 26,
+            "lineHeight": 34,
+            "marginBottom": 24,
+            "textAlign": "center",
           }
         }
       >
-        <Text
-          style={
+        No local Health Department Selected
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
             Object {
               "color": "#ffffff",
-              "fontFamily": "IBMPlexSans-Medium",
-              "fontSize": 26,
-              "lineHeight": 34,
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "lineHeight": 24.5,
               "marginBottom": 24,
               "textAlign": "center",
-            }
+            },
+          ]
+        }
+      >
+        Allow PathCheck to add your local Health Department or select one yourself to receive info about COVID-19 in your area
+      </Text>
+      <View
+        accessibilityLabel="Add Health Department"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        isTVSelectable={true}
+        style={
+          Object {
+            "alignContent": "center",
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#ffffff",
+            "borderBottomLeftRadius": 8,
+            "borderBottomRightRadius": 8,
+            "borderColor": "transparent",
+            "borderStyle": "solid",
+            "borderTopLeftRadius": 8,
+            "borderTopRightRadius": 8,
+            "borderWidth": 2,
+            "flexDirection": "row",
+            "height": 54,
+            "justifyContent": "center",
+            "marginTop": 24,
+            "opacity": 1,
+            "paddingHorizontal": 16,
           }
-        >
-          No local Health Department Selected
-        </Text>
+        }
+      >
         <Text
           style={
             Array [
@@ -142,70 +196,17 @@ exports[`select authority screen matches snapshot 1`] = `
                 "writingDirection": "ltr",
               },
               Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 18,
-                "lineHeight": 24.5,
-                "marginBottom": 24,
-                "textAlign": "center",
+                "color": "#1f2c9b",
+                "fontFamily": "IBMPlexSans-Medium",
+                "fontSize": 20,
+                "fontWeight": "normal",
+                "lineHeight": 40,
               },
             ]
           }
         >
-          Allow PathCheck to add your local Health Department or select one yourself to receive info about COVID-19 in your area
+          Add Health Department
         </Text>
-        <View
-          accessibilityLabel="Add Health Department"
-          accessibilityRole="button"
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "alignContent": "center",
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "backgroundColor": "#ffffff",
-              "borderBottomLeftRadius": 8,
-              "borderBottomRightRadius": 8,
-              "borderColor": "transparent",
-              "borderStyle": "solid",
-              "borderTopLeftRadius": 8,
-              "borderTopRightRadius": 8,
-              "borderWidth": 2,
-              "flexDirection": "row",
-              "height": 54,
-              "justifyContent": "center",
-              "marginTop": 24,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontSize": 17,
-                  "lineHeight": 28,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#1f2c9b",
-                  "fontFamily": "IBMPlexSans-Medium",
-                  "fontSize": 20,
-                  "fontWeight": "normal",
-                  "lineHeight": 40,
-                },
-              ]
-            }
-          >
-            Add Health Department
-          </Text>
-        </View>
       </View>
     </View>
   </View>

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/TracingOff.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/TracingOff.spec.js.snap
@@ -15,9 +15,10 @@ exports[`tracing off screen matches snapshot 1`] = `
     style={
       Object {
         "flex": 1,
-        "height": "100%",
+        "height": "110%",
         "justifyContent": "flex-end",
         "resizeMode": "cover",
+        "top": 0,
         "width": "100%",
       }
     }
@@ -38,7 +39,7 @@ exports[`tracing off screen matches snapshot 1`] = `
             "top": 0,
           },
           Object {
-            "height": "100%",
+            "height": "110%",
             "width": "100%",
           },
           undefined,
@@ -83,53 +84,106 @@ exports[`tracing off screen matches snapshot 1`] = `
 </svg>"
       />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "paddingBottom": 12,
+        "paddingHorizontal": 24,
+        "position": "absolute",
+        "right": 0,
+        "top": "-10%",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "height": "100%",
-          "left": 0,
-          "paddingBottom": 12,
-          "paddingHorizontal": "12%",
-          "position": "absolute",
-          "right": 0,
-          "top": "-10%",
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "paddingBottom": 40,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-start",
+          "paddingTop": 80,
         }
       }
     >
-      <View
+      <Text
         style={
           Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-end",
-            "paddingBottom": 40,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-start",
-            "paddingTop": 80,
+            "color": "#ffffff",
+            "fontFamily": "IBMPlexSans-Medium",
+            "fontSize": 26,
+            "lineHeight": 34,
+            "marginBottom": 24,
+            "textAlign": "center",
           }
         }
       >
-        <Text
-          style={
+        Location Access Disabled
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
             Object {
               "color": "#ffffff",
-              "fontFamily": "IBMPlexSans-Medium",
-              "fontSize": 26,
-              "lineHeight": 34,
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "lineHeight": 24.5,
               "marginBottom": 24,
               "textAlign": "center",
-            }
+            },
+          ]
+        }
+      >
+        PathCheck needs location access in Settings to privately save the places you visit
+      </Text>
+      <View
+        accessibilityLabel="Allow Location Access"
+        accessibilityRole="button"
+        accessible={true}
+        focusable={true}
+        isTVSelectable={true}
+        style={
+          Object {
+            "alignContent": "center",
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#ffffff",
+            "borderBottomLeftRadius": 8,
+            "borderBottomRightRadius": 8,
+            "borderColor": "transparent",
+            "borderStyle": "solid",
+            "borderTopLeftRadius": 8,
+            "borderTopRightRadius": 8,
+            "borderWidth": 2,
+            "flexDirection": "row",
+            "height": 54,
+            "justifyContent": "center",
+            "marginTop": 24,
+            "opacity": 1,
+            "paddingHorizontal": 16,
           }
-        >
-          Location Access Disabled
-        </Text>
+        }
+      >
         <Text
           style={
             Array [
@@ -142,70 +196,17 @@ exports[`tracing off screen matches snapshot 1`] = `
                 "writingDirection": "ltr",
               },
               Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 18,
-                "lineHeight": 24.5,
-                "marginBottom": 24,
-                "textAlign": "center",
+                "color": "#1f2c9b",
+                "fontFamily": "IBMPlexSans-Medium",
+                "fontSize": 20,
+                "fontWeight": "normal",
+                "lineHeight": 40,
               },
             ]
           }
         >
-          PathCheck needs location access in Settings to privately save the places you visit
+          Allow Location Access
         </Text>
-        <View
-          accessibilityLabel="Allow Location Access"
-          accessibilityRole="button"
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "alignContent": "center",
-              "alignItems": "center",
-              "alignSelf": "stretch",
-              "backgroundColor": "#ffffff",
-              "borderBottomLeftRadius": 8,
-              "borderBottomRightRadius": 8,
-              "borderColor": "transparent",
-              "borderStyle": "solid",
-              "borderTopLeftRadius": 8,
-              "borderTopRightRadius": 8,
-              "borderWidth": 2,
-              "flexDirection": "row",
-              "height": 54,
-              "justifyContent": "center",
-              "marginTop": 24,
-              "opacity": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontSize": 17,
-                  "lineHeight": 28,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#1f2c9b",
-                  "fontFamily": "IBMPlexSans-Medium",
-                  "fontSize": 20,
-                  "fontWeight": "normal",
-                  "lineHeight": 40,
-                },
-              ]
-            }
-          >
-            Allow Location Access
-          </Text>
-        </View>
       </View>
     </View>
   </View>

--- a/app/views/main/__tests__/__snapshots__/AllServicesOn.spec.js.snap
+++ b/app/views/main/__tests__/__snapshots__/AllServicesOn.spec.js.snap
@@ -15,9 +15,10 @@ exports[`all services on matches snapshot 1`] = `
     style={
       Object {
         "flex": 1,
-        "height": "100%",
+        "height": "110%",
         "justifyContent": "flex-end",
         "resizeMode": "cover",
+        "top": 0,
         "width": "100%",
       }
     }
@@ -38,7 +39,7 @@ exports[`all services on matches snapshot 1`] = `
             "top": 0,
           },
           Object {
-            "height": "100%",
+            "height": "110%",
             "width": "100%",
           },
           undefined,
@@ -83,88 +84,88 @@ exports[`all services on matches snapshot 1`] = `
 "
       />
     </View>
+  </View>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "left": 0,
+        "paddingBottom": 12,
+        "paddingHorizontal": 24,
+        "position": "absolute",
+        "right": 0,
+        "top": "-10%",
+      }
+    }
+  >
     <View
       style={
         Object {
-          "height": "100%",
-          "left": 0,
-          "paddingBottom": 12,
-          "paddingHorizontal": "12%",
-          "position": "absolute",
-          "right": 0,
-          "top": "-10%",
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-end",
+          "paddingBottom": 40,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "flex-start",
+          "paddingTop": 80,
         }
       }
     >
-      <View
+      <Text
         style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-end",
-            "paddingBottom": 40,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "flex-start",
-            "paddingTop": 80,
-          }
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
+            Object {
+              "color": "#ffffff",
+              "fontFamily": "IBMPlexSans-Medium",
+              "fontSize": 26,
+              "lineHeight": 34,
+              "marginBottom": 24,
+              "textAlign": "center",
+            },
+          ]
         }
       >
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontSize": 17,
-                "lineHeight": 28,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans-Medium",
-                "fontSize": 26,
-                "lineHeight": 34,
-                "marginBottom": 24,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          PathCheck
-        </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontSize": 17,
-                "lineHeight": 28,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "color": "#ffffff",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 18,
-                "lineHeight": 24.5,
-                "marginBottom": 24,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          PathCheck is saving the places you visit to create your private location diary
-        </Text>
-      </View>
+        PathCheck
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
+            Object {
+              "color": "#ffffff",
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "lineHeight": 24.5,
+              "marginBottom": 24,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        PathCheck is saving the places you visit to create your private location diary
+      </Text>
     </View>
   </View>
 </View>

--- a/app/views/main/style.ts
+++ b/app/views/main/style.ts
@@ -1,14 +1,18 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Dimensions } from 'react-native';
 
 import fontFamily from '../../constants/fonts';
-import { Colors } from '../../styles';
+import { Colors, Spacing } from '../../styles';
 
 const PULSE_GAP = 80;
 
+const { height } = Dimensions.get('window');
+const IS_SMALL = height < 700;
+
 export const styles = StyleSheet.create({
   backgroundImage: {
+    top: IS_SMALL ? '-10%' : 0,
     width: '100%',
-    height: '100%',
+    height: '110%',
     resizeMode: 'cover',
     flex: 1,
     justifyContent: 'flex-end',
@@ -19,11 +23,11 @@ export const styles = StyleSheet.create({
     // aligns the center of the main container with center of pulse
     // so that two `flex: 1` views will be have a reasonable chance at natural
     // flex flow for above and below the pulse.
-    top: '-10%',
+    top: IS_SMALL ? '-20%' : '-10%',
     left: 0,
     right: 0,
     height: '100%',
-    paddingHorizontal: '12%',
+    paddingHorizontal: Spacing.large,
     paddingBottom: 12,
   },
   contentAbovePulse: {


### PR DESCRIPTION
### These changes are 99% snapshots de-nesting one component. Disregard the large amount of dif changes

This changes the view layout on the main pages so that the `BackgroundImage`'s layout is positioned separately from the content, allowing us to position the animation / background higher on small screens by a minimal amount of conditional screen size logic.
Now:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/25315679/85345150-b2382a80-b4bf-11ea-9fcc-19d18a78310a.png">
<img width="504" alt="image" src="https://user-images.githubusercontent.com/25315679/85345466-8bc6bf00-b4c0-11ea-8dc4-e5759c8afd59.png">

(same on larger:)
<img width="506" alt="image" src="https://user-images.githubusercontent.com/25315679/85345152-b401ee00-b4bf-11ea-8425-9ba758565b11.png">

Before:
<img width="504" alt="image" src="https://user-images.githubusercontent.com/25315679/85345412-6df95a00-b4c0-11ea-923c-74478410c95b.png">
<img width="504" alt="image" src="https://user-images.githubusercontent.com/25315679/85345446-82d5ed80-b4c0-11ea-8b28-d9d2d365244d.png">

