### PR TITLE
Configure Notifications Only If Notifications Are Enabled

### DIFF
--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -73,7 +73,7 @@ const initialState = {
     check: () => {},
     request: () => {},
   },
-  requestNotificationSettings: () => {}
+  requestNotificationSettings: () => {},
 };
 
 const PermissionsContext = createContext<PermissionContextState>(initialState);
@@ -169,7 +169,7 @@ const PermissionsProvider = ({
     if (statusToEnum(status) === PermissionStatus.DENIED) {
       openSettings();
     }
-  }
+  };
 
   return (
     <PermissionsContext.Provider

--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -152,7 +152,7 @@ const PermissionsProvider = ({
   const requestNotificationPermission = async () => {
     const { status } = await requestNotifications(['alert', 'sound']);
     setNotificationPermission(statusToEnum(status));
-    return status
+    return status;
   };
 
   const requestAuthSubscriptionPermission = async () => {

--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -8,6 +8,7 @@ import {
   requestNotifications,
   Permission,
 } from 'react-native-permissions';
+import { openSettings } from 'react-native-permissions';
 
 import { HCAService } from '../services/HCAService.js';
 
@@ -53,6 +54,7 @@ interface PermissionContextState {
     check: () => void;
     request: () => void;
   };
+  requestNotificationSettings: () => void;
 }
 
 const initialState = {
@@ -71,6 +73,7 @@ const initialState = {
     check: () => {},
     request: () => {},
   },
+  requestNotificationSettings: () => {}
 };
 
 const PermissionsContext = createContext<PermissionContextState>(initialState);
@@ -161,6 +164,13 @@ const PermissionsProvider = ({
     setAuthSubscriptionPermission(status);
   };
 
+  const requestNotificationSettings = async () => {
+    const status = await requestNotificationPermission();
+    if (statusToEnum(status) === PermissionStatus.DENIED) {
+      openSettings();
+    }
+  }
+
   return (
     <PermissionsContext.Provider
       value={{
@@ -179,6 +189,7 @@ const PermissionsProvider = ({
           check: checkAuthSubscriptionPermission,
           request: requestAuthSubscriptionPermission,
         },
+        requestNotificationSettings,
       }}>
       {children}
     </PermissionsContext.Provider>

--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -17,7 +17,7 @@ export enum PermissionStatus {
   DENIED,
 }
 
-const statusToEnum = (status: string) => {
+export const statusToEnum = (status: string | void) => {
   switch (status) {
     case 'unknown': {
       return PermissionStatus.UNKNOWN;
@@ -152,6 +152,7 @@ const PermissionsProvider = ({
   const requestNotificationPermission = async () => {
     const { status } = await requestNotifications(['alert', 'sound']);
     setNotificationPermission(statusToEnum(status));
+    return status
   };
 
   const requestAuthSubscriptionPermission = async () => {

--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -17,7 +17,7 @@ export enum PermissionStatus {
   DENIED,
 }
 
-export const statusToEnum = (status: string | void) : PermissionStatus => {
+export const statusToEnum = (status: string | void): PermissionStatus => {
   switch (status) {
     case 'unknown': {
       return PermissionStatus.UNKNOWN;
@@ -152,7 +152,7 @@ const PermissionsProvider = ({
   const requestNotificationPermission = async () => {
     const { status } = await requestNotifications(['alert', 'sound']);
     setNotificationPermission(statusToEnum(status));
-    return status
+    return status;
   };
 
   const requestAuthSubscriptionPermission = async () => {

--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -17,7 +17,7 @@ export enum PermissionStatus {
   DENIED,
 }
 
-export const statusToEnum = (status: string | void) => {
+export const statusToEnum = (status: string | void) : PermissionStatus => {
   switch (status) {
     case 'unknown': {
       return PermissionStatus.UNKNOWN;
@@ -152,7 +152,7 @@ const PermissionsProvider = ({
   const requestNotificationPermission = async () => {
     const { status } = await requestNotifications(['alert', 'sound']);
     setNotificationPermission(statusToEnum(status));
-    return status;
+    return status
   };
 
   const requestAuthSubscriptionPermission = async () => {

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -45,18 +45,6 @@ export default class LocationServices {
       return;
     }
 
-    PushNotification.configure({
-      // (required) Called when a remote or local notification is opened or received
-      onNotification(notification) {
-        console.log('NOTIFICATION:', notification);
-        // required on iOS only (see fetchCompletionHandler docs: https://github.com/react-native-community/react-native-push-notification-ios)
-        notification.finish(PushNotificationIOS.FetchResult.NoData);
-      },
-      // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
-      // https://github.com/zo0r/react-native-push-notification#usage
-      requestPermissions: Platform.OS === 'ios',
-    });
-
     BackgroundGeolocation.configure({
       maxLocations: 0,
       desiredAccuracy: BackgroundGeolocation.HIGH_ACCURACY,

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -1,6 +1,5 @@
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
-import PushNotificationIOS from '@react-native-community/push-notification-ios';
-import { NativeModules, Platform } from 'react-native';
+import { NativeModules } from 'react-native';
 import PushNotification from 'react-native-push-notification';
 
 import { CROSSED_PATHS } from '../constants/storage';

--- a/app/services/NotificationService.js
+++ b/app/services/NotificationService.js
@@ -3,14 +3,9 @@ import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import PushNotification from 'react-native-push-notification';
 import { PermissionStatus } from '../gps/PermissionsContext';
 
-let isNotificationConfigured = false;
-
 export default class NotificationService {
   static async configure(notificationStatus) {
-    if (
-      !isNotificationConfigured &&
-      notificationStatus === PermissionStatus.GRANTED
-    ) {
+    if (notificationStatus === PermissionStatus.GRANTED) {
       PushNotification.configure({
         // (required) Called when a remote or local notification is opened or received
         onNotification(notification) {

--- a/app/services/NotificationService.js
+++ b/app/services/NotificationService.js
@@ -7,7 +7,10 @@ let isNotificationConfigured = false;
 
 export default class NotificationService {
   static async configure(notificationStatus) {
-    if (!isNotificationConfigured && notificationStatus === PermissionStatus.GRANTED) {
+    if (
+      !isNotificationConfigured &&
+      notificationStatus === PermissionStatus.GRANTED
+    ) {
       PushNotification.configure({
         // (required) Called when a remote or local notification is opened or received
         onNotification(notification) {

--- a/app/services/NotificationService.js
+++ b/app/services/NotificationService.js
@@ -1,0 +1,25 @@
+import { Platform } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
+import PushNotification from 'react-native-push-notification';
+import { PermissionStatus } from '../gps/PermissionsContext';
+
+let isNotificationConfigured = false;
+
+export default class NotificationService {
+  static async configure(notificationStatus) {
+    if (!isNotificationConfigured && notificationStatus === PermissionStatus.GRANTED) {
+      PushNotification.configure({
+        // (required) Called when a remote or local notification is opened or received
+        onNotification(notification) {
+          console.log('NOTIFICATION:', notification);
+          // required on iOS only (see fetchCompletionHandler docs: https://github.com/react-native-community/react-native-push-notification-ios)
+          notification.finish(PushNotificationIOS.FetchResult.NoData);
+        },
+        // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
+        // https://github.com/zo0r/react-native-push-notification#usage
+        requestPermissions: Platform.OS === 'ios',
+      });
+      isNotificationConfigured = true;
+    }
+  }
+}

--- a/app/services/NotificationService.js
+++ b/app/services/NotificationService.js
@@ -17,7 +17,6 @@ export default class NotificationService {
         // https://github.com/zo0r/react-native-push-notification#usage
         requestPermissions: Platform.OS === 'ios',
       });
-      isNotificationConfigured = true;
     }
   }
 }

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react';
-import { AppState, Platform } from 'react-native';
+import { AppState } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import PushNotificationIOS from '@react-native-community/push-notification-ios';
-import PushNotification from 'react-native-push-notification';
 
 import { checkIntersect } from '../helpers/Intersect';
 import BackgroundTaskServices from '../services/BackgroundTaskService';
 import LocationServices from '../services/LocationService';
+import NotificationService from '../services/NotificationService';
 import { AllServicesOnScreen } from './main/AllServicesOn';
 import {
   TracingOffScreen,
@@ -55,19 +54,7 @@ export const Main = () => {
   }, [navigation, updateStateInfo]);
 
   useEffect(() => {
-    if (notification.status === PermissionStatus.GRANTED) {
-      PushNotification.configure({
-        // (required) Called when a remote or local notification is opened or received
-        onNotification(notification) {
-          console.log('NOTIFICATION:', notification);
-          // required on iOS only (see fetchCompletionHandler docs: https://github.com/react-native-community/react-native-push-notification-ios)
-          notification.finish(PushNotificationIOS.FetchResult.NoData);
-        },
-        // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
-        // https://github.com/zo0r/react-native-push-notification#usage
-        requestPermissions: Platform.OS === 'ios',
-      });
-    }
+    NotificationService.configure(notification.status)
   }, [notification.status]);
 
   if (!trackingInfo.canTrack) {

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react';
 import { AppState } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
+import PushNotification from 'react-native-push-notification';
 
 import { checkIntersect } from '../helpers/Intersect';
 import BackgroundTaskServices from '../services/BackgroundTaskService';
@@ -51,6 +53,22 @@ export const Main = () => {
       unsubscribe();
     };
   }, [navigation, updateStateInfo]);
+
+  useEffect(() => {
+    if (notification.status === PermissionStatus.GRANTED) {
+      PushNotification.configure({
+        // (required) Called when a remote or local notification is opened or received
+        onNotification(notification) {
+          console.log('NOTIFICATION:', notification);
+          // required on iOS only (see fetchCompletionHandler docs: https://github.com/react-native-community/react-native-push-notification-ios)
+          notification.finish(PushNotificationIOS.FetchResult.NoData);
+        },
+        // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
+        // https://github.com/zo0r/react-native-push-notification#usage
+        requestPermissions: Platform.OS === 'ios',
+      });
+    }
+  }, [notification.status]);
 
   if (!trackingInfo.canTrack) {
     return <TracingOffScreen />;

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -54,7 +54,7 @@ export const Main = () => {
   }, [navigation, updateStateInfo]);
 
   useEffect(() => {
-    NotificationService.configure(notification.status)
+    NotificationService.configure(notification.status);
   }, [notification.status]);
 
   if (!trackingInfo.canTrack) {

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -37,7 +37,8 @@ export const Main = () => {
     checkForPossibleExposure();
     const { canTrack } = await LocationServices.checkStatusAndStartOrStop();
     setTrackingInfo({ canTrack });
-  }, [setTrackingInfo]);
+    NotificationService.configure(notification.status);
+  }, [setTrackingInfo, notification.status]);
 
   useEffect(() => {
     updateStateInfo();
@@ -52,10 +53,6 @@ export const Main = () => {
       unsubscribe();
     };
   }, [navigation, updateStateInfo]);
-
-  useEffect(() => {
-    NotificationService.configure(notification.status);
-  }, [notification.status]);
 
   if (!trackingInfo.canTrack) {
     return <TracingOffScreen />;

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import PushNotification from 'react-native-push-notification';

--- a/app/views/main/ServiceOffScreens/NotificationsOff.tsx
+++ b/app/views/main/ServiceOffScreens/NotificationsOff.tsx
@@ -1,7 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
+import { openSettings } from 'react-native-permissions';
 import { useAssets } from '../../../TracingStrategyAssets';
 import { ServiceOffScreen } from './Base';
-import PermissionsContext from '../../../gps/PermissionsContext';
 
 export const NotificationsOffScreen = (): JSX.Element => {
   const {
@@ -9,11 +9,6 @@ export const NotificationsOffScreen = (): JSX.Element => {
     notificationsOffScreenSubheader,
     notificationsOffScreenButton,
   } = useAssets();
-  const { notification } = useContext(PermissionsContext);
-
-  const requestNotifications = async () => {
-    await notification.request();
-  };
 
   return (
     <ServiceOffScreen
@@ -21,7 +16,7 @@ export const NotificationsOffScreen = (): JSX.Element => {
       subheader={notificationsOffScreenSubheader}
       button={{
         label: notificationsOffScreenButton,
-        onPress: requestNotifications,
+        onPress: openSettings,
       }}
     />
   );

--- a/app/views/main/ServiceOffScreens/NotificationsOff.tsx
+++ b/app/views/main/ServiceOffScreens/NotificationsOff.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { openSettings } from 'react-native-permissions';
+import React, { useContext } from 'react';
 import { useAssets } from '../../../TracingStrategyAssets';
 import { ServiceOffScreen } from './Base';
+import PermissionsContext, { statusToEnum, PermissionStatus } from '../../../gps/PermissionsContext';
+import { openSettings } from 'react-native-permissions';
 
 export const NotificationsOffScreen = (): JSX.Element => {
   const {
@@ -9,15 +10,20 @@ export const NotificationsOffScreen = (): JSX.Element => {
     notificationsOffScreenSubheader,
     notificationsOffScreenButton,
   } = useAssets();
+  const { notification } = useContext(PermissionsContext);
+
+  const requestNotifications = async () => {
+    const status = await notification.request();
+    if (statusToEnum(status) === PermissionStatus.DENIED) {
+      openSettings();
+    }
+  };
 
   return (
     <ServiceOffScreen
       header={notificationsOffScreenHeader}
       subheader={notificationsOffScreenSubheader}
-      button={{
-        label: notificationsOffScreenButton,
-        onPress: openSettings,
-      }}
+      button={{ label: notificationsOffScreenButton, onPress: requestNotifications }}
     />
   );
 };

--- a/app/views/main/ServiceOffScreens/NotificationsOff.tsx
+++ b/app/views/main/ServiceOffScreens/NotificationsOff.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useAssets } from '../../../TracingStrategyAssets';
 import { ServiceOffScreen } from './Base';
-import { openSettings } from 'react-native-permissions';
+import PermissionsContext from '../../../gps/PermissionsContext';
 
 export const NotificationsOffScreen = (): JSX.Element => {
   const {
@@ -9,12 +9,17 @@ export const NotificationsOffScreen = (): JSX.Element => {
     notificationsOffScreenSubheader,
     notificationsOffScreenButton,
   } = useAssets();
+  const { notification } = useContext(PermissionsContext);
+
+  const requestNotifications = async () => {
+    await notification.request();
+  };
 
   return (
     <ServiceOffScreen
       header={notificationsOffScreenHeader}
       subheader={notificationsOffScreenSubheader}
-      button={{ label: notificationsOffScreenButton, onPress: openSettings }}
+      button={{ label: notificationsOffScreenButton, onPress: requestNotifications }}
     />
   );
 };

--- a/app/views/main/ServiceOffScreens/NotificationsOff.tsx
+++ b/app/views/main/ServiceOffScreens/NotificationsOff.tsx
@@ -1,11 +1,7 @@
 import React, { useContext } from 'react';
 import { useAssets } from '../../../TracingStrategyAssets';
 import { ServiceOffScreen } from './Base';
-import PermissionsContext, {
-  statusToEnum,
-  PermissionStatus,
-} from '../../../gps/PermissionsContext';
-import { openSettings } from 'react-native-permissions';
+import PermissionsContext from '../../../gps/PermissionsContext';
 
 export const NotificationsOffScreen = (): JSX.Element => {
   const {
@@ -13,14 +9,7 @@ export const NotificationsOffScreen = (): JSX.Element => {
     notificationsOffScreenSubheader,
     notificationsOffScreenButton,
   } = useAssets();
-  const { notification } = useContext(PermissionsContext);
-
-  const requestNotifications = async () => {
-    const status = await notification.request();
-    if (statusToEnum(status) === PermissionStatus.DENIED) {
-      openSettings();
-    }
-  };
+  const { requestNotificationSettings } = useContext(PermissionsContext);
 
   return (
     <ServiceOffScreen
@@ -28,7 +17,7 @@ export const NotificationsOffScreen = (): JSX.Element => {
       subheader={notificationsOffScreenSubheader}
       button={{
         label: notificationsOffScreenButton,
-        onPress: requestNotifications,
+        onPress: requestNotificationSettings,
       }}
     />
   );

--- a/app/views/main/ServiceOffScreens/NotificationsOff.tsx
+++ b/app/views/main/ServiceOffScreens/NotificationsOff.tsx
@@ -1,7 +1,10 @@
 import React, { useContext } from 'react';
 import { useAssets } from '../../../TracingStrategyAssets';
 import { ServiceOffScreen } from './Base';
-import PermissionsContext, { statusToEnum, PermissionStatus } from '../../../gps/PermissionsContext';
+import PermissionsContext, {
+  statusToEnum,
+  PermissionStatus,
+} from '../../../gps/PermissionsContext';
 import { openSettings } from 'react-native-permissions';
 
 export const NotificationsOffScreen = (): JSX.Element => {
@@ -23,7 +26,10 @@ export const NotificationsOffScreen = (): JSX.Element => {
     <ServiceOffScreen
       header={notificationsOffScreenHeader}
       subheader={notificationsOffScreenSubheader}
-      button={{ label: notificationsOffScreenButton, onPress: requestNotifications }}
+      button={{
+        label: notificationsOffScreenButton,
+        onPress: requestNotifications,
+      }}
     />
   );
 };

--- a/app/views/main/ServiceOffScreens/NotificationsOff.tsx
+++ b/app/views/main/ServiceOffScreens/NotificationsOff.tsx
@@ -19,7 +19,10 @@ export const NotificationsOffScreen = (): JSX.Element => {
     <ServiceOffScreen
       header={notificationsOffScreenHeader}
       subheader={notificationsOffScreenSubheader}
-      button={{ label: notificationsOffScreenButton, onPress: requestNotifications }}
+      button={{
+        label: notificationsOffScreenButton,
+        onPress: requestNotifications,
+      }}
     />
   );
 };


### PR DESCRIPTION
#### Description:
The user is prompted to enable notifications anytime the main screen is loaded if notifications are not enabled. This PR check to make sure that notifications are enabled before configuring push notifications, thereby preventing the enable notifications prompt

#### Linked issues:
https://pathcheck.atlassian.net/browse/SAF-738

#### How to test:

Install the app from scratch and go through onboarding. Select Maybe Later on the Notification Permissions screen. You should not see the Enable Notifications popup on the next screen.

With the app already installed, close the app and enable notifications from the device settings. Close and reopen the app. You should not see the Enable Notifications popup on the next screen.
