### PR TITLE
Fix Request Location Permissions Bug

### DIFF
--- a/app/gps/PermissionsContext.tsx
+++ b/app/gps/PermissionsContext.tsx
@@ -54,6 +54,7 @@ interface PermissionContextState {
     check: () => void;
     request: () => void;
   };
+  requestLocationSettings: () => void;
   requestNotificationSettings: () => void;
 }
 
@@ -73,6 +74,7 @@ const initialState = {
     check: () => {},
     request: () => {},
   },
+  requestLocationSettings: () => {},
   requestNotificationSettings: () => {},
 };
 
@@ -138,18 +140,23 @@ const PermissionsProvider = ({
   };
 
   const requestLocationPermission = async () => {
+    let status;
     if (Platform.OS === 'ios') {
-      await requestLocationForPlatform(PERMISSIONS.IOS.LOCATION_ALWAYS);
+      status = await requestLocationForPlatform(
+        PERMISSIONS.IOS.LOCATION_ALWAYS,
+      );
     } else if (Platform.OS === 'android') {
-      await requestLocationForPlatform(
+      status = await requestLocationForPlatform(
         PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
       );
     }
+    return status;
   };
 
   const requestLocationForPlatform = async (permission: Permission) => {
     const status = await request(permission);
     setLocationPermission(statusToEnum(status));
+    return status;
   };
 
   const requestNotificationPermission = async () => {
@@ -166,6 +173,13 @@ const PermissionsProvider = ({
 
   const requestNotificationSettings = async () => {
     const status = await requestNotificationPermission();
+    if (statusToEnum(status) === PermissionStatus.DENIED) {
+      openSettings();
+    }
+  };
+
+  const requestLocationSettings = async () => {
+    const status = await requestLocationPermission();
     if (statusToEnum(status) === PermissionStatus.DENIED) {
       openSettings();
     }
@@ -189,6 +203,7 @@ const PermissionsProvider = ({
           check: checkAuthSubscriptionPermission,
           request: requestAuthSubscriptionPermission,
         },
+        requestLocationSettings,
         requestNotificationSettings,
       }}>
       {children}

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -26,7 +26,7 @@ export const Main = () => {
   const { notification } = useContext(PermissionsContext);
   const hasSelectedAuthorities =
     useSelector(selectedHealthcareAuthoritiesSelector).length > 0;
-  const [trackingInfo, setTrackingInfo] = useState({ canTrack: true });
+  const [canTrack, setCanTrack] = useState(true);
 
   const checkForPossibleExposure = () => {
     BackgroundTaskServices.start();
@@ -35,11 +35,13 @@ export const Main = () => {
 
   const updateStateInfo = useCallback(async () => {
     checkForPossibleExposure();
-    const { canTrack } = await LocationServices.checkStatusAndStartOrStop();
-    setTrackingInfo({ canTrack });
+    const locationStatus = await LocationServices.checkStatusAndStartOrStop();
+    console.log('locationStatus')
+    console.log(locationStatus)
+    setCanTrack(locationStatus.canTrack);
     notification.check();
     NotificationService.configure(notification.status);
-  }, [setTrackingInfo, notification.status]);
+  }, [setCanTrack, notification.status]);
 
   useEffect(() => {
     updateStateInfo();
@@ -55,7 +57,7 @@ export const Main = () => {
     };
   }, [navigation, updateStateInfo]);
 
-  if (!trackingInfo.canTrack) {
+  if (!canTrack) {
     return <TracingOffScreen />;
   } else if (notification.status === PermissionStatus.DENIED) {
     return <NotificationsOffScreen />;

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -36,8 +36,6 @@ export const Main = () => {
   const updateStateInfo = useCallback(async () => {
     checkForPossibleExposure();
     const locationStatus = await LocationServices.checkStatusAndStartOrStop();
-    console.log('locationStatus')
-    console.log(locationStatus)
     setCanTrack(locationStatus.canTrack);
     notification.check();
     NotificationService.configure(notification.status);

--- a/app/views/Main.js
+++ b/app/views/Main.js
@@ -37,6 +37,7 @@ export const Main = () => {
     checkForPossibleExposure();
     const { canTrack } = await LocationServices.checkStatusAndStartOrStop();
     setTrackingInfo({ canTrack });
+    notification.check();
     NotificationService.configure(notification.status);
   }, [setTrackingInfo, notification.status]);
 

--- a/app/views/main/ServiceOffScreens/TracingOff.tsx
+++ b/app/views/main/ServiceOffScreens/TracingOff.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useAssets } from '../../../TracingStrategyAssets';
 import { ServiceOffScreen } from './Base';
-import { openSettings } from 'react-native-permissions';
+import PermissionsContext from '../../../gps/PermissionsContext';
 
 export const TracingOffScreen = (): JSX.Element => {
   const {
@@ -9,12 +9,16 @@ export const TracingOffScreen = (): JSX.Element => {
     tracingOffScreenSubheader,
     tracingOffScreenButton,
   } = useAssets();
+  const { requestLocationSettings } = useContext(PermissionsContext);
 
   return (
     <ServiceOffScreen
       header={tracingOffScreenHeader}
       subheader={tracingOffScreenSubheader}
-      button={{ label: tracingOffScreenButton, onPress: openSettings }}
+      button={{
+        label: tracingOffScreenButton,
+        onPress: requestLocationSettings,
+      }}
     />
   );
 };


### PR DESCRIPTION
#### Description:
Fix a bug in which you cannot enable location permissions follow certain onboarding selections. 

#### Linked Tickets:
https://pathcheck.atlassian.net/browse/SAF-759

#### How to test:
Do through the onboarding flow and select `Maybe Later`. On the main screen pressing `Allow Location Access` should open the enable location popup. If the pop has already been opened, then pressing the button should navigate to the ios app settings.