### PR TITLE
iPhone 8 / Nexus 4 UI improvements, larger accessibility text sizes improvements

### DIFF
--- a/app/bt/Home/Home.tsx
+++ b/app/bt/Home/Home.tsx
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     position: 'absolute',
-    top: Layout.screenHeight / 2 - 40,
+    top: Layout.screenHeight / 3,
     width: '100%',
   },
   headerText: {

--- a/app/bt/Home/__snapshots__/index.spec.tsx.snap
+++ b/app/bt/Home/__snapshots__/index.spec.tsx.snap
@@ -46,7 +46,7 @@ exports[`HomeScreen renders 1`] = `
     <View
       style={
         Object {
-          "bottom": -667,
+          "bottom": -444.6666666666667,
           "left": -375,
           "position": "absolute",
         }
@@ -98,7 +98,7 @@ exports[`HomeScreen renders 1`] = `
           style={
             Object {
               "position": "absolute",
-              "top": 627,
+              "top": 444.6666666666667,
               "width": "100%",
             }
           }

--- a/app/bt/Home/index.tsx
+++ b/app/bt/Home/index.tsx
@@ -45,7 +45,7 @@ const styles = StyleSheet.create({
   iconContainer: {
     position: 'absolute',
     left: -(Layout.screenWidth / 2),
-    bottom: -(Layout.screenHeight / 2),
+    bottom: -(Layout.screenHeight / 3),
   },
   homeContainer: {
     flex: 1,

--- a/app/styles/buttons.ts
+++ b/app/styles/buttons.ts
@@ -74,6 +74,11 @@ export const largeWhiteOutline: ViewStyle = {
   ...outlined,
 };
 
+export const largeSecondary: ViewStyle = {
+  ...base,
+  ...large,
+};
+
 export const tinyTeritiaryRounded: ViewStyle = {
   ...base,
   ...tiny,

--- a/app/styles/layout.ts
+++ b/app/styles/layout.ts
@@ -5,6 +5,9 @@ import * as Spacing from './spacing';
 export const screenWidth = Dimensions.get('window').width;
 export const screenHeight = Dimensions.get('window').height;
 
+// iphone 8
+export const smallScreenWidth = 375;
+
 export const baseScreenPadding = Spacing.xSmall;
 
 export const xxSmallWidth = 0.05 * screenWidth;

--- a/app/views/Export/ExportCodeInput.js
+++ b/app/views/Export/ExportCodeInput.js
@@ -14,7 +14,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button } from '../../components/Button';
 import { IconButton } from '../../components/IconButton';
 import { Typography } from '../../components/Typography';
-import fontFamily from '../../constants/fonts';
 import { Theme } from '../../constants/themes';
 import { useAssets } from '../../TracingStrategyAssets';
 import exitWarningAlert from './exitWarningAlert';
@@ -241,11 +240,6 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderRadius: 10,
     marginRight: 6,
-  },
-  exportSectionTitles: {
-    color: Colors.violetTextDark,
-    fontWeight: '500',
-    fontFamily: fontFamily.primaryMedium,
   },
 });
 

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -96,6 +96,7 @@ const styles = StyleSheet.create({
   header: {},
   headerRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     marginTop: Spacing.xSmall,
   },
   headerText: {
@@ -116,6 +117,7 @@ const styles = StyleSheet.create({
   detailsContainer: {
     flex: 1,
     marginTop: Spacing.small,
+    marginBottom: Spacing.huge,
   },
 });
 

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import {
   TouchableOpacity,
   ImageBackground,
+  ScrollView,
   StatusBar,
   StyleSheet,
   View,
@@ -58,7 +59,7 @@ export const EnableExposureNotifications = (): JSX.Element => {
         <View
           testID={'onboarding-permissions-screen'}
           style={styles.mainContainer}>
-          <View style={styles.contentContainer}>
+          <ScrollView style={styles.contentContainer}>
             <View style={styles.iconContainer}>
               <SvgXml xml={Icons.ExposureIcon} />
             </View>
@@ -69,24 +70,24 @@ export const EnableExposureNotifications = (): JSX.Element => {
               {titleText}
             </Typography>
             <Typography style={styles.subheaderText}>{subTitleText}</Typography>
-          </View>
+          </ScrollView>
 
           <View style={styles.footerContainer}>
-            <TouchableOpacity
-              style={styles.dontEnableButton}
-              onPress={handleOnPressDontEnable}
-              testID={'onboarding-permissions-disable-button'}>
-              <Typography style={styles.dontEnableButtonText}>
-                {disableButtonLabel}
-              </Typography>
-            </TouchableOpacity>
-
             <TouchableOpacity
               style={styles.enableButton}
               onPress={handleOnPressEnable}
               testID={'onboarding-permissions-button'}>
               <Typography style={styles.enableButtonText}>
                 {buttonLabel}
+              </Typography>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.dontEnableButton}
+              onPress={handleOnPressDontEnable}
+              testID={'onboarding-permissions-disable-button'}>
+              <Typography style={styles.dontEnableButtonText}>
+                {disableButtonLabel}
               </Typography>
             </TouchableOpacity>
           </View>
@@ -108,17 +109,16 @@ const styles = StyleSheet.create({
     padding: Spacing.large,
   },
   contentContainer: {
-    flex: 3,
-    justifyContent: 'center',
+    paddingTop: Spacing.large,
   },
   footerContainer: {
-    flex: 1,
+    height: 'auto',
     width: '100%',
-    justifyContent: 'space-around',
   },
   headerText: {
     ...TypographyStyles.header2,
     color: Colors.white,
+    marginBottom: Spacing.small,
   },
   iconContainer: {
     paddingBottom: Spacing.large,
@@ -126,6 +126,7 @@ const styles = StyleSheet.create({
   subheaderText: {
     ...TypographyStyles.mainContent,
     color: Colors.invertedText,
+    marginBottom: Spacing.xHuge,
   },
   enableButton: {
     ...Buttons.largeWhite,
@@ -134,7 +135,7 @@ const styles = StyleSheet.create({
     ...TypographyStyles.buttonTextDark,
   },
   dontEnableButton: {
-    ...Buttons.largeWhiteOutline,
+    ...Buttons.largeSecondary,
   },
   dontEnableButtonText: {
     ...TypographyStyles.buttonTextLight,

--- a/app/views/onboarding/OnboardingTemplate.tsx
+++ b/app/views/onboarding/OnboardingTemplate.tsx
@@ -11,7 +11,7 @@ import { SvgXml } from 'react-native-svg';
 import { Button } from '../../components/Button';
 import { Typography } from '../../components/Typography';
 
-import { Colors, Spacing } from '../../styles';
+import { Colors, Layout, Spacing } from '../../styles';
 import { Theme } from '../../constants/themes';
 
 type OnboardingTemplateProps = {
@@ -47,7 +47,9 @@ const OnboardingTemplate = ({
           backgroundColor='transparent'
           translucent
         />
-        <ImageBackground source={background} style={styles.backgroundImage} />
+        {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
+          <ImageBackground source={background} style={styles.backgroundImage} />
+        )}
         <View style={styles.content}>
           <ScrollView
             alwaysBounceVertical={false}


### PR DESCRIPTION
#### Description:

This commit resolves UI issues present on the on iPhone 8 and with larger accessibility text sizes. Includes:

- Update enable exposure notification screen to match mockups and resolve small screen padding issues, add scrollview.
- fix overflow issue with tab bar on exposure history
- Shift position of home svg to accommodate larger text sizes
- Conditionally hide onboarding bg image for iphone 8 or smaller phones
- add flex wrap to calendar header
- Updates snapshots

#### Linked issues:

https://trello.com/c/WTz6cti5/74-as-nexus-4-and-iphone-8-users-we-want-an-optimal-user-experience-that-is-synonomous-with-those-with-larger-phones

#### Screenshots:

<img width="429" alt="Screen Shot 2020-06-24 at 2 53 50 PM" src="https://user-images.githubusercontent.com/2924479/85615660-9d2bda80-b62a-11ea-88ef-779bfeb0c3d2.png">
<img width="439" alt="Screen Shot 2020-06-24 at 2 53 44 PM" src="https://user-images.githubusercontent.com/2924479/85615663-9dc47100-b62a-11ea-8b4b-af61981ebe9e.png">
<img width="435" alt="Screen Shot 2020-06-24 at 2 53 35 PM" src="https://user-images.githubusercontent.com/2924479/85615666-9ef59e00-b62a-11ea-9e99-5fe13c576088.png">
<img width="434" alt="Screen Shot 2020-06-24 at 2 53 26 PM" src="https://user-images.githubusercontent.com/2924479/85615672-9f8e3480-b62a-11ea-9673-0c20c95a1785.png">
<img width="428" alt="Screen Shot 2020-06-24 at 2 53 16 PM" src="https://user-images.githubusercontent.com/2924479/85615674-a0bf6180-b62a-11ea-99dc-c66152ea1638.png">

