### PR TITLE
Handle "Dark Mode" in iOS

### DIFF
--- a/app/views/__tests__/__snapshots__/Export.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Export.spec.js.snap
@@ -89,6 +89,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                 "fontSize": 19,
                 "fontWeight": "500",
                 "lineHeight": 40,
+                "textTransform": "uppercase",
               },
             ]
           }

--- a/ios/BT/Info.plist
+++ b/ios/BT/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.transistorsoft.fetch</string>

--- a/ios/GPS/Info.plist
+++ b/ios/GPS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.transistorsoft.fetch</string>


### PR DESCRIPTION
### Why
We'd like the app to reflect our designs. The designs do not handle multiple user interface styles (i.e. "dark mode"), so in order to avoid, for example, white text on a white background while in dark mode, we set the user interface style to always be `Light`.

### This Commit
This commit sets the user interface style to `Light` for both the `BT` and `GPS` iOS targets

### Before
![Jun-24-2020 21-08-48](https://user-images.githubusercontent.com/2637355/85642339-3aa10180-b65f-11ea-875d-dcb253329b5d.gif)

### After
![IMG_D9F3605D3F8A-1](https://user-images.githubusercontent.com/2637355/85642488-a7b49700-b65f-11ea-92f2-39bc50c4bf1b.jpeg)
