### PR TITLE
Minor updates for demo

### DIFF
--- a/app/ExposureHistoryContext.tsx
+++ b/app/ExposureHistoryContext.tsx
@@ -50,7 +50,7 @@ const ExposureHistoryProvider = ({
   const [exposureHistory, setExposureHistory] = useState<ExposureHistory>(
     blankHistory,
   );
-  const [userHasNewExposure, setUserHasNewExposure] = useState<boolean>(true);
+  const [userHasNewExposure, setUserHasNewExposure] = useState<boolean>(false);
 
   useEffect(() => {
     const subscription = exposureInfoSubscription(

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -82,13 +82,11 @@ const NoKnownExposureDetail = ({
   datum: { date },
 }: NoKnownExposureDetailProps) => {
   const exposureDate = dayjs(date).format('dddd, MMM DD');
-  const dailyReports = `Current daily reports: 0`;
   const explainationContent =
     'Your exposure history will be updated if this changes in the future.';
   return (
     <View style={styles.container}>
       <Typography style={styles.date}>{exposureDate}</Typography>
-      <Typography style={styles.info}>{dailyReports}</Typography>
       <View style={styles.contentContainer}>
         <Typography style={styles.content}>{explainationContent}</Typography>
       </View>

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -16,7 +16,7 @@ const NextSteps = (): JSX.Element => {
     navigation.goBack();
   };
 
-  const healthAuthority = 'The PathCheck Health Department';
+  const healthAuthority = 'Boston Public Health Commission';
 
   const headerText = `${healthAuthority} recommends you take a self-assessment`;
 
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   headerText: {
-    ...TypographyStyles.header2,
+    ...TypographyStyles.header3,
   },
   contentText: {
     ...TypographyStyles.mainContent,

--- a/app/views/__tests__/__snapshots__/Export.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Export.spec.js.snap
@@ -89,6 +89,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                 "fontSize": 19,
                 "fontWeight": "500",
                 "lineHeight": 40,
+                "textTransform": "uppercase",
               },
             ]
           }


### PR DESCRIPTION
Why:
We would like to polish a few loose ends for upcoming demos

This commit:
- Removes 'Current daily reports' from the exposure info detail as its no
longer in the designs.
- Updates the HA name on the next steps screen to make it consistent
with other parts of the app
- Turns off the badge for new exposure on the exposure history icon