### PR TITLE
Fix start affected user flow crash

### DIFF
--- a/app/views/Export/ExportIntro.js
+++ b/app/views/Export/ExportIntro.js
@@ -20,11 +20,36 @@ export const ExportIntro = ({ navigation }) => {
   const authorities = useSelector(healthcareAuthorityOptionsSelector);
   const selectedAuthorityDummy = authorities[0];
 
-  const onNext = () =>
-    navigation.navigate(Screens.ExportCodeInput, {
-      selectedAuthority: selectedAuthorityDummy,
-    });
+  const onNext = () => {
+    if (selectedAuthorityDummy) {
+      navigation.navigate(Screens.ExportCodeInput, {
+        selectedAuthority: selectedAuthorityDummy,
+      });
+    } else {
+      const fakeAuthority = {
+        name: 'Boston Health Commission',
+        bounds: {
+          ne: {
+            latitude: 42.0,
+            longitude: 71.0,
+          },
+          sw: {
+            latitude: 43.0,
+            longitude: 72.0,
+          },
+        },
+        org_id: '1234',
+        cursor_url: '',
+        public_api: '',
+        internal_id: '',
+      };
+      navigation.navigate(Screens.ExportCodeInput, {
+        selectedAuthority: fakeAuthority,
+      });
+    }
+  };
   const onClose = () => navigation.goBack();
+
   return (
     <ExportTemplate
       onNext={onNext}

--- a/app/views/__tests__/__snapshots__/Export.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Export.spec.js.snap
@@ -89,6 +89,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                 "fontSize": 19,
                 "fontWeight": "500",
                 "lineHeight": 40,
+                "textTransform": "uppercase",
               },
             ]
           }


### PR DESCRIPTION
Why:
Currently the app will crash if a user tries to start the affected user
flow while there are not health authorities in the store.

This commit:
Provides a fake health authority if there are none such that the app
will not crash. A future commit should properly handle this null state
and we should remove this fake authority.