### PR TITLE
Dont post export code for bt

### DIFF
--- a/app/views/Export/ExportCodeInput.js
+++ b/app/views/Export/ExportCodeInput.js
@@ -137,19 +137,31 @@ export const ExportSelectHA = ({ route, navigation }) => {
     setIsCheckingCode(true);
     setCodeInvalid(false);
     try {
-      let { valid } = await exportCodeApi(selectedAuthority, code);
+      if (isGPS) {
+        const { valid } = await exportCodeApi(selectedAuthority, code);
 
-      if (!isGPS) valid = code === '123456';
-
-      if (valid) {
-        navigation.navigate(exportCodeInputNextRoute, {
-          selectedAuthority,
-          code,
-        });
+        if (valid) {
+          navigation.navigate(exportCodeInputNextRoute, {
+            selectedAuthority,
+            code,
+          });
+        } else {
+          setCodeInvalid(true);
+        }
+        setIsCheckingCode(false);
       } else {
-        setCodeInvalid(true);
+        const valid = code === '123456';
+
+        if (valid) {
+          navigation.navigate(exportCodeInputNextRoute, {
+            selectedAuthority,
+            code,
+          });
+        } else {
+          setCodeInvalid(true);
+        }
+        setIsCheckingCode(false);
       }
-      setIsCheckingCode(false);
     } catch (e) {
       Alert.alert(t('common.something_went_wrong'), e.message);
       setIsCheckingCode(false);


### PR DESCRIPTION
Why:
Currently for the BT app we are not setup for posting export codes on
the affected user flow, but would like to fake it for demo purposes.

This commit:
Removes the request for the BT build.
