### PR TITLE
Refactor, update styling, update content for about page

### DIFF
--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -58,6 +58,7 @@ const jacksonsPurple = '#1f2c9b';
 const moonRaker = '#e5e7fa';
 const indigo = '#4754C5';
 const melrose = '#a5affb';
+const faintViolet = '#f8f8ff';
 
 export const primaryViolet = jacksonsPurple;
 export const secondaryViolet = indigo;
@@ -77,7 +78,7 @@ export const defaultBlue = primaryBlue;
 export const defaultRed = primaryRed;
 
 // Backgrounds
-export const primaryBackground = faintGray;
+export const primaryBackground = faintViolet;
 export const primaryBackgroundFaintShade = faintGray;
 export const secondaryBackground = moonRaker;
 export const tertiaryBackground = lighterGray;

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -35,6 +35,11 @@ export const mediumFontFamily = 'IBMPlexSans-Medium';
 export const boldFontFamily = 'IBMPlexSans-Bold';
 export const monospaceFontFamily = 'IBMPlexMono';
 
+export const extraBold: TextStyle = {
+  fontFamily: boldFontFamily,
+  fontWeight: heaviestWeight,
+};
+
 export const bold: TextStyle = {
   fontFamily: boldFontFamily,
   fontWeight: heavyWeight,
@@ -106,6 +111,12 @@ export const header3: TextStyle = {
 export const header4: TextStyle = {
   ...smallFont,
   color: Colors.secondaryHeaderText,
+};
+
+export const header5: TextStyle = {
+  ...mediumFont,
+  ...extraBold,
+  color: Colors.primaryHeaderText,
 };
 
 export const title: TextStyle = {

--- a/app/views/About.js
+++ b/app/views/About.js
@@ -1,21 +1,19 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Dimensions,
   Linking,
   Platform,
   ScrollView,
   StyleSheet,
-  View,
   Text,
+  View,
 } from 'react-native';
 
 import packageJson from '../../package.json';
-import fontFamily from './../constants/fonts';
 import { NavigationBarWrapper, Typography } from '../components';
 import { useAssets } from '../TracingStrategyAssets';
 
-import { Colors, Spacing } from '../styles';
+import { Colors, Spacing, Typography as TypographyStyles } from '../styles';
 
 export const AboutScreen = ({ navigation }) => {
   const { t } = useTranslation();
@@ -32,74 +30,36 @@ export const AboutScreen = ({ navigation }) => {
       <ScrollView
         contentContainerStyle={styles.contentContainer}
         alwaysBounceVertical={false}>
-        <View style={styles.spacer} />
-        <View style={styles.spacer} />
-
-        <Typography use='headline2'>{aboutHeader}</Typography>
-        <View style={{ height: 10 }} />
-        <Typography use='body2'>
-          {t('label.about_para')}
-          {/* Space between the copy & link*/}
-          <Text> </Text>
-          <Typography
-            style={styles.hyperlink}
-            onPress={() => {
-              Linking.openURL('https://covidsafepaths.org/');
-            }}>
-            {/* eslint-disable-next-line react-native/no-raw-text */}
-            {'covidsafepaths.org'}
-          </Typography>
+        <Typography use='headline2' style={styles.heading}>
+          {aboutHeader}
+        </Typography>
+        <Typography use='body2'>{t('label.about_para')}</Typography>
+        <Typography
+          style={styles.hyperlink}
+          onPress={() => {
+            Linking.openURL('https://covidsafepaths.org/');
+          }}>
+          <Text>{'covidsafepaths.org'}</Text>
         </Typography>
 
-        <View style={styles.spacer} />
-        <View style={styles.spacer} />
-
-        <View style={styles.main}>
-          <View>
-            <View style={styles.row}>
-              <Typography style={styles.aboutSectionParaBold}>
-                {t('about.version')}
-              </Typography>
-            </View>
-
-            <View style={styles.row}>
-              <Typography style={styles.aboutSectionParaBold}>
-                {t('about.operating_system_abbr')}
-              </Typography>
-            </View>
-
-            <View style={styles.row}>
-              <Typography style={styles.aboutSectionParaBold}>
-                {t('about.dimensions')}
-              </Typography>
-            </View>
+        <View style={styles.rowContainer}>
+          <View style={styles.row}>
+            <Typography style={styles.aboutSectionParaLabel}>
+              {t('about.version')}
+            </Typography>
+            <Typography style={styles.aboutSectionParaContent}>
+              {packageJson.version}
+            </Typography>
           </View>
-
-          <View>
-            <View style={styles.row}>
-              <Typography style={styles.aboutSectionParaBold}>
-                {packageJson.version}
-              </Typography>
-            </View>
-
-            <View style={styles.row}>
-              <Typography style={styles.aboutSectionParaBold}>
-                {Platform.OS + ' v' + Platform.Version}
-              </Typography>
-            </View>
-
-            <View style={styles.row}>
-              <Typography style={styles.aboutSectionParaBold}>
-                {Math.trunc(Dimensions.get('screen').width) +
-                  ' x ' +
-                  Math.trunc(Dimensions.get('screen').height)}
-              </Typography>
-            </View>
+          <View style={styles.row}>
+            <Typography style={styles.aboutSectionParaLabel}>
+              {t('about.operating_system_abbr')}
+            </Typography>
+            <Typography style={styles.aboutSectionParaContent}>
+              {Platform.OS + ' v' + Platform.Version}
+            </Typography>
           </View>
         </View>
-
-        <View style={styles.spacer} />
-        <View style={styles.spacer} />
       </ScrollView>
     </NavigationBarWrapper>
   );
@@ -107,33 +67,31 @@ export const AboutScreen = ({ navigation }) => {
 
 const styles = StyleSheet.create({
   contentContainer: {
-    flexDirection: 'column',
     backgroundColor: Colors.primaryBackground,
     paddingHorizontal: Spacing.medium,
+    paddingTop: Spacing.huge,
+  },
+  heading: {
+    marginBottom: Spacing.small,
   },
   hyperlink: {
     color: Colors.linkText,
     textDecorationLine: 'underline',
   },
-  aboutSectionParaBold: {
-    color: Colors.primaryViolet,
-    fontSize: 16,
-    lineHeight: 22.5,
-    marginTop: 20,
-    alignSelf: 'center',
-    fontFamily: fontFamily.primaryBold,
+  aboutSectionParaLabel: {
+    ...TypographyStyles.header5,
+    width: Spacing.xxxHuge * 2,
+    marginTop: Spacing.small,
   },
-  spacer: {
-    marginVertical: '2%',
+  aboutSectionParaContent: {
+    ...TypographyStyles.mainContent,
+    marginTop: Spacing.small,
   },
-  main: {
-    flexDirection: 'row',
+  rowContainer: {
+    marginTop: Spacing.medium,
   },
   row: {
     flexDirection: 'row',
-    color: Colors.primaryText,
-    alignItems: 'flex-start',
-    marginRight: 20,
   },
 });
 

--- a/app/views/__tests__/__snapshots__/Export.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Export.spec.js.snap
@@ -108,7 +108,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#f8f8f8",
+          "backgroundColor": "#f8f8ff",
           "flex": 1,
         }
       }

--- a/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
@@ -108,7 +108,7 @@ exports[`renders default values from the flags provider 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#f8f8f8",
+          "backgroundColor": "#f8f8ff",
           "flex": 1,
         }
       }

--- a/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -106,7 +106,7 @@ exports[`Import component renders correctly 1`] = `
   <View
     style={
       Object {
-        "backgroundColor": "#f8f8f8",
+        "backgroundColor": "#f8f8ff",
         "flex": 1,
       }
     }

--- a/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -108,7 +108,7 @@ exports[`renders correctly 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#f8f8f8",
+          "backgroundColor": "#f8f8ff",
           "flex": 1,
         }
       }

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -83,7 +83,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#f8f8f8",
+          "backgroundColor": "#f8f8ff",
           "flex": 1,
         }
       }
@@ -672,7 +672,7 @@ exports[`<Settings /> renders correctly without google import flag 1`] = `
     <View
       style={
         Object {
-          "backgroundColor": "#f8f8f8",
+          "backgroundColor": "#f8f8ff",
           "flex": 1,
         }
       }


### PR DESCRIPTION
#### Description:

This commit makes the following changes to the About screen:

- Removes the screen dimensions field and label
- Restyled and repositioning the copy on the screen
- Refactored the existing code and stripped out unused styling
- Updates screenshots

The following global changes were also made to allow these changes to happen:

- Created the `faintViolet` color variable and applied it to `primaryBackground`
- Created the `extraBold` and `header5` typography tokens

#### Linked issues:

https://trello.com/c/kptBs0kz/86-as-a-user-i-want-the-about-page-layout-to-be-consistent-with-the-mockups-and-the-spacing-typography-to-be-consistent-with-the-re

#### Screenshots:

![image](https://user-images.githubusercontent.com/2924479/85778507-a0899980-b6f0-11ea-87bd-f6b5d34479c0.png)

Co-authored-by: Alex Chen <achen178@gmail.com>