### PR TITLE
Dev Exposure Notifications Entitlements

### DIFF
--- a/ios/BT/BT-Development.entitlements
+++ b/ios/BT/BT-Development.entitlements
@@ -2,10 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>Development</string>
 	<key>com.apple.developer.exposure-notification-test</key>
 	<true/>
+  <key>com.apple.developer.exposure-notification-test-skip-file-verification</key>
+  <true/>
+  <key>com.apple.developer.exposure-notification-logging</key>
+  <true/>
+	<key>aps-environment</key>
+	<string>Development</string>
 	<key>com.apple.developer.exposure-notification</key>
 	<true/>
 </dict>

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -89,8 +89,6 @@ final class ExposureManager: NSObject {
     func finish(_ result: Result<[Exposure]>) {
 
       cleanup()
-
-      progress.cancel()
       
       if progress.isCancelled {
         detectingExposures = false


### PR DESCRIPTION
### Why
We'd like to detect exposures while running in dev

### This Commit
This commit adds the appropriate entitlements to the BT entitlements file, allowing us to use the `detectExposures` part of the framework without verifying keys from the server.

** Note: the exposure detection process takes about 2 minutes to execute

![IMG_1864](https://user-images.githubusercontent.com/2637355/85788454-fe22e380-b6fa-11ea-8044-822d75c024ca.PNG)
