### PR TITLE
Grab the HA to use in copy on app

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -26,7 +26,7 @@
     "isolate_description": "You <1>have some symptoms</1> that may be related to COVID-19. Call your healthcare provider if your symtoms get worse. Start home isolation.",
     "isolate_cta": "Next",
     "share_title": "Publish anonymized data",
-    "share_description": "Your anonymous data helps the Boston Public Health Commission analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.\n\nYour data contains your survey responses and zip code, but no additional or personally-identifying information.\n\nThe Boston Public Health Commission will retain your anonymous data for a specific period of time.",
+    "share_description": "Your anonymous data helps the {{ha_name}} analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.\n\nYour data contains your survey responses and zip code, but no additional or personally-identifying information.\n\nThe {{ha_name}} will retain your anonymous data for a specific period of time.",
     "share_screening_title": "Anonymized Screening Data",
     "share_screening_description": "Share anonymized answers to screening questions with your local healthcare authority.",
     "share_cta_skip": "No thanks, I don't want to share data",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -33,7 +33,7 @@
     "settings_subtitle": "Encuesta de autoinforme",
     "settings_title": "Encuesta",
     "share_cta_skip": "No gracias, no quiero compartir datos",
-    "share_description": "Sus datos anónimos ayudan a la Comisión de Salud Pública de Boston a analizar, rastrear y contener la propagación de COVID-19. Sus datos serán agregados a los de otros usuarios de PathCheck que elijan compartir.\n\nSus datos contienen sus respuestas a la encuesta y el código postal, pero ninguna información adicional o de identificación personal.\n\nLa Comisión de Salud Pública de Boston retendrá sus datos anónimos por un período de tiempo específico.",
+    "share_description": "Sus datos anónimos ayudan a la {{ha_name}} a analizar, rastrear y contener la propagación de COVID-19. Sus datos serán agregados a los de otros usuarios de PathCheck que elijan compartir.\n\nSus datos contienen sus respuestas a la encuesta y el código postal, pero ninguna información adicional o de identificación personal.\n\nLa {{ha_name}} retendrá sus datos anónimos por un período de tiempo específico.",
     "share_screening_description": "Comparta las respuestas anónimas a las preguntas de detección con su autoridad sanitaria local.",
     "share_screening_title": "Datos de cernimiento anónimos",
     "start_description": "Su información es privada, anónima y encriptada. Ningún dato sale de su dispositivo a menos que usted lo autorice.",

--- a/app/locales/es_PR.json
+++ b/app/locales/es_PR.json
@@ -34,7 +34,7 @@
     "settings_title": "Encuesta",
     "share_cta": "Entiendo y doy mi consentimiento",
     "share_cta_skip": "No gracias, no quiero compartir datos",
-    "share_description": "Sus datos anónimos ayudan a la Comisión de Salud Pública de Boston a analizar, rastrear y contener la propagación de COVID-19. Sus datos serán agregados a los de otros usuarios de PathCheck que elijan compartir.\n\nSus datos contienen sus respuestas a la encuesta y el código postal, pero ninguna información adicional o de identificación personal.\n\nLa Comisión de Salud Pública de Boston retendrá sus datos anónimos por un período de tiempo específico.",
+    "share_description": "Sus datos anónimos ayudan a la {{ha_name}} a analizar, rastrear y contener la propagación de COVID-19. Sus datos serán agregados a los de otros usuarios de PathCheck que elijan compartir.\n\nSus datos contienen sus respuestas a la encuesta y el código postal, pero ninguna información adicional o de identificación personal.\n\nLa {{ha_name}} retendrá sus datos anónimos por un período de tiempo específico.",
     "share_screening_description": "Comparta las respuestas anónimas a las preguntas de detección con su autoridad sanitaria local.",
     "share_screening_title": "Datos de cernimiento anónimos",
     "share_title": "Publicar datos anónimos",

--- a/app/locales/tl.json
+++ b/app/locales/tl.json
@@ -8,7 +8,7 @@
     "next": "Sa susunod",
     "share_cta": "Naiintindihan ko at pumapayag ako",
     "share_cta_skip": "Salamat na lang, ayaw ko'ng magbahagi ng data",
-    "share_description": "Ang anonimong, o walang pangalan na, na data ay tumutulong sa Boston Public Health Commission sa paganalisa, pagsubaybay at pagpigil sa paglaganap ng COVID-19. Ang iyong data ay isasama sa impormasyon ng ibang gumagamit ng PathCheck na pinili ang makipagbigay-alam.",
+    "share_description": "Ang anonimong, o walang pangalan na, na data ay tumutulong sa {{ha_name}} sa paganalisa, pagsubaybay at pagpigil sa paglaganap ng COVID-19. Ang iyong data ay isasama sa impormasyon ng ibang gumagamit ng PathCheck na pinili ang makipagbigay-alam.",
     "share_screening_description": "Ipamahagi ang anonimo, o walang pangalan, na sagot sa mga screening questions sa iyong Departamentong Pangkalusugan.",
     "share_screening_title": "Anonimong, o walang pangalan na, Data ng Screening",
     "start_cta": "Simula",

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -1,14 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { TouchableOpacity, View, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import { Typography } from '../../components/Typography';
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
 import { Screens, useStatusBarEffect } from '../../navigation';
+import getHealthcareAuthorities from '../../store/actions/healthcareAuthorities/getHealthcareAuthoritiesAction';
+import healthcareAuthorityOptionsSelector from '../../store/selectors/healthcareAuthorityOptionsSelector';
 
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 
 const NextSteps = (): JSX.Element => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getHealthcareAuthorities());
+  }, [dispatch]);
+  const authorities = useSelector(healthcareAuthorityOptionsSelector);
+  const selectedAuthorityDummy = authorities[0];
+
   const navigation = useNavigation();
   useStatusBarEffect('light-content');
 
@@ -16,9 +26,9 @@ const NextSteps = (): JSX.Element => {
     navigation.goBack();
   };
 
-  const healthAuthority = 'Boston Public Health Commission';
+  const healthAuthorityName = selectedAuthorityDummy.name;
 
-  const headerText = `${healthAuthority} recommends you take a self-assessment`;
+  const headerText = `${healthAuthorityName} recommends you take a self-assessment`;
 
   const contentTextOne =
     'It is possible that you may have crossed paths with somebody who has been diagnosed with COVID-19.';

--- a/app/views/assessment/__tests__/endScreens/Share.spec.js
+++ b/app/views/assessment/__tests__/endScreens/Share.spec.js
@@ -6,6 +6,15 @@ import i18n from '../../../../locales/languages';
 import { MetaContext } from '../../Context';
 import { Share } from '../../endScreens/Share';
 
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(jest.fn),
+  useSelector: () => [
+    {
+      name: 'Boston Public Health Commission',
+    },
+  ],
+}));
+
 test('base', () => {
   const { asJSON } = render(<Share />, { wrapper: Wrapper });
   expect(asJSON()).toMatchSnapshot();

--- a/app/views/assessment/endScreens/Share.js
+++ b/app/views/assessment/endScreens/Share.js
@@ -1,8 +1,10 @@
-import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 
 import { Icons } from '../../../assets';
-import { Typography } from '../../../components/Typography';
+import getHealthcareAuthorities from '../../../store/actions/healthcareAuthorities/getHealthcareAuthoritiesAction';
+import healthcareAuthorityOptionsSelector from '../../../store/selectors/healthcareAuthorityOptionsSelector';
 import { Info } from '../Info';
 
 import { Colors } from '../../../styles';
@@ -10,6 +12,15 @@ import { Colors } from '../../../styles';
 /** @type {React.FunctionComponent<{}>} */
 export const Share = ({ navigation }) => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getHealthcareAuthorities());
+  }, [dispatch]);
+  const authorities = useSelector(healthcareAuthorityOptionsSelector);
+  const selectedAuthorityDummy = authorities[0];
+  const shareDescription = t('assessment.share_description', {
+    ha_name: selectedAuthorityDummy.name,
+  });
 
   return (
     <Info
@@ -19,13 +30,7 @@ export const Share = ({ navigation }) => {
       icon={Icons.AnonymizedDataInverted}
       backgroundColor={Colors.primaryBackgroundFaintShade}
       ctaTitle={t('assessment.share_cta')}
-      description={
-        <>
-          <Trans t={t} i18nKey='assessment.share_description'>
-            <Typography />
-          </Trans>
-        </>
-      }
+      description={shareDescription}
       title={t('assessment.share_title')}
     />
   );


### PR DESCRIPTION
#### Description:

In order to easily sub in the appropriate HA, different AUTHORITIES_YAML_ROUTE's can be used in the env files. This is a simple solution to allow for customization inside the app.

#### Linked issues:

[Customize HA in app](https://trello.com/c/L4pNhsN4/71-as-a-dev-team-we-have-a-way-to-customize-the-webview-url-and-the-health-authority-name-in-the-app)

#### How to test:

By changing the URL inside the env.bt file to point to a URL that provides a different HA, the content within the app will change. We are using the trusted_authorities repo to set this `https://raw.githubusercontent.com/Path-Check/trusted-authorities/master/staging/authorities.1.0.1.yaml`. I would recommend using a new branch on that repo, updating the data appropriately, and changing the url inside the env.bt to point to that url instead.