### PR TITLE
Remove share test results from settings

### DIFF
--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -155,17 +155,6 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
           </NativePicker>
         </View>
 
-        {!isGPS && (
-          <View style={styles.section}>
-            <SettingsListItem
-              label={t('settings.share_test_result')}
-              onPress={navigateTo('ExportFlow')}
-              description={t('settings.share_test_result_description')}
-              style={styles.lastListItem}
-            />
-          </View>
-        )}
-
         {isGPS ? (
           <FeatureFlag name={'google_import'}>
             <View style={styles.section}>


### PR DESCRIPTION
#### Description:

Removed share test results from the settings screen to match the latest Figma mockups here https://www.figma.com/file/79OwaKqHvSeriExpYzAvVN/PathCheck-Exploration-April-May-June-2020?node-id=3601%3A26330

#### Linked issues:

https://www.figma.com/file/79OwaKqHvSeriExpYzAvVN/PathCheck-Exploration-April-May-June-2020?node-id=3601%3A26330

#### Screenshots:

<img width="435" alt="Screen Shot 2020-06-27 at 10 18 58 AM" src="https://user-images.githubusercontent.com/2924479/85924330-a5b92680-b85f-11ea-8797-6dba573cf6c8.png">

