### PR TITLE
Update styling of exposure history flow

### DIFF
--- a/app/styles/outlines.ts
+++ b/app/styles/outlines.ts
@@ -9,6 +9,7 @@ export const maxBorderRadius = 500;
 export const hairline = 1;
 export const thin = 2;
 export const thick = 3;
+export const extraThick = 4;
 
 export const roundedBorder: ViewStyle = {
   borderWidth: 1,

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -49,6 +49,10 @@ export const mediumBold: TextStyle = {
   fontFamily: mediumFontFamily,
 };
 
+export const base: TextStyle = {
+  fontFamily: baseFontFamily,
+};
+
 export const monospace: TextStyle = {
   fontFamily: monospaceFontFamily,
 };
@@ -119,6 +123,12 @@ export const header5: TextStyle = {
   color: Colors.primaryHeaderText,
 };
 
+export const header6: TextStyle = {
+  ...largerFont,
+  ...bold,
+  color: Colors.black,
+};
+
 export const title: TextStyle = {
   ...largeFont,
   fontWeight: heaviestWeight,
@@ -133,6 +143,7 @@ export const mainContent: TextStyle = {
 
 export const secondaryContent: TextStyle = {
   ...mediumFont,
+  ...base,
   color: Colors.secondaryText,
   lineHeight: mediumLineHeight,
 };

--- a/app/views/ExposureHistory/Calendar.tsx
+++ b/app/views/ExposureHistory/Calendar.tsx
@@ -36,14 +36,14 @@ const Calendar = ({
     return (
       <View style={styles.calendarRow}>
         {week.map((datum: ExposureDatum) => {
+          const isSelected = datum.date === selectedDatum?.date;
+
           return (
             <TouchableOpacity
               key={`calendar-day-${datum.date}`}
               onPress={() => onSelectDate(datum)}>
               <ExposureDatumIndicator
-                isSelected={
-                  selectedDatum ? datum.date === selectedDatum.date : false
-                }
+                isSelected={isSelected}
                 exposureDatum={datum}
               />
             </TouchableOpacity>
@@ -60,7 +60,7 @@ const Calendar = ({
         {labels.map((label: string, idx: number) => {
           return (
             <View style={styles.labelStyle} key={`calendar-label-${idx}`}>
-              <Text>{label}</Text>
+              <Text style={styles.labelTextStyle}>{label}</Text>
             </View>
           );
         })}
@@ -93,12 +93,16 @@ const styles = StyleSheet.create({
   },
   monthText: {
     ...TypographyStyles.label,
+    ...TypographyStyles.bold,
     color: Colors.secondaryHeaderText,
   },
-  calendarContainer: { flex: 1, paddingVertical: Spacing.small },
+  calendarContainer: {
+    flex: 1,
+    paddingVertical: Spacing.small,
+  },
   calendarRow: {
     flex: 1,
-    paddingVertical: Spacing.xSmall,
+    paddingVertical: Spacing.xxSmall,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -106,7 +110,10 @@ const styles = StyleSheet.create({
   labelStyle: {
     justifyContent: 'center',
     alignItems: 'center',
-    width: 36,
+    width: Spacing.xHuge,
+  },
+  labelTextStyle: {
+    ...TypographyStyles.base,
   },
 });
 

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -44,7 +44,7 @@ const PossibleExposureDetail = ({
   const navigation = useNavigation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
   const exposureTime = `Possible Exposure Time: ${exposureDurationText}`;
-  const explainationContent = `For ${exposureDurationText}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.`;
+  const explanationContent = `For ${exposureDurationText}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.`;
 
   const handleOnPressNextSteps = () => {
     navigation.navigate(Screens.NextSteps);
@@ -58,7 +58,7 @@ const PossibleExposureDetail = ({
         <Typography style={styles.date}>{exposureDate}</Typography>
         <Typography style={styles.info}>{exposureTime}</Typography>
         <View style={styles.contentContainer}>
-          <Typography style={styles.content}>{explainationContent}</Typography>
+          <Typography style={styles.content}>{explanationContent}</Typography>
         </View>
       </View>
       <View style={styles.ctaContainer}>
@@ -82,13 +82,13 @@ const NoKnownExposureDetail = ({
   datum: { date },
 }: NoKnownExposureDetailProps) => {
   const exposureDate = dayjs(date).format('dddd, MMM DD');
-  const explainationContent =
+  const explanationContent =
     'Your exposure history will be updated if this changes in the future.';
   return (
     <View style={styles.container}>
       <Typography style={styles.date}>{exposureDate}</Typography>
       <View style={styles.contentContainer}>
-        <Typography style={styles.content}>{explainationContent}</Typography>
+        <Typography style={styles.content}>{explanationContent}</Typography>
       </View>
     </View>
   );
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.lighterGray,
   },
   date: {
-    ...TypographyStyles.header2,
+    ...TypographyStyles.header6,
   },
   info: {
     lineHeight: TypographyStyles.largeLineHeight,

--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -4,7 +4,13 @@ import dayjs from 'dayjs';
 
 import { DateTimeUtils } from '../../helpers';
 import { ExposureDatum } from '../../exposureHistory';
-import { Affordances, Outlines, Colors, Typography } from '../../styles';
+import {
+  Affordances,
+  Outlines,
+  Colors,
+  Typography,
+  Spacing,
+} from '../../styles';
 
 interface ExposureDatumIndicatorProps {
   exposureDatum: ExposureDatum;
@@ -111,15 +117,17 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    width: 36,
-    height: 36,
+    width: Spacing.xHuge,
+    height: Spacing.xHuge,
     borderRadius: Outlines.maxBorderRadius,
     borderColor: Colors.transparent,
-    borderWidth: Outlines.thick,
+    borderWidth: Outlines.extraThick,
   },
   textBase: {
     ...Typography.smallFont,
+    ...Typography.monospace,
     color: Colors.primaryText,
+    fontWeight: Typography.heavyWeight,
   },
   selectedBadge: {
     ...Affordances.bottomDotBadge(Colors.primaryText),

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -26,6 +26,7 @@ import {
   Typography as TypographyStyles,
   Colors,
 } from '../../styles';
+import dayjs from 'dayjs';
 
 const ExposureHistoryScreen = (): JSX.Element => {
   const { t } = useTranslation();
@@ -37,8 +38,14 @@ const ExposureHistoryScreen = (): JSX.Element => {
 
   useStatusBarEffect('dark-content');
 
+  const isTodayOrBefore = (date: number) => {
+    return !dayjs(date).isAfter(dayjs(), 'day');
+  };
+
   const handleOnSelectDate = (datum: ExposureDatum) => {
-    setSelectedDatum(datum);
+    if (isTodayOrBefore(datum.date)) {
+      setSelectedDatum(datum);
+    }
   };
 
   const handleOnPressMoreInfo = () => {
@@ -54,13 +61,16 @@ const ExposureHistoryScreen = (): JSX.Element => {
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <ScrollView style={styles.container} alwaysBounceVertical={false}>
-        <View style={styles.header}>
+        <View>
           <View style={styles.headerRow}>
             <Typography style={styles.headerText}>{titleText}</Typography>
             <TouchableOpacity
               onPress={handleOnPressMoreInfo}
               style={styles.moreInfoButton}>
-              <SvgXml xml={Icons.QuestionMark} />
+              <SvgXml
+                xml={Icons.QuestionMark}
+                style={styles.moreInfoButtonIcon}
+              />
             </TouchableOpacity>
           </View>
           {!isGPS ? (
@@ -93,7 +103,6 @@ const styles = StyleSheet.create({
     padding: Spacing.medium,
     backgroundColor: Colors.primaryBackground,
   },
-  header: {},
   headerRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -105,11 +114,16 @@ const styles = StyleSheet.create({
   },
   subHeaderText: {
     ...TypographyStyles.header4,
+    ...TypographyStyles.bold,
   },
   moreInfoButton: {
     ...Buttons.tinyTeritiaryRounded,
-    minHeight: 44,
-    minWidth: 44,
+    minHeight: Spacing.xHuge,
+    minWidth: Spacing.xHuge,
+  },
+  moreInfoButtonIcon: {
+    minHeight: Spacing.small,
+    minWidth: Spacing.small,
   },
   calendarContainer: {
     marginTop: Spacing.xxLarge,

--- a/app/views/__tests__/__snapshots__/Export.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Export.spec.js.snap
@@ -221,6 +221,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                     Array [
                       Object {
                         "color": "#ffffff",
+                        "fontFamily": "IBMPlexSans",
                         "fontSize": 17,
                         "lineHeight": 28,
                       },

--- a/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/FeatureFlagToggles.spec.js.snap
@@ -139,6 +139,7 @@ exports[`renders default values from the flags provider 1`] = `
           Array [
             Object {
               "color": "#4e4e4e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -263,6 +264,7 @@ exports[`renders default values from the flags provider 1`] = `
                 Array [
                   Object {
                     "color": "#4e4e4e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
@@ -158,6 +158,7 @@ exports[`LicensesScreen renders correctly 1`] = `
                   Array [
                     Object {
                       "color": "#4e4e4e",
+                      "fontFamily": "IBMPlexSans",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },
@@ -185,6 +186,7 @@ Somerville, MA 02144
                   Array [
                     Object {
                       "color": "#4e4e4e",
+                      "fontFamily": "IBMPlexSans",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },
@@ -205,6 +207,7 @@ Somerville, MA 02144
                   Array [
                     Object {
                       "color": "#4e4e4e",
+                      "fontFamily": "IBMPlexSans",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -326,6 +326,7 @@ exports[`<Settings /> renders correctly with google import flag 1`] = `
                   Array [
                     Object {
                       "color": "#4e4e4e",
+                      "fontFamily": "IBMPlexSans",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },


### PR DESCRIPTION
#### Description:
- Disables the selection of future dates in the calendar
- Updates styling on the exposure history screen

#### Linked issues:
https://trello.com/c/IEWxxQLX

#### Screenshots:
<img width="320" alt="Screen Shot 2020-06-29 at 5 59 00 PM" src="https://user-images.githubusercontent.com/39350030/86060175-39425100-ba32-11ea-95f5-299dabd231d2.png">

#### How to test:
- Try to select a date in the future on the calendar and validate that you cannot
- Validate that the visual styles on the Exposure History screen match the mockups

Co-Authored-By: Jeff Stolz <jstolz123@gmail.com>
Co-Authored-By: Eric Bailey <eric.w.bailey@gmail.com>