### PR TITLE
Fix Notification Service Import Warning

### DIFF
--- a/app/services/NotificationService.js
+++ b/app/services/NotificationService.js
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import PushNotification from 'react-native-push-notification';
-import { PermissionStatus } from '../gps/PermissionsContext';
+import { PermissionStatus } from '../permissionStatus';
 
 export default class NotificationService {
   static async configure(notificationStatus) {


### PR DESCRIPTION
#### Description:
When navigating to the main screen of the GPS app there is an unhandled promise rejection warning. This fixes the import bug causing the warning.

#### Screenshots:
<img width="413" alt="Screen Shot 2020-06-30 at 11 07 03 AM" src="https://user-images.githubusercontent.com/20758953/86142994-df896780-bac1-11ea-8c67-8cdc39274f47.png">

#### How to test:
Navigate to the main screen. You should no longer see the warning in the console.
