### PR TITLE
Add base font family to all text

### DIFF
--- a/app/bt/Home/__snapshots__/index.spec.tsx.snap
+++ b/app/bt/Home/__snapshots__/index.spec.tsx.snap
@@ -108,6 +108,7 @@ exports[`HomeScreen renders 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },
@@ -133,6 +134,7 @@ exports[`HomeScreen renders 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },
@@ -141,6 +143,7 @@ exports[`HomeScreen renders 1`] = `
                 },
                 Object {
                   "color": "#ffffff",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 15,
                   "lineHeight": 24,
                   "marginTop": 20,
@@ -178,6 +181,7 @@ exports[`HomeScreen renders 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },

--- a/app/components/Typography.tsx
+++ b/app/components/Typography.tsx
@@ -39,7 +39,7 @@ export const Typography = ({
         return TypographyStyles.secondaryContent;
       }
       case 'body3': {
-        return TypographyStyles.tertirayContent;
+        return TypographyStyles.tertiaryContent;
       }
     }
   };

--- a/app/components/__tests__/__snapshots__/Button.spec.js.snap
+++ b/app/components/__tests__/__snapshots__/Button.spec.js.snap
@@ -35,6 +35,7 @@ exports[`allows small override 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },
@@ -90,6 +91,7 @@ exports[`changes color based on theme 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },
@@ -132,6 +134,7 @@ exports[`changes color based on theme 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },
@@ -174,6 +177,7 @@ exports[`changes color based on theme 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },
@@ -229,6 +233,7 @@ exports[`renders a violet 72px button on default theme 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },
@@ -284,6 +289,7 @@ exports[`renders an icon and space-between if supplied 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },
@@ -339,6 +345,7 @@ exports[`renders different color for secondary 1`] = `
         Array [
           Object {
             "color": "#2e2e2e",
+            "fontFamily": "IBMPlexSans",
             "fontSize": 17,
             "lineHeight": 28,
           },

--- a/app/components/__tests__/__snapshots__/Typography.spec.js.snap
+++ b/app/components/__tests__/__snapshots__/Typography.spec.js.snap
@@ -15,6 +15,7 @@ exports[`body1 is regular 1`] = `
       Array [
         Object {
           "color": "#2e2e2e",
+          "fontFamily": "IBMPlexSans",
           "fontSize": 17,
           "lineHeight": 28,
         },

--- a/app/constants/__tests__/__snapshots__/Theme.spec.js.snap
+++ b/app/constants/__tests__/__snapshots__/Theme.spec.js.snap
@@ -15,6 +15,7 @@ exports[`changes text color based on theme 1`] = `
       Array [
         Object {
           "color": "#2e2e2e",
+          "fontFamily": "IBMPlexSans",
           "fontSize": 17,
           "lineHeight": 28,
         },
@@ -32,6 +33,7 @@ exports[`changes text color based on theme 1`] = `
       Array [
         Object {
           "color": "#2e2e2e",
+          "fontFamily": "IBMPlexSans",
           "fontSize": 17,
           "lineHeight": 28,
         },

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -35,6 +35,10 @@ export const mediumFontFamily = 'IBMPlexSans-Medium';
 export const boldFontFamily = 'IBMPlexSans-Bold';
 export const monospaceFontFamily = 'IBMPlexMono';
 
+const base: TextStyle = {
+  fontFamily: baseFontFamily,
+};
+
 export const extraBold: TextStyle = {
   fontFamily: boldFontFamily,
   fontWeight: heaviestWeight,
@@ -49,46 +53,49 @@ export const mediumBold: TextStyle = {
   fontFamily: mediumFontFamily,
 };
 
-export const base: TextStyle = {
-  fontFamily: baseFontFamily,
-};
-
 export const monospace: TextStyle = {
   fontFamily: monospaceFontFamily,
 };
 
 // Standard Font Types
 export const tinyFont: TextStyle = {
+  ...base,
   lineHeight: smallestLineHeight,
   fontSize: tiny,
 };
 
 export const smallFont: TextStyle = {
+  ...base,
   lineHeight: smallLineHeight,
   fontSize: small,
 };
 
 export const mediumFont: TextStyle = {
+  ...base,
   lineHeight: mediumLineHeight,
   fontSize: medium,
 };
 
 export const largeFont: TextStyle = {
+  ...base,
   lineHeight: largestLineHeight,
   fontSize: large,
 };
 
 export const largerFont: TextStyle = {
+  ...base,
   lineHeight: largestLineHeight,
   fontSize: larger,
 };
 
 export const largestFont: TextStyle = {
+  ...base,
   lineHeight: largestLineHeight,
   fontSize: largest,
 };
 
 export const hugeFont: TextStyle = {
+  ...base,
   lineHeight: hugeLineHeight,
   fontSize: huge,
 };
@@ -148,7 +155,7 @@ export const secondaryContent: TextStyle = {
   lineHeight: mediumLineHeight,
 };
 
-export const tertirayContent: TextStyle = {
+export const tertiaryContent: TextStyle = {
   ...smallFont,
   color: Colors.tertiaryText,
   lineHeight: smallLineHeight,

--- a/app/views/ExposureHistory/Calendar.tsx
+++ b/app/views/ExposureHistory/Calendar.tsx
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
     width: Spacing.xHuge,
   },
   labelTextStyle: {
-    ...TypographyStyles.base,
+    ...TypographyStyles.label,
   },
 });
 

--- a/app/views/__tests__/__snapshots__/Export.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Export.spec.js.snap
@@ -77,6 +77,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },
@@ -179,6 +180,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                   Array [
                     Object {
                       "color": "#2e2e2e",
+                      "fontFamily": "IBMPlexSans",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },
@@ -212,6 +214,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                   Array [
                     Object {
                       "color": "#2e2e2e",
+                      "fontFamily": "IBMPlexSans",
                       "fontSize": 17,
                       "lineHeight": 28,
                     },
@@ -260,6 +263,7 @@ exports[`<ExportScreen /> renders correctly 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -75,6 +75,7 @@ exports[`Import component renders correctly 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -124,6 +125,7 @@ exports[`Import component renders correctly 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },
@@ -143,6 +145,7 @@ exports[`Import component renders correctly 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },
@@ -162,6 +165,7 @@ exports[`Import component renders correctly 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },
@@ -213,6 +217,7 @@ exports[`Import component renders correctly 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },
@@ -262,6 +267,7 @@ exports[`Import component renders correctly 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },

--- a/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
@@ -77,6 +77,7 @@ exports[`LicensesScreen renders correctly 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },
@@ -247,6 +248,7 @@ Somerville, MA 02144
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },

--- a/app/views/assessment/__tests__/__snapshots__/Button.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Button.spec.js.snap
@@ -40,6 +40,7 @@ exports[`base 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -105,6 +106,7 @@ exports[`color 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -170,6 +172,7 @@ exports[`disabled 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },

--- a/app/views/assessment/__tests__/__snapshots__/Option.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Option.spec.js.snap
@@ -68,6 +68,7 @@ exports[`SCREEN_TYPE_CHECKBOX 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },
@@ -163,6 +164,7 @@ exports[`SCREEN_TYPE_RADIO 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },

--- a/app/views/assessment/__tests__/__snapshots__/Question.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Question.spec.js.snap
@@ -67,6 +67,7 @@ exports[`base 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },
@@ -150,6 +151,7 @@ exports[`base 1`] = `
                       Array [
                         Object {
                           "color": "#2e2e2e",
+                          "fontFamily": "IBMPlexSans",
                           "fontSize": 17,
                           "lineHeight": 28,
                         },
@@ -232,6 +234,7 @@ exports[`base 1`] = `
                       Array [
                         Object {
                           "color": "#2e2e2e",
+                          "fontFamily": "IBMPlexSans",
                           "fontSize": 17,
                           "lineHeight": 28,
                         },
@@ -297,6 +300,7 @@ exports[`base 1`] = `
               Array [
                 Object {
                   "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
                   "fontSize": 17,
                   "lineHeight": 28,
                 },

--- a/app/views/assessment/__tests__/__snapshots__/Start.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Start.spec.js.snap
@@ -101,6 +101,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -156,6 +157,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Caregiver.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Caregiver.spec.js.snap
@@ -105,6 +105,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -164,6 +165,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Complete.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Complete.spec.js.snap
@@ -101,6 +101,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -158,6 +159,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Distancing.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Distancing.spec.js.snap
@@ -105,6 +105,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -162,6 +163,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Emergency.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Emergency.spec.js.snap
@@ -105,6 +105,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -164,6 +165,7 @@ Tell the emergency operator if you have been in contact with someone with COVID-
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Isolate.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Isolate.spec.js.snap
@@ -105,6 +105,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -162,6 +163,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Share.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Share.spec.js.snap
@@ -96,6 +96,7 @@ exports[`base 1`] = `
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },
@@ -155,6 +156,7 @@ The Boston Public Health Commission will retain your anonymous data for a specif
                 Array [
                   Object {
                     "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans",
                     "fontSize": 17,
                     "lineHeight": 28,
                   },

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NoAuthorities.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NoAuthorities.spec.js.snap
@@ -136,6 +136,7 @@ exports[`no authorities screen matches snapshot 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NotificationsOff.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NotificationsOff.spec.js.snap
@@ -136,6 +136,7 @@ exports[`notifications off screen matches snapshot 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -171,6 +172,7 @@ exports[`notifications off screen matches snapshot 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/SelectAuthority.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/SelectAuthority.spec.js.snap
@@ -136,6 +136,7 @@ exports[`select authority screen matches snapshot 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -171,6 +172,7 @@ exports[`select authority screen matches snapshot 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/TracingOff.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/TracingOff.spec.js.snap
@@ -136,6 +136,7 @@ exports[`tracing off screen matches snapshot 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -171,6 +172,7 @@ exports[`tracing off screen matches snapshot 1`] = `
             Array [
               Object {
                 "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
                 "fontSize": 17,
                 "lineHeight": 28,
               },

--- a/app/views/main/__tests__/__snapshots__/AllServicesOn.spec.js.snap
+++ b/app/views/main/__tests__/__snapshots__/AllServicesOn.spec.js.snap
@@ -123,6 +123,7 @@ exports[`all services on matches snapshot 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },
@@ -146,6 +147,7 @@ exports[`all services on matches snapshot 1`] = `
           Array [
             Object {
               "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
               "fontSize": 17,
               "lineHeight": 28,
             },


### PR DESCRIPTION
Why:
Currently we are only applying the product's font family, IBMPlexSans,
to text elements that have been given the bold style and others have the
default system font family. We would like for all of the fonts to be the
product font family.

Co-authored-by: devin jameson <devin@thoughtbot.com>
