### PR TITLE
Add exposure history legend

### DIFF
--- a/app/components/Typography.tsx
+++ b/app/components/Typography.tsx
@@ -39,7 +39,7 @@ export const Typography = ({
         return TypographyStyles.secondaryContent;
       }
       case 'body3': {
-        return TypographyStyles.tertirayContent;
+        return TypographyStyles.tertiaryContent;
       }
     }
   };

--- a/app/factories/exposureDatum.tsx
+++ b/app/factories/exposureDatum.tsx
@@ -1,0 +1,16 @@
+import { Factory } from 'fishery';
+
+import { daysAgo, beginningOfDay } from '../helpers/dateTimeUtils';
+
+import { ExposureDatum } from '../exposureHistory';
+
+export default Factory.define<ExposureDatum>(() => {
+  const defaultDate = beginningOfDay(daysAgo(2));
+  return {
+    kind: 'Possible',
+    date: defaultDate,
+    duration: 300000,
+    totalRiskScore: 4,
+    transmissionRiskLevel: 7,
+  };
+});

--- a/app/factories/index.ts
+++ b/app/factories/index.ts
@@ -1,6 +1,8 @@
 import { register } from 'fishery';
 import tracingStrategy from './tracingStrategy';
+import exposureDatum from './exposureDatum';
 
 export const factories = register({
   tracingStrategy,
+  exposureDatum,
 });

--- a/app/helpers/dateTimeUtils.ts
+++ b/app/helpers/dateTimeUtils.ts
@@ -9,6 +9,10 @@ export const isToday = (date: Posix): boolean => {
   return beginningOfToday <= date && endOfToday >= date;
 };
 
+export const daysAgo = (days: number): Posix => {
+  return dayjs(Date.now()).subtract(days, 'day').valueOf();
+};
+
 export const beginningOfDay = (date: Posix): Posix => {
   return dayjs(date).startOf('day').valueOf();
 };

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -107,6 +107,12 @@
     "last_days": "Last 21 days",
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
     "how_does_this_work": "How does this work?",
+    "legend": {
+      "exposure_likely": "Exposure very likely",
+      "exposure_possible": "Exposure possible",
+      "no_exposure_detected": "No exposure detected",
+      "today": "Today"
+    },
     "bt": {
       "why_did_i_get_an_en_para": "You will receive an exposure notification when someone you crossed paths with later receives a confirmed, positive diagnosis or test for COVID-19 and chooses to notify others",
       "how_does_this_work": "How does this work?",

--- a/app/styles/affordances.ts
+++ b/app/styles/affordances.ts
@@ -26,3 +26,16 @@ export const bottomDotBadge = (color: string): ViewStyle => {
     alignItems: 'center',
   };
 };
+
+export const smallBottomDotBadge = (color: string): ViewStyle => {
+  return {
+    position: 'absolute',
+    bottom: -2,
+    backgroundColor: color,
+    borderRadius: 2,
+    width: 4,
+    height: 4,
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+};

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -157,4 +157,5 @@ export const onboardingIconYellow = champangne;
 export const onboardingIconBlue = moonRaker;
 
 // Exposure History
-export const exposureRiskWarning = royalBlue;
+export const possibleExposure = royalBlue;
+export const expectedExposure = amber;

--- a/app/styles/iconography.ts
+++ b/app/styles/iconography.ts
@@ -1,7 +1,17 @@
-import { ViewStyle } from 'react-native';
+import { ViewStyle, TextStyle } from 'react-native';
 
 import * as Colors from './colors';
 import * as Spacing from './spacing';
+import * as Typography from './typography';
+
+export const smallIcon: ViewStyle = {
+  height: 30,
+  width: 30,
+  borderRadius: 100,
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginVertical: Spacing.small,
+};
 
 export const largeIcon: ViewStyle = {
   height: 70,
@@ -21,4 +31,36 @@ export const largeBlueIcon: ViewStyle = {
 export const largeGoldIcon: ViewStyle = {
   ...largeIcon,
   backgroundColor: Colors.onboardingIconYellow,
+};
+
+// Exposure History
+export const possibleExposure: ViewStyle = {
+  backgroundColor: Colors.possibleExposure,
+  borderColor: Colors.possibleExposure,
+};
+
+export const expectedExposure: ViewStyle = {
+  backgroundColor: Colors.expectedExposure,
+  borderColor: Colors.expectedExposure,
+};
+
+export const possibleExposureText: TextStyle = {
+  ...Typography.bold,
+  color: Colors.white,
+};
+
+export const expectedExposureText: TextStyle = {
+  ...Typography.bold,
+  color: Colors.darkestGray,
+};
+
+export const noExposureText: TextStyle = {
+  ...Typography.bold,
+  color: Colors.primaryViolet,
+};
+
+export const todayText: TextStyle = {
+  ...Typography.smallFont,
+  ...Typography.bold,
+  color: Colors.primaryViolet,
 };

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -49,12 +49,12 @@ export const mediumBold: TextStyle = {
   fontFamily: mediumFontFamily,
 };
 
-export const base: TextStyle = {
-  fontFamily: baseFontFamily,
-};
-
 export const monospace: TextStyle = {
   fontFamily: monospaceFontFamily,
+};
+
+export const base: TextStyle = {
+  fontFamily: baseFontFamily,
 };
 
 // Standard Font Types
@@ -148,7 +148,7 @@ export const secondaryContent: TextStyle = {
   lineHeight: mediumLineHeight,
 };
 
-export const tertirayContent: TextStyle = {
+export const tertiaryContent: TextStyle = {
   ...smallFont,
   color: Colors.tertiaryText,
   lineHeight: smallLineHeight,

--- a/app/views/ExposureHistory/Calendar.spec.tsx
+++ b/app/views/ExposureHistory/Calendar.spec.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react-native';
+
+import { calendarDays, toExposureHistory } from '../../exposureHistory';
+import { factories } from '../../factories';
+
+import Calendar from './Calendar';
+
+afterEach(cleanup);
+
+describe('Calendar', () => {
+  it('renders', () => {
+    const exposureHistory = buildExposureHistory();
+    const onSelectDate = () => {};
+    const selectedDatum = exposureHistory[0];
+
+    const { asJSON } = render(
+      <Calendar
+        exposureHistory={exposureHistory}
+        onSelectDate={onSelectDate}
+        selectedDatum={selectedDatum}
+      />,
+    );
+
+    expect(asJSON()).toMatchSnapshot();
+  });
+});
+
+const buildExposureHistory = () => {
+  const datum = factories.exposureDatum.build();
+  const exposureInfo = {
+    [datum.date]: datum,
+  };
+  const calendar = calendarDays(Date.now(), 21);
+  return toExposureHistory(exposureInfo, calendar);
+};

--- a/app/views/ExposureHistory/Calendar.tsx
+++ b/app/views/ExposureHistory/Calendar.tsx
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 
 import { ExposureHistory, ExposureDatum } from '../../exposureHistory';
 import { Typography } from '../../components/Typography';
 import ExposureDatumIndicator from './ExposureDatumIndicator';
+import LegendModal from './LegendModal';
 
-import { Colors, Spacing, Typography as TypographyStyles } from '../../styles';
+import {
+  Buttons,
+  Colors,
+  Spacing,
+  Typography as TypographyStyles,
+} from '../../styles';
 
 interface CalendarProps {
   exposureHistory: ExposureHistory;
@@ -14,11 +21,15 @@ interface CalendarProps {
   selectedDatum: ExposureDatum | null;
 }
 
+type ModalState = 'Open' | 'Closed';
+
 const Calendar = ({
   exposureHistory,
   onSelectDate,
   selectedDatum,
 }: CalendarProps): JSX.Element => {
+  const { t } = useTranslation();
+  const [legendModal, setLegendModal] = useState<ModalState>('Closed');
   const lastMonth = dayjs().subtract(1, 'month');
   const title = `${lastMonth.format('MMMM')} | ${dayjs().format(
     'MMMM',
@@ -68,10 +79,25 @@ const Calendar = ({
     );
   };
 
+  const handleOnPressLegend = () => {
+    setLegendModal('Open');
+  };
+
+  const handleOnCloseModal = () => {
+    setLegendModal('Closed');
+  };
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
         <Typography style={styles.monthText}>{title}</Typography>
+        <TouchableOpacity
+          onPress={handleOnPressLegend}
+          style={styles.legendButton}>
+          <Typography style={styles.legendText}>
+            {t('exposure_history.legend_button')}
+          </Typography>
+        </TouchableOpacity>
       </View>
       <View style={styles.calendarContainer}>
         <DayLabels />
@@ -79,6 +105,10 @@ const Calendar = ({
         <CalendarRow week={week2} />
         <CalendarRow week={week3} />
       </View>
+      <LegendModal
+        status={legendModal}
+        handleOnCloseModal={handleOnCloseModal}
+      />
     </View>
   );
 };
@@ -90,8 +120,17 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'center',
   },
   monthText: {
+    ...TypographyStyles.label,
+    ...TypographyStyles.bold,
+    color: Colors.secondaryHeaderText,
+  },
+  legendButton: {
+    ...Buttons.tinyTeritiaryRounded,
+  },
+  legendText: {
     ...TypographyStyles.label,
     ...TypographyStyles.bold,
     color: Colors.secondaryHeaderText,

--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -9,6 +9,7 @@ import {
   Outlines,
   Colors,
   Typography,
+  Iconography,
   Spacing,
 } from '../../styles';
 
@@ -49,8 +50,7 @@ const ExposureDatumIndicator = ({
         return [
           {
             ...circleStyle,
-            backgroundColor: Colors.exposureRiskWarning,
-            borderColor: Colors.exposureRiskWarning,
+            ...Iconography.possibleExposure,
           },
           { ...textStyle, color: Colors.white },
         ];

--- a/app/views/ExposureHistory/LegendModal.tsx
+++ b/app/views/ExposureHistory/LegendModal.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import {
+  Modal,
+  TouchableOpacity,
+  View,
+  StyleSheet,
+  Text,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { Typography } from '../../components/Typography';
+
+import {
+  Affordances,
+  Outlines,
+  Colors,
+  Iconography,
+  Spacing,
+  Typography as TypographyStyles,
+} from '../../styles';
+
+export type ModalState = 'Open' | 'Closed';
+
+interface LegendItem {
+  backgroundStyle: ViewStyle | null;
+  badgeStyle: ViewStyle | null;
+  textStyle: TextStyle;
+  iconContent: string;
+  itemText: string;
+}
+
+interface LegendModalProps {
+  status: ModalState;
+  handleOnCloseModal: () => void;
+}
+
+const LegendModal = ({
+  status,
+  handleOnCloseModal,
+}: LegendModalProps): JSX.Element => {
+  const { t } = useTranslation();
+  const legendItems: LegendItem[] = [
+    {
+      backgroundStyle: styles.expectedExposureIcon,
+      badgeStyle: null,
+      textStyle: styles.expectedExposureText,
+      iconContent: '1',
+      itemText: t('exposure_history.legend.exposure_likely'),
+    },
+    {
+      backgroundStyle: styles.possibleExposureIcon,
+      badgeStyle: null,
+      textStyle: styles.possibleExposureText,
+      iconContent: '2',
+      itemText: t('exposure_history.legend.exposure_possible'),
+    },
+    {
+      backgroundStyle: null,
+      badgeStyle: null,
+      textStyle: styles.noExposureText,
+      iconContent: '3',
+      itemText: t('exposure_history.legend.no_exposure_detected'),
+    },
+    {
+      backgroundStyle: null,
+      badgeStyle: styles.todayIcon,
+      textStyle: styles.todayText,
+      iconContent: '4',
+      itemText: t('exposure_history.legend.today'),
+    },
+  ];
+
+  return (
+    <Modal animationType={'fade'} transparent visible={status === 'Open'}>
+      <View style={styles.container}>
+        <TouchableOpacity onPress={handleOnCloseModal} style={styles.overlay} />
+        <View style={styles.cardContainer}>
+          {legendItems.map((legendItem, index) => {
+            return (
+              <View style={styles.legendItem} key={index}>
+                <View style={[styles.exposureIcon, legendItem.backgroundStyle]}>
+                  <Text style={legendItem.textStyle}>
+                    {legendItem.iconContent}
+                  </Text>
+                  <View style={legendItem.badgeStyle} />
+                </View>
+
+                <Typography style={styles.legendText}>
+                  {legendItem.itemText}
+                </Typography>
+              </View>
+            );
+          })}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+  },
+  container: {
+    backgroundColor: Colors.transparentDark,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cardContainer: {
+    borderRadius: Outlines.largeBorderRadius,
+    width: '80%',
+    padding: Spacing.small,
+    paddingHorizontal: Spacing.large,
+    backgroundColor: Colors.white,
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  legendText: {
+    ...TypographyStyles.label,
+    ...TypographyStyles.bold,
+  },
+  exposureIcon: {
+    ...Iconography.smallIcon,
+    marginRight: Spacing.small,
+  },
+  possibleExposureIcon: {
+    ...Iconography.possibleExposure,
+  },
+  expectedExposureIcon: {
+    ...Iconography.expectedExposure,
+  },
+  todayIcon: {
+    ...Affordances.smallBottomDotBadge(Colors.primaryBlue),
+  },
+  possibleExposureText: {
+    ...Iconography.possibleExposureText,
+  },
+  expectedExposureText: {
+    ...Iconography.expectedExposureText,
+  },
+  noExposureText: {
+    ...Iconography.noExposureText,
+  },
+  todayText: {
+    ...Iconography.todayText,
+  },
+});
+
+export default LegendModal;

--- a/app/views/ExposureHistory/__snapshots__/Calendar.spec.tsx.snap
+++ b/app/views/ExposureHistory/__snapshots__/Calendar.spec.tsx.snap
@@ -1,0 +1,1435 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Calendar renders 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontSize": 17,
+              "lineHeight": 28,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
+            Object {
+              "color": "#4754C5",
+              "fontFamily": "IBMPlexSans-Bold",
+              "fontSize": 15,
+              "fontWeight": "500",
+              "lineHeight": 24,
+            },
+          ]
+        }
+      >
+        MAY | JUNE
+      </Text>
+      <View
+        accessible={true}
+        focusable={true}
+        isTVSelectable={true}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#e5e7fa",
+            "borderColor": "#e5e7fa",
+            "borderRadius": 500,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "opacity": 1,
+            "paddingHorizontal": 12,
+            "paddingVertical": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontSize": 17,
+                "lineHeight": 28,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#4754C5",
+                "fontFamily": "IBMPlexSans-Bold",
+                "fontSize": 15,
+                "fontWeight": "500",
+                "lineHeight": 24,
+              },
+            ]
+          }
+        >
+          LEGEND
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "paddingVertical": 16,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            S
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            M
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            T
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            W
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            T
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            F
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "width": 44,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontFamily": "IBMPlexSans",
+              }
+            }
+          >
+            S
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "#4e4e4e",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              14
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              15
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              16
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              17
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              18
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              19
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              20
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              21
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              22
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              23
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              24
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              25
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              26
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              27
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "paddingVertical": 8,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#4051db",
+                "borderColor": "#4051db",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#ffffff",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              28
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              29
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              30
+            </Text>
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "#2e2e2e",
+                  "borderRadius": 6,
+                  "bottom": -4,
+                  "height": 6,
+                  "justifyContent": "center",
+                  "position": "absolute",
+                  "width": 6,
+                }
+              }
+            />
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              1
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              2
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              3
+            </Text>
+          </View>
+        </View>
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "borderColor": "rgba(0, 0, 0, 0)",
+                "borderRadius": 500,
+                "borderWidth": 4,
+                "flex": 1,
+                "height": 44,
+                "justifyContent": "center",
+                "width": 44,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexMono",
+                  "fontSize": 15,
+                  "fontWeight": "500",
+                  "lineHeight": 24,
+                }
+              }
+            >
+              4
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <Modal
+      animationType="fade"
+      hardwareAccelerated={false}
+      transparent={true}
+      visible={false}
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(0,0,0,0.7)",
+            "flex": 1,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          isTVSelectable={true}
+          style={
+            Object {
+              "height": "100%",
+              "opacity": 1,
+              "position": "absolute",
+              "width": "100%",
+            }
+          }
+        />
+        <View
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "borderRadius": 16,
+              "padding": 16,
+              "paddingHorizontal": 24,
+              "width": "80%",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 100,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "marginRight": 16,
+                    "marginVertical": 16,
+                    "width": 30,
+                  },
+                  Object {
+                    "backgroundColor": "#ffcc00",
+                    "borderColor": "#ffcc00",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                1
+              </Text>
+              <View
+                style={null}
+              />
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontSize": 17,
+                    "lineHeight": 28,
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontSize": 15,
+                    "fontWeight": "500",
+                    "lineHeight": 24,
+                  },
+                ]
+              }
+            >
+              Exposure very likely
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 100,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "marginRight": 16,
+                    "marginVertical": 16,
+                    "width": 30,
+                  },
+                  Object {
+                    "backgroundColor": "#4051db",
+                    "borderColor": "#4051db",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#ffffff",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                2
+              </Text>
+              <View
+                style={null}
+              />
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontSize": 17,
+                    "lineHeight": 28,
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontSize": 15,
+                    "fontWeight": "500",
+                    "lineHeight": 24,
+                  },
+                ]
+              }
+            >
+              Exposure possible
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 100,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "marginRight": 16,
+                    "marginVertical": 16,
+                    "width": 30,
+                  },
+                  null,
+                ]
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#1f2c9b",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                3
+              </Text>
+              <View
+                style={null}
+              />
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontSize": 17,
+                    "lineHeight": 28,
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontSize": 15,
+                    "fontWeight": "500",
+                    "lineHeight": 24,
+                  },
+                ]
+              }
+            >
+              No exposure detected
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "borderRadius": 100,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "marginRight": 16,
+                    "marginVertical": 16,
+                    "width": 30,
+                  },
+                  null,
+                ]
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#1f2c9b",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontSize": 15,
+                    "fontWeight": "500",
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                4
+              </Text>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#4051db",
+                    "borderRadius": 2,
+                    "bottom": -2,
+                    "height": 4,
+                    "justifyContent": "center",
+                    "position": "absolute",
+                    "width": 4,
+                  }
+                }
+              />
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontSize": 17,
+                    "lineHeight": 28,
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {
+                    "color": "#2e2e2e",
+                    "fontFamily": "IBMPlexSans-Bold",
+                    "fontSize": 15,
+                    "fontWeight": "500",
+                    "lineHeight": 24,
+                  },
+                ]
+              }
+            >
+              Today
+            </Text>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  </View>
+</View>
+`;

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -73,13 +73,13 @@ const ExposureHistoryScreen = (): JSX.Element => {
               />
             </TouchableOpacity>
           </View>
-          {!isGPS ? (
-            <View style={styles.headerRow}>
+          <View style={styles.headerRow}>
+            {!isGPS ? (
               <Typography style={styles.subHeaderText}>
                 {lastDaysText}
               </Typography>
-            </View>
-          ) : null}
+            ) : null}
+          </View>
         </View>
         <View style={styles.calendarContainer}>
           <Calendar


### PR DESCRIPTION
Why:
We would like to provide the user a way to view a legend of what the
indicators on the exposure history screen mean.

This commit:
Introduces a legend modal to the exposure history screen.

Co-Authored-By: devin jameson <devin@thoughtbot.com>


<img width="559" alt="Screen Shot 2020-06-30 at 4 24 05 PM" src="https://user-images.githubusercontent.com/16049495/86179260-ea5eef00-baf7-11ea-8651-c52a9d6e344c.png">
