### PR TITLE
Request notification permissions for bt app

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -31,6 +31,7 @@ import {
   ExportLocally,
 } from './views/Export';
 import { PublishConsent } from './bt/PositiveDiagnosis/PublishConsent';
+import NotificationPermissionsBT from './bt/NotificationPermissionsBT';
 import ExposureHistoryScreen from './views/ExposureHistory';
 import Assessment from './views/assessment';
 import NextSteps from './views/ExposureHistory/NextSteps';
@@ -305,6 +306,10 @@ const OnboardingStack = () => (
     <Stack.Screen
       name={Screens.OnboardingLocationPermissions}
       component={LocationsPermissions}
+    />
+    <Stack.Screen
+      name={Screens.NotificationPermissionsBT}
+      component={NotificationPermissionsBT}
     />
     <Stack.Screen
       name={Screens.EnableExposureNotifications}

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -1,0 +1,126 @@
+import React, { useContext } from 'react';
+import {
+  ImageBackground,
+  View,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useNavigation } from '@react-navigation/native';
+import { SvgXml } from 'react-native-svg';
+
+import PermissionsContext from './PermissionsContext';
+import { Screens } from '../navigation';
+import { Typography } from '../components/Typography';
+import { useStatusBarEffect } from '../navigation';
+
+import { Icons, Images } from '../assets';
+import {
+  Buttons,
+  Spacing,
+  Colors,
+  Iconography,
+  Typography as TypographyStyles,
+} from '../styles';
+
+const NotificationsPermissions = (): JSX.Element => {
+  const navigation = useNavigation();
+  const { t } = useTranslation();
+  const { notification } = useContext(PermissionsContext);
+
+  useStatusBarEffect('dark-content');
+
+  const requestPermission = async () => {
+    await notification.request();
+  };
+
+  const continueOnboarding = () => {
+    navigation.navigate(Screens.EnableExposureNotifications);
+  };
+
+  const handleOnPressEnable = async () => {
+    await requestPermission();
+    continueOnboarding();
+  };
+
+  const handleOnPressMaybeLater = () => {
+    continueOnboarding();
+  };
+
+  return (
+    <ImageBackground
+      source={Images.BlueGradientBackground}
+      style={styles.backgroundImage}>
+      <View style={styles.container}>
+        <ScrollView
+          alwaysBounceVertical={false}
+          contentContainerStyle={{ paddingBottom: Spacing.large }}>
+          <View style={styles.iconCircle}>
+            <SvgXml xml={Icons.Bell} width={30} height={30} />
+          </View>
+          <Typography style={styles.headerText}>
+            {t('onboarding.notification_header')}
+          </Typography>
+          <View style={{ height: Spacing.medium }} />
+          <Typography style={styles.contentText}>
+            {t('onboarding.notification_subheader')}
+          </Typography>
+        </ScrollView>
+        <TouchableOpacity
+          onPress={handleOnPressEnable}
+          style={styles.enableButton}>
+          <Typography style={styles.enableButtonText}>
+            {t('label.launch_enable_notif')}
+          </Typography>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={handleOnPressMaybeLater}
+          style={styles.maybeLaterButton}>
+          <Typography style={styles.maybeLaterButtonText}>
+            {t('onboarding.maybe_later')}
+          </Typography>
+        </TouchableOpacity>
+      </View>
+    </ImageBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: Spacing.large,
+  },
+  backgroundImage: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+    flex: 1,
+  },
+  iconCircle: {
+    ...Iconography.largeBlueIcon,
+  },
+  headerText: {
+    ...TypographyStyles.header2,
+    color: Colors.white,
+  },
+  contentText: {
+    ...TypographyStyles.mainContent,
+    color: Colors.white,
+  },
+  enableButton: {
+    ...Buttons.largeWhite,
+  },
+  enableButtonText: {
+    ...TypographyStyles.buttonTextDark,
+  },
+  maybeLaterButton: {
+    ...Buttons.largeTransparent,
+  },
+  maybeLaterButtonText: {
+    ...TypographyStyles.buttonTextLight,
+  },
+});
+
+export default NotificationsPermissions;

--- a/app/navigation/index.ts
+++ b/app/navigation/index.ts
@@ -40,6 +40,7 @@ export type Screen =
   | 'ShareDiagnosis'
   | 'OnboardingLocationPermissions'
   | 'OnboardingNotificationPermissions'
+  | 'NotificationPermissionsBT'
   | 'EnableExposureNotifications'
   | 'ExportFlow'
   | 'SelfAssessment'
@@ -75,6 +76,7 @@ export const Screens: { [key in Screen]: Screen } = {
   ShareDiagnosis: 'ShareDiagnosis',
   OnboardingLocationPermissions: 'OnboardingLocationPermissions',
   OnboardingNotificationPermissions: 'OnboardingNotificationPermissions',
+  NotificationPermissionsBT: 'NotificationPermissionsBT',
   EnableExposureNotifications: 'EnableExposureNotifications',
   ExportFlow: 'ExportFlow',
   SelfAssessment: 'SelfAssessment',

--- a/app/views/onboarding/ShareDiagnosis.js
+++ b/app/views/onboarding/ShareDiagnosis.js
@@ -20,7 +20,7 @@ const ShareDiagnosis = (props) => {
     );
 
   const btNext = () =>
-    props.navigation.replace(Screens.EnableExposureNotifications);
+    props.navigation.replace(Screens.NotificationPermissionsBT);
 
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 


### PR DESCRIPTION
Why:
We would like for the bt build of the app to request notification
permissions during onboarding as they are necessary for the Exposure
Notification flow.

This commit:
Adds the screen to the onboarding flow for the BT build. Note that we
needed to duplicate the component from the GPS build. Ideally a future
commit will refactor the flow such that it can be agnostic to the
tracing strategy and we can avoid this code duplication.

Co-Authored-By: mattthousand <matt@nicethings.io>