### PR TITLE
Update more screen design

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -174,8 +174,8 @@
     }
   },
   "settings": {
-    "share_test_result": "Report a positive test result",
-    "share_test_result_description": "Share Covid-19 exposure information with your health authority with a provided code"
+    "share_test_result": "Report Positive Test Result",
+    "share_test_result_description": "Anonymously notify others you may have recently encountered if you test positive for COVID-19"
   },
   "label": {
     "about_header_bluetooth": "PathCheck BT",

--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableHighlight,
+  TouchableOpacity,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { SvgXml } from 'react-native-svg';
@@ -30,7 +31,12 @@ import GoogleMapsImport from './GoogleMapsImport';
 import { Screens, useStatusBarEffect } from '../../navigation';
 
 import { Icons } from '../../assets';
-import { Colors, Spacing, Typography as TypographyStyles } from '../../styles';
+import {
+  Buttons,
+  Colors,
+  Spacing,
+  Typography as TypographyStyles,
+} from '../../styles';
 import { FeatureFlagOption, RootState } from '../../store/types';
 import { useSelector } from 'react-redux';
 
@@ -138,6 +144,21 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
       title={t('navigation.more')}
       includeBackButton={false}>
       <ScrollView style={styles.container}>
+        {!isGPS && (
+          <View style={styles.sectionPrimary}>
+            <Typography>
+              {t('settings.share_test_result_description')}
+            </Typography>
+            <TouchableOpacity
+              onPress={navigateTo(Screens.ExportFlow)}
+              style={styles.button}>
+              <Typography style={styles.buttonText}>
+                {t('settings.share_test_result')}
+              </Typography>
+            </TouchableOpacity>
+          </View>
+        )}
+
         <View style={styles.section}>
           <NativePicker
             items={localeList}
@@ -158,17 +179,6 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
             )}
           </NativePicker>
         </View>
-
-        {!isGPS && (
-          <View style={styles.section}>
-            <SettingsListItem
-              label={t('settings.share_test_result')}
-              onPress={navigateTo('ExportFlow')}
-              description={t('settings.share_test_result_description')}
-              style={styles.lastListItem}
-            />
-          </View>
-        )}
 
         {isGPS ? (
           <FeatureFlag flag={FeatureFlagOption.GOOGLE_IMPORT}>
@@ -231,7 +241,7 @@ const Divider = () => <View style={styles.divider} />;
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: Colors.primaryBackgroundFaintShade,
+    backgroundColor: Colors.primaryBackground,
   },
   divider: {
     marginHorizontal: Spacing.small,
@@ -246,6 +256,17 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderBottomWidth: 1,
     borderColor: Colors.tertiaryViolet,
+  },
+  sectionPrimary: {
+    flex: 1,
+    margin: Spacing.medium,
+  },
+  button: {
+    ...Buttons.largeSecondaryBlue,
+    marginTop: Spacing.medium,
+  },
+  buttonText: {
+    ...TypographyStyles.buttonTextLight,
   },
   icon: {
     maxWidth: Spacing.icon,


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Update the more screen to match the latest approved designs in Figma. Moves the "Report Positive Test Result" CTA to the top of the screen and gives it more prominent styling.

#### Linked issues:

https://trello.com/c/mF3Pebdn

#### Screenshots:

<img width="444" alt="Screen Shot 2020-07-01 at 1 55 43 PM" src="https://user-images.githubusercontent.com/2924479/86276439-dc19dd00-bba2-11ea-99c9-9b39d34a5933.png">


#### How to test:

Run the app locally and ensure it matches the attached screenshot
