### PR TITLE
added health authorities constant to config file

### DIFF
--- a/app/constants/authorities.ts
+++ b/app/constants/authorities.ts
@@ -3,3 +3,5 @@ export const PUBLIC_DATA_URL =
 
 export const AUTHORITIES_LIST_URL =
   'https://raw.githubusercontent.com/Path-Check/safeplaces-frontend/develop/healthcare-authorities.yaml';
+
+export const AUTHORITY_NAME = 'Boston Public Health Commission';

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -26,7 +26,7 @@
     "isolate_description": "You <1>have some symptoms</1> that may be related to COVID-19. Call your healthcare provider if your symtoms get worse. Start home isolation.",
     "isolate_cta": "Next",
     "share_title": "Publish anonymized data",
-    "share_description": "Your anonymous data helps the Boston Public Health Commission analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.\n\nYour data contains your survey responses and zip code, but no additional or personally-identifying information.\n\nThe Boston Public Health Commission will retain your anonymous data for a specific period of time.",
+    "share_description": "Your anonymous data helps the {{authority}} analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.\n\nYour data contains your survey responses and zip code, but no additional or personally-identifying information.\n\nThe {{authority}} will retain your anonymous data for a specific period of time.",
     "share_screening_title": "Anonymized Screening Data",
     "share_screening_description": "Share anonymized answers to screening questions with your local healthcare authority.",
     "share_cta_skip": "No thanks, I don't want to share data",

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -8,6 +8,8 @@ import { Screens, useStatusBarEffect } from '../../navigation';
 
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 
+import { AUTHORITY_NAME as healthAuthority }  from '../../constants/authorities';
+
 const NextSteps = (): JSX.Element => {
   const navigation = useNavigation();
   useStatusBarEffect('light-content');
@@ -15,8 +17,6 @@ const NextSteps = (): JSX.Element => {
   const handleOnBackPress = () => {
     navigation.goBack();
   };
-
-  const healthAuthority = 'Boston Public Health Commission';
 
   const headerText = `${healthAuthority} recommends you take a self-assessment`;
 

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -8,7 +8,7 @@ import { Screens, useStatusBarEffect } from '../../navigation';
 
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 
-import { AUTHORITY_NAME as healthAuthority }  from '../../constants/authorities';
+import { AUTHORITY_NAME as healthAuthority } from '../../constants/authorities';
 
 const NextSteps = (): JSX.Element => {
   const navigation = useNavigation();

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Share.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Share.spec.js.snap
@@ -110,11 +110,28 @@ exports[`base 1`] = `
               }
               testID="description"
             >
-              Your anonymous data helps the Boston Public Health Commission analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2e2e2e",
+                      "fontFamily": "IBMPlexSans",
+                      "fontSize": 17,
+                      "lineHeight": 28,
+                    },
+                    Object {
+                      "writingDirection": "ltr",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Your anonymous data helps the Boston Public Health Commission analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.
 
 Your data contains your survey responses and zip code, but no additional or personally-identifying information.
 
 The Boston Public Health Commission will retain your anonymous data for a specific period of time.
+              </Text>
             </Text>
           </View>
         </View>

--- a/app/views/assessment/endScreens/Share.js
+++ b/app/views/assessment/endScreens/Share.js
@@ -7,7 +7,7 @@ import { Info } from '../Info';
 
 import { Colors } from '../../../styles';
 
-import { AUTHORITY_NAME as authority }  from '../../../constants/authorities';
+import { AUTHORITY_NAME as authority } from '../../../constants/authorities';
 
 /** @type {React.FunctionComponent<{}>} */
 export const Share = ({ navigation }) => {
@@ -24,7 +24,7 @@ export const Share = ({ navigation }) => {
       description={
         <>
           <Typography>
-            {t('assessment.share_description', {authority})}
+            {t('assessment.share_description', { authority })}
           </Typography>
         </>
       }

--- a/app/views/assessment/endScreens/Share.js
+++ b/app/views/assessment/endScreens/Share.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Icons } from '../../../assets';
 import { Typography } from '../../../components/Typography';
 import { Info } from '../Info';
 
 import { Colors } from '../../../styles';
+
+import { AUTHORITY_NAME as authority }  from '../../../constants/authorities';
 
 /** @type {React.FunctionComponent<{}>} */
 export const Share = ({ navigation }) => {
@@ -21,9 +23,9 @@ export const Share = ({ navigation }) => {
       ctaTitle={t('assessment.share_cta')}
       description={
         <>
-          <Trans t={t} i18nKey='assessment.share_description'>
-            <Typography />
-          </Trans>
+          <Typography>
+            {t('assessment.share_description', {authority})}
+          </Typography>
         </>
       }
       title={t('assessment.share_title')}


### PR DESCRIPTION


added a constant for health authority name to authorities.ts, and used it to replace static content on next steps and sharing screens

#### Linked issues:

https://trello.com/c/L4pNhsN4/71-as-a-dev-team-we-have-a-way-to-customize-the-health-authority-name-in-the-app

#### Screenshots:

![Screen Shot 2020-07-01 at 2 48 03 PM](https://user-images.githubusercontent.com/19334037/86280493-e2f81e00-bba9-11ea-9e29-23df069200c2.png)

#### How to test:

Change the name of the health authority in authorities.ts - make sure the new name is in the "published anonymized data" copy on the sharing screen the end of the health questionnaire, and one the next steps screen.  
