### PR TITLE
Refactor OnboardingTemplate component and use it on a few more screens

### DIFF
--- a/app/TracingStrategyContext.spec.tsx
+++ b/app/TracingStrategyContext.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, ImageBackground, StyleSheet } from 'react-native';
 import { render, cleanup } from '@testing-library/react-native';
 import '@testing-library/jest-native/extend-expect';
 
@@ -38,9 +38,11 @@ const renderTracingStrategyProvider = (strategy: TracingStrategy) => {
     return (
       <View>
         <Text testID={'tracing-strategy-name'}>{name}</Text>
-        <Text testID={'tracing-strategy-assets'}>
-          {StrategyAssets.personalPrivacyBackground}
-        </Text>
+        <ImageBackground
+          source={StrategyAssets.personalPrivacyBackground}
+          testID={'tracing-strategy-assets'}
+          style={styles.background}
+        />
         <Text testID={'tracing-strategy-copy'}>{StrategyCopy.aboutHeader}</Text>
         <Text testID={'tracing-strategy-interpolated-copy'}>
           {InterpolatedStrategyCopy.exportCodeBody('code-body-name')}
@@ -130,7 +132,9 @@ describe('TracingStrategyProvider', () => {
         'tracing-strategy-interpolated-copy',
       );
 
-      expect(assets).toHaveTextContent(expectedAsset);
+      expect(assets).toHaveProp('source', {
+        testUri: '../../../app/assets/images/blueGradientBackground.png',
+      });
       expect(copy).toHaveTextContent(expectedCopy);
       expect(interpolatedCopy).toHaveTextContent(
         expectedCodeBody('code-body-name'),
@@ -155,4 +159,13 @@ describe('TracingStrategyProvider', () => {
       });
     });
   });
+});
+
+const styles = StyleSheet.create({
+  background: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+    position: 'absolute',
+  },
 });

--- a/app/TracingStrategyContext.spec.tsx
+++ b/app/TracingStrategyContext.spec.tsx
@@ -14,6 +14,7 @@ import {
   testInterpolatedStrategyCopy,
 } from './factories/tracingStrategy';
 import { factories } from './factories';
+import { Images } from '../app/assets/images/';
 
 import { TracingStrategy } from './tracingStrategy';
 
@@ -96,7 +97,7 @@ describe('TracingStrategyProvider', () => {
     });
 
     it('provides the correct strategy content', () => {
-      const expectedAsset = 'Test Asset';
+      const expectedAsset = Images.BlueGradientBackground;
       const expectedCopy = 'Test About Header';
       const expectedCodeBody = (name: string) => {
         return `expectedCodeBody ${name}`;

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -38,24 +38,24 @@ const NotificationsPermissions = (): JSX.Element => {
   return (
     <DescriptionTemplate
       iconXml={Icons.Bell}
-      title={t('onboarding.notification_header')}
-      titleStyle={styles.titleStyle}
+      header={t('onboarding.notification_header')}
+      headerStyle={styles.header}
       body={t('onboarding.notification_subheader')}
-      bodyStyle={styles.bodyStyle}
+      bodyStyle={styles.body}
       primaryButtonLabel={t('label.launch_enable_notif')}
       primaryButtonOnPress={handleOnPressEnable}
       secondaryButtonLabel={t('onboarding.maybe_later')}
       secondaryButtonOnPress={handleOnPressMaybeLater}
-      background={Images.BlueGradientBackground}
+      backgroundImage={Images.BlueGradientBackground}
     />
   );
 };
 
 const styles = StyleSheet.create({
-  titleStyle: {
+  header: {
     color: Colors.white,
   },
-  bodyStyle: {
+  body: {
     color: Colors.white,
   },
 });

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -6,7 +6,9 @@ import { StyleSheet } from 'react-native';
 import PermissionsContext from './PermissionsContext';
 import { Screens } from '../navigation';
 import { useStatusBarEffect } from '../navigation';
-import DescriptionTemplate from '../views/common/DescriptionTemplate';
+import ExplanationScreen, {
+  IconStyle,
+} from '../views/common/ExplanationScreen';
 
 import { Icons, Images } from '../assets';
 import { Colors } from '../styles';
@@ -47,6 +49,7 @@ const NotificationsPermissions = (): JSX.Element => {
   const descriptionTemplateStyles = {
     headerStyle: styles.header,
     bodyStyle: styles.body,
+    iconStyle: IconStyle.Blue,
   };
 
   const descriptionTemplateActions = {
@@ -55,7 +58,7 @@ const NotificationsPermissions = (): JSX.Element => {
   };
 
   return (
-    <DescriptionTemplate
+    <ExplanationScreen
       descriptionTemplateContent={descriptionTemplateContent}
       descriptionTemplateStyles={descriptionTemplateStyles}
       descriptionTemplateActions={descriptionTemplateActions}

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -37,7 +37,7 @@ const NotificationsPermissions = (): JSX.Element => {
 
   const descriptionTemplateContent = {
     backgroundImage: Images.BlueGradientBackground,
-    iconXml: Icons.Bell,
+    icon: Icons.Bell,
     header: t('onboarding.notification_header'),
     body: t('onboarding.notification_subheader'),
     primaryButtonLabel: t('label.launch_enable_notif'),

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -1,28 +1,15 @@
 import React, { useContext } from 'react';
-import {
-  ImageBackground,
-  View,
-  ScrollView,
-  StyleSheet,
-  TouchableOpacity,
-} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from '@react-navigation/native';
-import { SvgXml } from 'react-native-svg';
+import { StyleSheet } from 'react-native';
 
 import PermissionsContext from './PermissionsContext';
 import { Screens } from '../navigation';
-import { Typography } from '../components/Typography';
 import { useStatusBarEffect } from '../navigation';
+import DescriptionTemplate from '../views/common/DescriptionTemplate';
 
 import { Icons, Images } from '../assets';
-import {
-  Buttons,
-  Spacing,
-  Colors,
-  Iconography,
-  Typography as TypographyStyles,
-} from '../styles';
+import { Colors } from '../styles';
 
 const NotificationsPermissions = (): JSX.Element => {
   const navigation = useNavigation();
@@ -49,77 +36,27 @@ const NotificationsPermissions = (): JSX.Element => {
   };
 
   return (
-    <ImageBackground
-      source={Images.BlueGradientBackground}
-      style={styles.backgroundImage}>
-      <View style={styles.container}>
-        <ScrollView
-          alwaysBounceVertical={false}
-          contentContainerStyle={{ paddingBottom: Spacing.large }}>
-          <View style={styles.iconCircle}>
-            <SvgXml xml={Icons.Bell} width={30} height={30} />
-          </View>
-          <Typography style={styles.headerText}>
-            {t('onboarding.notification_header')}
-          </Typography>
-          <View style={{ height: Spacing.medium }} />
-          <Typography style={styles.contentText}>
-            {t('onboarding.notification_subheader')}
-          </Typography>
-        </ScrollView>
-        <TouchableOpacity
-          onPress={handleOnPressEnable}
-          style={styles.enableButton}>
-          <Typography style={styles.enableButtonText}>
-            {t('label.launch_enable_notif')}
-          </Typography>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          onPress={handleOnPressMaybeLater}
-          style={styles.maybeLaterButton}>
-          <Typography style={styles.maybeLaterButtonText}>
-            {t('onboarding.maybe_later')}
-          </Typography>
-        </TouchableOpacity>
-      </View>
-    </ImageBackground>
+    <DescriptionTemplate
+      iconXml={Icons.Bell}
+      title={t('onboarding.notification_header')}
+      titleStyle={styles.titleStyle}
+      body={t('onboarding.notification_subheader')}
+      bodyStyle={styles.bodyStyle}
+      primaryButtonLabel={t('label.launch_enable_notif')}
+      primaryButtonOnPress={handleOnPressEnable}
+      secondaryButtonLabel={t('onboarding.maybe_later')}
+      secondaryButtonOnPress={handleOnPressMaybeLater}
+      background={Images.BlueGradientBackground}
+    />
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing.large,
-  },
-  backgroundImage: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-    flex: 1,
-  },
-  iconCircle: {
-    ...Iconography.largeBlueIcon,
-  },
-  headerText: {
-    ...TypographyStyles.header2,
+  titleStyle: {
     color: Colors.white,
   },
-  contentText: {
-    ...TypographyStyles.mainContent,
+  bodyStyle: {
     color: Colors.white,
-  },
-  enableButton: {
-    ...Buttons.largeWhite,
-  },
-  enableButtonText: {
-    ...TypographyStyles.buttonTextDark,
-  },
-  maybeLaterButton: {
-    ...Buttons.largeTransparent,
-  },
-  maybeLaterButtonText: {
-    ...TypographyStyles.buttonTextLight,
   },
 });
 

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -35,18 +35,30 @@ const NotificationsPermissions = (): JSX.Element => {
     continueOnboarding();
   };
 
+  const descriptionTemplateContent = {
+    backgroundImage: Images.BlueGradientBackground,
+    iconXml: Icons.Bell,
+    header: t('onboarding.notification_header'),
+    body: t('onboarding.notification_subheader'),
+    primaryButtonLabel: t('label.launch_enable_notif'),
+    secondaryButtonLabel: t('onboarding.maybe_later'),
+  };
+
+  const descriptionTemplateStyles = {
+    headerStyle: styles.header,
+    bodyStyle: styles.body,
+  };
+
+  const descriptionTemplateActions = {
+    primaryButtonOnPress: handleOnPressEnable,
+    secondaryButtonOnPress: handleOnPressMaybeLater,
+  };
+
   return (
     <DescriptionTemplate
-      iconXml={Icons.Bell}
-      header={t('onboarding.notification_header')}
-      headerStyle={styles.header}
-      body={t('onboarding.notification_subheader')}
-      bodyStyle={styles.body}
-      primaryButtonLabel={t('label.launch_enable_notif')}
-      primaryButtonOnPress={handleOnPressEnable}
-      secondaryButtonLabel={t('onboarding.maybe_later')}
-      secondaryButtonOnPress={handleOnPressMaybeLater}
-      backgroundImage={Images.BlueGradientBackground}
+      descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateStyles={descriptionTemplateStyles}
+      descriptionTemplateActions={descriptionTemplateActions}
     />
   );
 };

--- a/app/bt/NotificationPermissionsBT.tsx
+++ b/app/bt/NotificationPermissionsBT.tsx
@@ -37,7 +37,7 @@ const NotificationsPermissions = (): JSX.Element => {
     continueOnboarding();
   };
 
-  const descriptionTemplateContent = {
+  const explanationScreenContent = {
     backgroundImage: Images.BlueGradientBackground,
     icon: Icons.Bell,
     header: t('onboarding.notification_header'),
@@ -46,22 +46,22 @@ const NotificationsPermissions = (): JSX.Element => {
     secondaryButtonLabel: t('onboarding.maybe_later'),
   };
 
-  const descriptionTemplateStyles = {
+  const explanationScreenStyles = {
     headerStyle: styles.header,
     bodyStyle: styles.body,
     iconStyle: IconStyle.Blue,
   };
 
-  const descriptionTemplateActions = {
+  const explanationScreenActions = {
     primaryButtonOnPress: handleOnPressEnable,
     secondaryButtonOnPress: handleOnPressMaybeLater,
   };
 
   return (
     <ExplanationScreen
-      descriptionTemplateContent={descriptionTemplateContent}
-      descriptionTemplateStyles={descriptionTemplateStyles}
-      descriptionTemplateActions={descriptionTemplateActions}
+      explanationScreenContent={explanationScreenContent}
+      explanationScreenStyles={explanationScreenStyles}
+      explanationScreenActions={explanationScreenActions}
     />
   );
 };

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   StyleSheet,
   ViewStyle,
+  TextStyle,
   TouchableOpacity,
 } from 'react-native';
 
@@ -12,10 +13,11 @@ import { Buttons, Typography as TypographyStyles } from '../styles';
 
 interface ButtonProps {
   label: string;
-  onPress: () => void;
+  onPress: (() => void) | undefined;
   loading?: boolean;
   disabled?: boolean;
   style?: ViewStyle;
+  textStyle?: TextStyle;
 }
 
 export const Button = ({
@@ -24,9 +26,12 @@ export const Button = ({
   disabled,
   loading,
   style,
+  textStyle,
 }: ButtonProps): JSX.Element => {
-  const textStyle =
-    disabled || loading ? styles.textDisabled : styles.textEnabled;
+  const buttonTextStyle =
+    disabled || loading
+      ? { ...styles.textDisabled, ...textStyle }
+      : { ...styles.textEnabled, ...textStyle };
 
   return (
     <TouchableOpacity
@@ -39,7 +44,7 @@ export const Button = ({
       {loading ? (
         <ActivityIndicator size={'large'} />
       ) : (
-        <Typography style={textStyle}>{label}</Typography>
+        <Typography style={buttonTextStyle}>{label}</Typography>
       )}
     </TouchableOpacity>
   );

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -13,7 +13,7 @@ import { Buttons, Typography as TypographyStyles } from '../styles';
 
 interface ButtonProps {
   label: string;
-  onPress: (() => void) | undefined;
+  onPress: () => void;
   loading?: boolean;
   disabled?: boolean;
   style?: ViewStyle;

--- a/app/factories/tracingStrategy.tsx
+++ b/app/factories/tracingStrategy.tsx
@@ -9,6 +9,8 @@ import {
   StrategyInterpolatedCopyContent,
 } from '../tracingStrategy';
 
+import { Images } from '../../app/assets/images';
+
 export default Factory.define<TracingStrategy>(() => ({
   name: 'test-tracing-strategy',
   exposureInfoSubscription: () => {
@@ -61,11 +63,11 @@ export const testStrategyCopy: StrategyCopyContent = {
 };
 
 export const testStrategyAssets: StrategyAssets = {
-  personalPrivacyBackground: '',
+  personalPrivacyBackground: Images.BlueGradientBackground,
   personalPrivacyIcon: '',
-  notificationDetailsBackground: '',
+  notificationDetailsBackground: Images.BlueGradientBackground,
   notificationDetailsIcon: '',
-  shareDiagnosisBackground: '',
+  shareDiagnosisBackground: Images.BlueGradientBackground,
   shareDiagnosisIcon: '',
   exportPublishIcon: '',
 };

--- a/app/tracingStrategy.ts
+++ b/app/tracingStrategy.ts
@@ -1,8 +1,8 @@
+import { ImageSourcePropType } from 'react-native';
+
 import { TFunction } from 'i18next';
 
 import { ExposureInfoSubscription } from './ExposureHistoryContext';
-
-import { ImageSourcePropType } from 'react-native';
 
 export interface TracingStrategy {
   name: string;

--- a/app/tracingStrategy.ts
+++ b/app/tracingStrategy.ts
@@ -2,6 +2,8 @@ import { TFunction } from 'i18next';
 
 import { ExposureInfoSubscription } from './ExposureHistoryContext';
 
+import { ImageSourcePropType } from 'react-native';
+
 export interface TracingStrategy {
   name: string;
   exposureInfoSubscription: ExposureInfoSubscription;
@@ -13,11 +15,11 @@ export interface TracingStrategy {
 }
 
 export interface StrategyAssets {
-  personalPrivacyBackground: string;
+  personalPrivacyBackground: ImageSourcePropType;
   personalPrivacyIcon: string;
-  notificationDetailsBackground: string;
+  notificationDetailsBackground: ImageSourcePropType;
   notificationDetailsIcon: string;
-  shareDiagnosisBackground: string;
+  shareDiagnosisBackground: ImageSourcePropType;
   shareDiagnosisIcon: string;
   exportPublishIcon: string;
 }

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -23,73 +23,77 @@ import {
   Typography as TypographyStyles,
 } from '../../styles';
 
-type DescriptionTemplateProps = {
+type DescriptionTemplateContent = {
   iconXml: string;
   header: string;
-  headerStyle?: TextStyle;
   body: string;
-  bodyStyle?: TextStyle;
   primaryButtonLabel: string;
+  secondaryButtonLabel?: string;
+  backgroundImage: ImageSourcePropType;
+};
+
+type DescriptionTemplateStyles = {
+  headerStyle?: TextStyle;
+  bodyStyle?: TextStyle;
   primaryButtonContainerStyle?: ViewStyle;
   primaryButtonTextStyle?: TextStyle;
-  primaryButtonOnPress: () => void;
-  secondaryButtonLabel?: string;
   secondaryButtonContainerStyle?: ViewStyle;
   secondaryButtonTextStyle?: TextStyle;
-  secondaryButtonOnPress?: () => void;
-  backgroundImage: ImageSourcePropType;
   backgroundStyle?: ViewStyle;
   invertIcon?: boolean;
 };
 
+type DescriptionTemplateActions = {
+  primaryButtonOnPress: () => void;
+  secondaryButtonOnPress?: () => void;
+};
+
+interface DescriptionTemplateProps {
+  descriptionTemplateContent: DescriptionTemplateContent;
+  descriptionTemplateStyles?: DescriptionTemplateStyles;
+  descriptionTemplateActions: DescriptionTemplateActions;
+}
+
 const DescriptionTemplate = ({
-  iconXml,
-  header,
-  headerStyle,
-  body,
-  bodyStyle,
-  primaryButtonLabel,
-  primaryButtonContainerStyle,
-  primaryButtonTextStyle,
-  primaryButtonOnPress,
-  secondaryButtonLabel,
-  secondaryButtonContainerStyle,
-  secondaryButtonTextStyle,
-  secondaryButtonOnPress,
-  backgroundImage,
-  backgroundStyle,
-  invertIcon,
+  descriptionTemplateContent,
+  descriptionTemplateStyles,
+  descriptionTemplateActions,
 }: DescriptionTemplateProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
-  const iconStyle = invertIcon ? styles.goldIcon : styles.blueIcon;
+  const iconStyle = descriptionTemplateStyles?.invertIcon
+    ? styles.goldIcon
+    : styles.blueIcon;
 
   const primaryButtonTextStyles = {
     ...styles.primaryButtonText,
-    ...primaryButtonTextStyle,
+    ...descriptionTemplateStyles?.primaryButtonTextStyle,
   };
 
   const secondaryButtonTextStyles = {
     ...styles.secondaryButtonText,
-    ...secondaryButtonTextStyle,
+    ...descriptionTemplateStyles?.secondaryButtonTextStyle,
   };
 
   const headerStyles = {
     ...styles.headerText,
-    ...headerStyle,
+    ...descriptionTemplateStyles?.headerStyle,
   };
 
   const contentStyles = {
     ...styles.contentText,
-    ...bodyStyle,
+    ...descriptionTemplateStyles?.bodyStyle,
   };
 
   return (
     <View style={styles.outerContainer}>
       {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
         <ImageBackground
-          source={backgroundImage}
-          style={[styles.background, backgroundStyle]}
+          source={descriptionTemplateContent.backgroundImage}
+          style={[
+            styles.background,
+            descriptionTemplateStyles?.backgroundStyle,
+          ]}
         />
       )}
       <View style={styles.content}>
@@ -98,24 +102,34 @@ const DescriptionTemplate = ({
           style={styles.innerContainer}
           contentContainerStyle={{ paddingBottom: Spacing.large }}>
           <View style={iconStyle}>
-            <SvgXml xml={iconXml} />
+            <SvgXml xml={descriptionTemplateContent.iconXml} />
           </View>
-          <Typography style={headerStyles}>{header}</Typography>
-          <Typography style={contentStyles}>{body}</Typography>
+          <Typography style={headerStyles}>
+            {descriptionTemplateContent.header}
+          </Typography>
+          <Typography style={contentStyles}>
+            {descriptionTemplateContent.body}
+          </Typography>
         </ScrollView>
         <TouchableOpacity
-          onPress={primaryButtonOnPress}
-          style={[styles.primaryButton, primaryButtonContainerStyle]}>
+          onPress={descriptionTemplateActions.primaryButtonOnPress}
+          style={[
+            styles.primaryButton,
+            descriptionTemplateStyles?.primaryButtonContainerStyle,
+          ]}>
           <Typography style={primaryButtonTextStyles}>
-            {primaryButtonLabel}
+            {descriptionTemplateContent.primaryButtonLabel}
           </Typography>
         </TouchableOpacity>
-        {secondaryButtonLabel && (
+        {descriptionTemplateContent.secondaryButtonLabel && (
           <TouchableOpacity
-            onPress={secondaryButtonOnPress}
-            style={[styles.secondaryButton, secondaryButtonContainerStyle]}>
+            onPress={descriptionTemplateActions.secondaryButtonOnPress}
+            style={[
+              styles.secondaryButton,
+              descriptionTemplateStyles?.secondaryButtonContainerStyle,
+            ]}>
             <Typography style={secondaryButtonTextStyles}>
-              {secondaryButtonLabel}
+              {descriptionTemplateContent.secondaryButtonLabel}
             </Typography>
           </TouchableOpacity>
         )}

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -26,7 +26,9 @@ import {
 type DescriptionTemplateProps = {
   iconXml: string;
   title: string;
+  titleStyle?: TextStyle;
   body: string;
+  bodyStyle?: TextStyle;
   primaryButtonLabel: string;
   primaryButtonContainerStyle?: ViewStyle;
   primaryButtonTextStyle?: TextStyle;
@@ -43,7 +45,9 @@ type DescriptionTemplateProps = {
 const DescriptionTemplate = ({
   iconXml,
   title,
+  titleStyle,
   body,
+  bodyStyle,
   primaryButtonLabel,
   primaryButtonContainerStyle,
   primaryButtonTextStyle,
@@ -70,6 +74,16 @@ const DescriptionTemplate = ({
     ...styles.secondaryButtonText,
   };
 
+  const headerStyles = {
+    ...styles.headerText,
+    ...titleStyle,
+  };
+
+  const contentStyles = {
+    ...styles.contentText,
+    ...bodyStyle,
+  };
+
   return (
     <View style={styles.outerContainer}>
       {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
@@ -84,10 +98,10 @@ const DescriptionTemplate = ({
           style={styles.innerContainer}
           contentContainerStyle={{ paddingBottom: Spacing.large }}>
           <View style={iconStyle}>
-            <SvgXml xml={iconXml} width={30} height={30} />
+            <SvgXml xml={iconXml} />
           </View>
-          <Typography style={styles.headerText}>{title}</Typography>
-          <Typography style={styles.contentText}>{body}</Typography>
+          <Typography style={headerStyles}>{title}</Typography>
+          <Typography style={contentStyles}>{body}</Typography>
         </ScrollView>
         <TouchableOpacity
           onPress={primaryButtonOnPress}
@@ -147,7 +161,7 @@ const styles = StyleSheet.create({
     ...Buttons.largeSecondaryBlue,
   },
   secondaryButton: {
-    ...Buttons.largeSecondaryBlue,
+    ...Buttons.largeTransparent,
   },
   primaryButtonText: {
     ...TypographyStyles.buttonTextLight,

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../styles';
 
 type DescriptionTemplateContent = {
-  iconXml: string;
+  icon: string;
   header: string;
   body: string;
   primaryButtonLabel: string;
@@ -102,7 +102,7 @@ const DescriptionTemplate = ({
           style={styles.innerContainer}
           contentContainerStyle={{ paddingBottom: Spacing.large }}>
           <View style={iconStyle}>
-            <SvgXml xml={descriptionTemplateContent.iconXml} />
+            <SvgXml xml={descriptionTemplateContent.icon} />
           </View>
           <Typography style={headerStyles}>
             {descriptionTemplateContent.header}

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -65,13 +65,13 @@ const DescriptionTemplate = ({
   const iconStyle = invertIcon ? styles.goldIcon : styles.blueIcon;
 
   const primaryButtonTextStyles = {
-    ...primaryButtonTextStyle,
     ...styles.primaryButtonText,
+    ...primaryButtonTextStyle,
   };
 
   const secondaryButtonTextStyles = {
-    ...secondaryButtonTextStyle,
     ...styles.secondaryButtonText,
+    ...secondaryButtonTextStyle,
   };
 
   const headerStyles = {

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -25,8 +25,8 @@ import {
 
 type DescriptionTemplateProps = {
   iconXml: string;
-  title: string;
-  titleStyle?: TextStyle;
+  header: string;
+  headerStyle?: TextStyle;
   body: string;
   bodyStyle?: TextStyle;
   primaryButtonLabel: string;
@@ -37,15 +37,15 @@ type DescriptionTemplateProps = {
   secondaryButtonContainerStyle?: ViewStyle;
   secondaryButtonTextStyle?: TextStyle;
   secondaryButtonOnPress?: () => void;
-  background: ImageSourcePropType;
+  backgroundImage: ImageSourcePropType;
   backgroundStyle?: ViewStyle;
   invertIcon?: boolean;
 };
 
 const DescriptionTemplate = ({
   iconXml,
-  title,
-  titleStyle,
+  header,
+  headerStyle,
   body,
   bodyStyle,
   primaryButtonLabel,
@@ -56,7 +56,7 @@ const DescriptionTemplate = ({
   secondaryButtonContainerStyle,
   secondaryButtonTextStyle,
   secondaryButtonOnPress,
-  background,
+  backgroundImage,
   backgroundStyle,
   invertIcon,
 }: DescriptionTemplateProps): JSX.Element => {
@@ -76,7 +76,7 @@ const DescriptionTemplate = ({
 
   const headerStyles = {
     ...styles.headerText,
-    ...titleStyle,
+    ...headerStyle,
   };
 
   const contentStyles = {
@@ -88,7 +88,7 @@ const DescriptionTemplate = ({
     <View style={styles.outerContainer}>
       {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
         <ImageBackground
-          source={background}
+          source={backgroundImage}
           style={[styles.background, backgroundStyle]}
         />
       )}
@@ -100,7 +100,7 @@ const DescriptionTemplate = ({
           <View style={iconStyle}>
             <SvgXml xml={iconXml} />
           </View>
-          <Typography style={headerStyles}>{title}</Typography>
+          <Typography style={headerStyles}>{header}</Typography>
           <Typography style={contentStyles}>{body}</Typography>
         </ScrollView>
         <TouchableOpacity

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -21,7 +21,7 @@ import {
   Typography as TypographyStyles,
 } from '../../styles';
 
-type OnboardingTemplateProps = {
+type DescriptionTemplateProps = {
   iconXml: string;
   title: string;
   body: string;
@@ -31,7 +31,7 @@ type OnboardingTemplateProps = {
   invertIcon?: boolean;
 };
 
-const OnboardingTemplate = ({
+const DescriptionTemplate = ({
   background,
   iconXml,
   title,
@@ -39,7 +39,7 @@ const OnboardingTemplate = ({
   buttonLabel,
   buttonOnPress,
   invertIcon,
-}: OnboardingTemplateProps): JSX.Element => {
+}: DescriptionTemplateProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
   const iconStyle = invertIcon ? styles.goldIcon : styles.blueIcon;
@@ -109,4 +109,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default OnboardingTemplate;
+export default DescriptionTemplate;

--- a/app/views/common/DescriptionTemplate.tsx
+++ b/app/views/common/DescriptionTemplate.tsx
@@ -3,9 +3,11 @@ import {
   ImageBackground,
   StyleSheet,
   TouchableOpacity,
+  TextStyle,
   View,
   ScrollView,
   ImageSourcePropType,
+  ViewStyle,
 } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
@@ -25,29 +27,56 @@ type DescriptionTemplateProps = {
   iconXml: string;
   title: string;
   body: string;
-  buttonLabel: string;
-  buttonOnPress: () => void;
+  primaryButtonLabel: string;
+  primaryButtonContainerStyle?: ViewStyle;
+  primaryButtonTextStyle?: TextStyle;
+  primaryButtonOnPress: () => void;
+  secondaryButtonLabel?: string;
+  secondaryButtonContainerStyle?: ViewStyle;
+  secondaryButtonTextStyle?: TextStyle;
+  secondaryButtonOnPress?: () => void;
   background: ImageSourcePropType;
+  backgroundStyle?: ViewStyle;
   invertIcon?: boolean;
 };
 
 const DescriptionTemplate = ({
-  background,
   iconXml,
   title,
   body,
-  buttonLabel,
-  buttonOnPress,
+  primaryButtonLabel,
+  primaryButtonContainerStyle,
+  primaryButtonTextStyle,
+  primaryButtonOnPress,
+  secondaryButtonLabel,
+  secondaryButtonContainerStyle,
+  secondaryButtonTextStyle,
+  secondaryButtonOnPress,
+  background,
+  backgroundStyle,
   invertIcon,
 }: DescriptionTemplateProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
   const iconStyle = invertIcon ? styles.goldIcon : styles.blueIcon;
 
+  const primaryButtonTextStyles = {
+    ...primaryButtonTextStyle,
+    ...styles.primaryButtonText,
+  };
+
+  const secondaryButtonTextStyles = {
+    ...secondaryButtonTextStyle,
+    ...styles.secondaryButtonText,
+  };
+
   return (
     <View style={styles.outerContainer}>
       {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
-        <ImageBackground source={background} style={styles.backgroundImage} />
+        <ImageBackground
+          source={background}
+          style={[styles.background, backgroundStyle]}
+        />
       )}
       <View style={styles.content}>
         <ScrollView
@@ -60,9 +89,22 @@ const DescriptionTemplate = ({
           <Typography style={styles.headerText}>{title}</Typography>
           <Typography style={styles.contentText}>{body}</Typography>
         </ScrollView>
-        <TouchableOpacity onPress={buttonOnPress} style={styles.button}>
-          <Typography style={styles.buttonText}>{buttonLabel}</Typography>
+        <TouchableOpacity
+          onPress={primaryButtonOnPress}
+          style={[styles.primaryButton, primaryButtonContainerStyle]}>
+          <Typography style={primaryButtonTextStyles}>
+            {primaryButtonLabel}
+          </Typography>
         </TouchableOpacity>
+        {secondaryButtonLabel && (
+          <TouchableOpacity
+            onPress={secondaryButtonOnPress}
+            style={[styles.secondaryButton, secondaryButtonContainerStyle]}>
+            <Typography style={secondaryButtonTextStyles}>
+              {secondaryButtonLabel}
+            </Typography>
+          </TouchableOpacity>
+        )}
       </View>
     </View>
   );
@@ -76,7 +118,7 @@ const styles = StyleSheet.create({
   innerContainer: {
     paddingVertical: Spacing.large,
   },
-  backgroundImage: {
+  background: {
     width: '100%',
     height: '100%',
     resizeMode: 'cover',
@@ -101,10 +143,16 @@ const styles = StyleSheet.create({
     ...TypographyStyles.mainContentViolet,
     marginTop: Spacing.xLarge,
   },
-  button: {
+  primaryButton: {
     ...Buttons.largeSecondaryBlue,
   },
-  buttonText: {
+  secondaryButton: {
+    ...Buttons.largeSecondaryBlue,
+  },
+  primaryButtonText: {
+    ...TypographyStyles.buttonTextLight,
+  },
+  secondaryButtonText: {
     ...TypographyStyles.buttonTextLight,
   },
 });

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -23,7 +23,12 @@ import {
   Typography as TypographyStyles,
 } from '../../styles';
 
-type DescriptionTemplateContent = {
+export enum IconStyle {
+  Blue,
+  Gold,
+}
+
+type ExplanationScreenContent = {
   icon: string;
   header: string;
   body: string;
@@ -32,7 +37,7 @@ type DescriptionTemplateContent = {
   backgroundImage: ImageSourcePropType;
 };
 
-type DescriptionTemplateStyles = {
+type ExplanationScreenStyles = {
   headerStyle?: TextStyle;
   bodyStyle?: TextStyle;
   primaryButtonContainerStyle?: ViewStyle;
@@ -40,49 +45,50 @@ type DescriptionTemplateStyles = {
   secondaryButtonContainerStyle?: ViewStyle;
   secondaryButtonTextStyle?: TextStyle;
   backgroundStyle?: ViewStyle;
-  invertIcon?: boolean;
+  iconStyle: IconStyle;
 };
 
-type DescriptionTemplateActions = {
+type ExplanationScreenActions = {
   primaryButtonOnPress: () => void;
   secondaryButtonOnPress?: () => void;
 };
 
-interface DescriptionTemplateProps {
-  descriptionTemplateContent: DescriptionTemplateContent;
-  descriptionTemplateStyles?: DescriptionTemplateStyles;
-  descriptionTemplateActions: DescriptionTemplateActions;
+interface ExplanationScreenProps {
+  descriptionTemplateContent: ExplanationScreenContent;
+  descriptionTemplateStyles: ExplanationScreenStyles;
+  descriptionTemplateActions: ExplanationScreenActions;
 }
 
-const DescriptionTemplate = ({
+const ExplanationScreen = ({
   descriptionTemplateContent,
   descriptionTemplateStyles,
   descriptionTemplateActions,
-}: DescriptionTemplateProps): JSX.Element => {
+}: ExplanationScreenProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
-  const iconStyle = descriptionTemplateStyles?.invertIcon
-    ? styles.goldIcon
-    : styles.blueIcon;
+  const iconStyle =
+    descriptionTemplateStyles.iconStyle == IconStyle.Blue
+      ? styles.blueIcon
+      : styles.goldIcon;
 
   const primaryButtonTextStyles = {
     ...styles.primaryButtonText,
-    ...descriptionTemplateStyles?.primaryButtonTextStyle,
+    ...descriptionTemplateStyles.primaryButtonTextStyle,
   };
 
   const secondaryButtonTextStyles = {
     ...styles.secondaryButtonText,
-    ...descriptionTemplateStyles?.secondaryButtonTextStyle,
+    ...descriptionTemplateStyles.secondaryButtonTextStyle,
   };
 
   const headerStyles = {
     ...styles.headerText,
-    ...descriptionTemplateStyles?.headerStyle,
+    ...descriptionTemplateStyles.headerStyle,
   };
 
   const contentStyles = {
     ...styles.contentText,
-    ...descriptionTemplateStyles?.bodyStyle,
+    ...descriptionTemplateStyles.bodyStyle,
   };
 
   return (
@@ -90,10 +96,7 @@ const DescriptionTemplate = ({
       {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
         <ImageBackground
           source={descriptionTemplateContent.backgroundImage}
-          style={[
-            styles.background,
-            descriptionTemplateStyles?.backgroundStyle,
-          ]}
+          style={[styles.background, descriptionTemplateStyles.backgroundStyle]}
         />
       )}
       <View style={styles.content}>
@@ -115,7 +118,7 @@ const DescriptionTemplate = ({
           onPress={descriptionTemplateActions.primaryButtonOnPress}
           style={[
             styles.primaryButton,
-            descriptionTemplateStyles?.primaryButtonContainerStyle,
+            descriptionTemplateStyles.primaryButtonContainerStyle,
           ]}>
           <Typography style={primaryButtonTextStyles}>
             {descriptionTemplateContent.primaryButtonLabel}
@@ -126,7 +129,7 @@ const DescriptionTemplate = ({
             onPress={descriptionTemplateActions.secondaryButtonOnPress}
             style={[
               styles.secondaryButton,
-              descriptionTemplateStyles?.secondaryButtonContainerStyle,
+              descriptionTemplateStyles.secondaryButtonContainerStyle,
             ]}>
             <Typography style={secondaryButtonTextStyles}>
               {descriptionTemplateContent.secondaryButtonLabel}
@@ -185,4 +188,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default DescriptionTemplate;
+export default ExplanationScreen;

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -54,41 +54,41 @@ type ExplanationScreenActions = {
 };
 
 interface ExplanationScreenProps {
-  descriptionTemplateContent: ExplanationScreenContent;
-  descriptionTemplateStyles: ExplanationScreenStyles;
-  descriptionTemplateActions: ExplanationScreenActions;
+  explanationScreenContent: ExplanationScreenContent;
+  explanationScreenStyles: ExplanationScreenStyles;
+  explanationScreenActions: ExplanationScreenActions;
 }
 
 const ExplanationScreen = ({
-  descriptionTemplateContent,
-  descriptionTemplateStyles,
-  descriptionTemplateActions,
+  explanationScreenContent,
+  explanationScreenStyles,
+  explanationScreenActions,
 }: ExplanationScreenProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
   const iconStyle =
-    descriptionTemplateStyles.iconStyle == IconStyle.Blue
+    explanationScreenStyles.iconStyle == IconStyle.Blue
       ? styles.blueIcon
       : styles.goldIcon;
 
   const primaryButtonTextStyles = {
     ...styles.primaryButtonText,
-    ...descriptionTemplateStyles.primaryButtonTextStyle,
+    ...explanationScreenStyles.primaryButtonTextStyle,
   };
 
   const secondaryButtonTextStyles = {
     ...styles.secondaryButtonText,
-    ...descriptionTemplateStyles.secondaryButtonTextStyle,
+    ...explanationScreenStyles.secondaryButtonTextStyle,
   };
 
   const headerStyles = {
     ...styles.headerText,
-    ...descriptionTemplateStyles.headerStyle,
+    ...explanationScreenStyles.headerStyle,
   };
 
   const contentStyles = {
     ...styles.contentText,
-    ...descriptionTemplateStyles.bodyStyle,
+    ...explanationScreenStyles.bodyStyle,
   };
 
   const smallScreenWidth = Layout.screenWidth <= Layout.smallScreenWidth;
@@ -97,8 +97,8 @@ const ExplanationScreen = ({
     <View style={styles.outerContainer}>
       {smallScreenWidth ? null : (
         <ImageBackground
-          source={descriptionTemplateContent.backgroundImage}
-          style={[styles.background, descriptionTemplateStyles.backgroundStyle]}
+          source={explanationScreenContent.backgroundImage}
+          style={[styles.background, explanationScreenStyles.backgroundStyle]}
         />
       )}
       <View style={styles.content}>
@@ -107,34 +107,34 @@ const ExplanationScreen = ({
           style={styles.innerContainer}
           contentContainerStyle={{ paddingBottom: Spacing.large }}>
           <View style={iconStyle}>
-            <SvgXml xml={descriptionTemplateContent.icon} />
+            <SvgXml xml={explanationScreenContent.icon} />
           </View>
           <Typography style={headerStyles}>
-            {descriptionTemplateContent.header}
+            {explanationScreenContent.header}
           </Typography>
           <Typography style={contentStyles}>
-            {descriptionTemplateContent.body}
+            {explanationScreenContent.body}
           </Typography>
         </ScrollView>
         <TouchableOpacity
-          onPress={descriptionTemplateActions.primaryButtonOnPress}
+          onPress={explanationScreenActions.primaryButtonOnPress}
           style={[
             styles.primaryButton,
-            descriptionTemplateStyles.primaryButtonContainerStyle,
+            explanationScreenStyles.primaryButtonContainerStyle,
           ]}>
           <Typography style={primaryButtonTextStyles}>
-            {descriptionTemplateContent.primaryButtonLabel}
+            {explanationScreenContent.primaryButtonLabel}
           </Typography>
         </TouchableOpacity>
-        {descriptionTemplateContent.secondaryButtonLabel && (
+        {explanationScreenContent.secondaryButtonLabel && (
           <TouchableOpacity
-            onPress={descriptionTemplateActions.secondaryButtonOnPress}
+            onPress={explanationScreenActions.secondaryButtonOnPress}
             style={[
               styles.secondaryButton,
-              descriptionTemplateStyles.secondaryButtonContainerStyle,
+              explanationScreenStyles.secondaryButtonContainerStyle,
             ]}>
             <Typography style={secondaryButtonTextStyles}>
-              {descriptionTemplateContent.secondaryButtonLabel}
+              {explanationScreenContent.secondaryButtonLabel}
             </Typography>
           </TouchableOpacity>
         )}

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -66,10 +66,14 @@ const ExplanationScreen = ({
 }: ExplanationScreenProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
-  const iconStyle =
-    explanationScreenStyles.iconStyle == IconStyle.Blue
-      ? styles.blueIcon
-      : styles.goldIcon;
+  function getIconStyle(iconStyle: IconStyle) {
+    switch (iconStyle) {
+      case IconStyle.Blue:
+        return styles.blueIcon;
+      case IconStyle.Gold:
+        return styles.goldIcon;
+    }
+  }
 
   const primaryButtonTextStyles = {
     ...styles.primaryButtonText,
@@ -106,7 +110,7 @@ const ExplanationScreen = ({
           alwaysBounceVertical={false}
           style={styles.innerContainer}
           contentContainerStyle={{ paddingBottom: Spacing.large }}>
-          <View style={iconStyle}>
+          <View style={getIconStyle(explanationScreenStyles.iconStyle)}>
             <SvgXml xml={explanationScreenContent.icon} />
           </View>
           <Typography style={headerStyles}>

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -91,9 +91,11 @@ const ExplanationScreen = ({
     ...descriptionTemplateStyles.bodyStyle,
   };
 
+  const smallScreenWidth = Layout.screenWidth <= Layout.smallScreenWidth;
+
   return (
     <View style={styles.outerContainer}>
-      {Layout.screenWidth <= Layout.smallScreenWidth ? null : (
+      {smallScreenWidth ? null : (
         <ImageBackground
           source={descriptionTemplateContent.backgroundImage}
           style={[styles.background, descriptionTemplateStyles.backgroundStyle]}

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   ImageBackground,
   StyleSheet,
-  TouchableOpacity,
   TextStyle,
   View,
   ScrollView,
@@ -11,6 +10,7 @@ import {
 } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
+import { Button } from '../../components/Button';
 import { useStatusBarEffect } from '../../navigation';
 import { Typography } from '../../components/Typography';
 
@@ -95,6 +95,16 @@ const ExplanationScreen = ({
     ...explanationScreenStyles.bodyStyle,
   };
 
+  const primaryButtonStyles = {
+    ...styles.primaryButton,
+    ...explanationScreenStyles.primaryButtonContainerStyle,
+  };
+
+  const secondaryButtonStyles = {
+    ...styles.secondaryButton,
+    ...explanationScreenStyles.secondaryButtonContainerStyle,
+  };
+
   const smallScreenWidth = Layout.screenWidth <= Layout.smallScreenWidth;
 
   return (
@@ -120,27 +130,19 @@ const ExplanationScreen = ({
             {explanationScreenContent.body}
           </Typography>
         </ScrollView>
-        <TouchableOpacity
+        <Button
+          label={explanationScreenContent.primaryButtonLabel}
           onPress={explanationScreenActions.primaryButtonOnPress}
-          style={[
-            styles.primaryButton,
-            explanationScreenStyles.primaryButtonContainerStyle,
-          ]}>
-          <Typography style={primaryButtonTextStyles}>
-            {explanationScreenContent.primaryButtonLabel}
-          </Typography>
-        </TouchableOpacity>
+          style={primaryButtonStyles}
+          textStyle={primaryButtonTextStyles}
+        />
         {explanationScreenContent.secondaryButtonLabel && (
-          <TouchableOpacity
+          <Button
+            label={explanationScreenContent.secondaryButtonLabel}
             onPress={explanationScreenActions.secondaryButtonOnPress}
-            style={[
-              styles.secondaryButton,
-              explanationScreenStyles.secondaryButtonContainerStyle,
-            ]}>
-            <Typography style={secondaryButtonTextStyles}>
-              {explanationScreenContent.secondaryButtonLabel}
-            </Typography>
-          </TouchableOpacity>
+            style={secondaryButtonStyles}
+            textStyle={secondaryButtonTextStyles}
+          />
         )}
       </View>
     </View>

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -136,14 +136,15 @@ const ExplanationScreen = ({
           style={primaryButtonStyles}
           textStyle={primaryButtonTextStyles}
         />
-        {explanationScreenContent.secondaryButtonLabel && (
-          <Button
-            label={explanationScreenContent.secondaryButtonLabel}
-            onPress={explanationScreenActions.secondaryButtonOnPress}
-            style={secondaryButtonStyles}
-            textStyle={secondaryButtonTextStyles}
-          />
-        )}
+        {explanationScreenActions.secondaryButtonOnPress &&
+          explanationScreenContent.secondaryButtonLabel && (
+            <Button
+              label={explanationScreenContent.secondaryButtonLabel}
+              onPress={explanationScreenActions.secondaryButtonOnPress}
+              style={secondaryButtonStyles}
+              textStyle={secondaryButtonTextStyles}
+            />
+          )}
       </View>
     </View>
   );

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -66,14 +66,14 @@ const ExplanationScreen = ({
 }: ExplanationScreenProps): JSX.Element => {
   useStatusBarEffect('dark-content');
 
-  function getIconStyle(iconStyle: IconStyle) {
+  const determineIconStyle = (iconStyle: IconStyle): ViewStyle => {
     switch (iconStyle) {
       case IconStyle.Blue:
         return styles.blueIcon;
       case IconStyle.Gold:
         return styles.goldIcon;
     }
-  }
+  };
 
   const primaryButtonTextStyles = {
     ...styles.primaryButtonText,
@@ -120,7 +120,7 @@ const ExplanationScreen = ({
           alwaysBounceVertical={false}
           style={styles.innerContainer}
           contentContainerStyle={{ paddingBottom: Spacing.large }}>
-          <View style={getIconStyle(explanationScreenStyles.iconStyle)}>
+          <View style={determineIconStyle(explanationScreenStyles.iconStyle)}>
             <SvgXml xml={explanationScreenContent.icon} />
           </View>
           <Typography style={headerStyles}>

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -38,7 +38,7 @@ export const EnableExposureNotifications = (): JSX.Element => {
     dispatchOnboardingComplete();
   };
 
-  const descriptionTemplateContent = {
+  const explanationScreenContent = {
     backgroundImage: Images.BlueGradientBackground,
     icon: Icons.ExposureIcon,
     header: headerText,
@@ -47,22 +47,22 @@ export const EnableExposureNotifications = (): JSX.Element => {
     secondaryButtonLabel: disableButtonLabel,
   };
 
-  const descriptionTemplateStyles = {
+  const explanationScreenStyles = {
     headerStyle: styles.header,
     bodyStyle: styles.body,
     iconStyle: IconStyle.Blue,
   };
 
-  const descriptionTemplateActions = {
+  const explanationScreenActions = {
     primaryButtonOnPress: handleOnPressEnable,
     secondaryButtonOnPress: handleOnPressDontEnable,
   };
 
   return (
     <ExplanationScreen
-      descriptionTemplateContent={descriptionTemplateContent}
-      descriptionTemplateStyles={descriptionTemplateStyles}
-      descriptionTemplateActions={descriptionTemplateActions}
+      explanationScreenContent={explanationScreenContent}
+      explanationScreenStyles={explanationScreenStyles}
+      explanationScreenActions={explanationScreenActions}
     />
   );
 };

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -1,28 +1,15 @@
 import React, { useContext } from 'react';
-import {
-  ImageBackground,
-  TouchableOpacity,
-  ScrollView,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { SvgXml } from 'react-native-svg';
 import { useDispatch } from 'react-redux';
 
 import PermissionsContext from '../../bt/PermissionsContext';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
-import { Typography } from '../../components/Typography';
 import { useStatusBarEffect } from '../../navigation';
+import DescriptionTemplate from '../../views/common/DescriptionTemplate';
 
 import { Icons, Images } from '../../assets';
-import {
-  Spacing,
-  Buttons,
-  Colors,
-  Iconography,
-  Typography as TypographyStyles,
-} from '../../styles';
+import { Colors } from '../../styles';
 
 export const EnableExposureNotifications = (): JSX.Element => {
   const { t } = useTranslation();
@@ -50,88 +37,26 @@ export const EnableExposureNotifications = (): JSX.Element => {
   };
 
   return (
-    <ImageBackground
-      source={Images.BlueGradientBackground}
-      style={styles.backgroundImage}>
-      <View testID={'onboarding-permissions-screen'} style={styles.container}>
-        <ScrollView style={styles.contentContainer}>
-          <View style={styles.iconContainer}>
-            <SvgXml xml={Icons.ExposureIcon} />
-          </View>
-          <Typography style={styles.headerText} testID='Header'>
-            {titleText}
-          </Typography>
-          <Typography style={styles.subheaderText}>{subTitleText}</Typography>
-        </ScrollView>
-
-        <View style={styles.footerContainer}>
-          <TouchableOpacity
-            style={styles.enableButton}
-            onPress={handleOnPressEnable}
-            testID={'onboarding-permissions-button'}>
-            <Typography style={styles.enableButtonText}>
-              {buttonLabel}
-            </Typography>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={styles.dontEnableButton}
-            onPress={handleOnPressDontEnable}
-            testID={'onboarding-permissions-disable-button'}>
-            <Typography style={styles.dontEnableButtonText}>
-              {disableButtonLabel}
-            </Typography>
-          </TouchableOpacity>
-        </View>
-      </View>
-    </ImageBackground>
+    <DescriptionTemplate
+      iconXml={Icons.ExposureIcon}
+      title={titleText}
+      titleStyle={styles.titleStyle}
+      body={subTitleText}
+      bodyStyle={styles.bodyStyle}
+      primaryButtonLabel={buttonLabel}
+      primaryButtonOnPress={handleOnPressEnable}
+      secondaryButtonLabel={disableButtonLabel}
+      secondaryButtonOnPress={handleOnPressDontEnable}
+      background={Images.BlueGradientBackground}
+    />
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing.large,
-    backgroundColor: Colors.invertedPrimaryBackground,
-  },
-  backgroundImage: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-    flex: 1,
-  },
-  contentContainer: {
-    paddingVertical: Spacing.large,
-  },
-  iconContainer: {
-    ...Iconography.largeBlueIcon,
-    marginBottom: Spacing.xHuge,
-  },
-  headerText: {
-    ...TypographyStyles.header2,
+  titleStyle: {
     color: Colors.white,
-    marginBottom: Spacing.small,
   },
-  subheaderText: {
-    ...TypographyStyles.mainContent,
-    color: Colors.invertedText,
-    marginBottom: Spacing.xHuge,
-    marginTop: Spacing.xLarge,
-  },
-  footerContainer: {
-    height: 'auto',
-    width: '100%',
-  },
-  enableButton: {
-    ...Buttons.largeWhite,
-  },
-  enableButtonText: {
-    ...TypographyStyles.buttonTextDark,
-  },
-  dontEnableButton: {
-    ...Buttons.largeSecondary,
-  },
-  dontEnableButtonText: {
-    ...TypographyStyles.buttonTextLight,
+  bodyStyle: {
+    color: Colors.white,
   },
 });

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -22,10 +22,10 @@ export const EnableExposureNotifications = (): JSX.Element => {
     dispatch(onboardingCompleteAction());
   };
 
+  const headerText = t('label.launch_exposure_notif_header');
+  const bodyText = t('label.launch_exposure_notif_subheader');
   const buttonLabel = t('label.launch_enable_exposure_notif');
   const disableButtonLabel = t('label.launch_disable_exposure_notif');
-  const subTitleText = t('label.launch_exposure_notif_subheader');
-  const titleText = t('label.launch_exposure_notif_header');
 
   const handleOnPressEnable = () => {
     exposureNotifications.request();
@@ -39,24 +39,24 @@ export const EnableExposureNotifications = (): JSX.Element => {
   return (
     <DescriptionTemplate
       iconXml={Icons.ExposureIcon}
-      title={titleText}
-      titleStyle={styles.titleStyle}
-      body={subTitleText}
-      bodyStyle={styles.bodyStyle}
+      header={headerText}
+      headerStyle={styles.header}
+      body={bodyText}
+      bodyStyle={styles.body}
       primaryButtonLabel={buttonLabel}
       primaryButtonOnPress={handleOnPressEnable}
       secondaryButtonLabel={disableButtonLabel}
       secondaryButtonOnPress={handleOnPressDontEnable}
-      background={Images.BlueGradientBackground}
+      backgroundImage={Images.BlueGradientBackground}
     />
   );
 };
 
 const styles = StyleSheet.create({
-  titleStyle: {
+  header: {
     color: Colors.white,
   },
-  bodyStyle: {
+  body: {
     color: Colors.white,
   },
 });

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -36,18 +36,30 @@ export const EnableExposureNotifications = (): JSX.Element => {
     dispatchOnboardingComplete();
   };
 
+  const descriptionTemplateContent = {
+    backgroundImage: Images.BlueGradientBackground,
+    iconXml: Icons.ExposureIcon,
+    header: headerText,
+    body: bodyText,
+    primaryButtonLabel: buttonLabel,
+    secondaryButtonLabel: disableButtonLabel,
+  };
+
+  const descriptionTemplateStyles = {
+    headerStyle: styles.header,
+    bodyStyle: styles.body,
+  };
+
+  const descriptionTemplateActions = {
+    primaryButtonOnPress: handleOnPressEnable,
+    secondaryButtonOnPress: handleOnPressDontEnable,
+  };
+
   return (
     <DescriptionTemplate
-      iconXml={Icons.ExposureIcon}
-      header={headerText}
-      headerStyle={styles.header}
-      body={bodyText}
-      bodyStyle={styles.body}
-      primaryButtonLabel={buttonLabel}
-      primaryButtonOnPress={handleOnPressEnable}
-      secondaryButtonLabel={disableButtonLabel}
-      secondaryButtonOnPress={handleOnPressDontEnable}
-      backgroundImage={Images.BlueGradientBackground}
+      descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateStyles={descriptionTemplateStyles}
+      descriptionTemplateActions={descriptionTemplateActions}
     />
   );
 };

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -6,7 +6,9 @@ import { useDispatch } from 'react-redux';
 import PermissionsContext from '../../bt/PermissionsContext';
 import onboardingCompleteAction from '../../store/actions/onboardingCompleteAction';
 import { useStatusBarEffect } from '../../navigation';
-import DescriptionTemplate from '../../views/common/DescriptionTemplate';
+import ExplanationScreen, {
+  IconStyle,
+} from '../../views/common/ExplanationScreen';
 
 import { Icons, Images } from '../../assets';
 import { Colors } from '../../styles';
@@ -48,6 +50,7 @@ export const EnableExposureNotifications = (): JSX.Element => {
   const descriptionTemplateStyles = {
     headerStyle: styles.header,
     bodyStyle: styles.body,
+    iconStyle: IconStyle.Blue,
   };
 
   const descriptionTemplateActions = {
@@ -56,7 +59,7 @@ export const EnableExposureNotifications = (): JSX.Element => {
   };
 
   return (
-    <DescriptionTemplate
+    <ExplanationScreen
       descriptionTemplateContent={descriptionTemplateContent}
       descriptionTemplateStyles={descriptionTemplateStyles}
       descriptionTemplateActions={descriptionTemplateActions}

--- a/app/views/onboarding/EnableExposureNotifications.tsx
+++ b/app/views/onboarding/EnableExposureNotifications.tsx
@@ -38,7 +38,7 @@ export const EnableExposureNotifications = (): JSX.Element => {
 
   const descriptionTemplateContent = {
     backgroundImage: Images.BlueGradientBackground,
-    iconXml: Icons.ExposureIcon,
+    icon: Icons.ExposureIcon,
     header: headerText,
     body: bodyText,
     primaryButtonLabel: buttonLabel,

--- a/app/views/onboarding/LocationsPermissions.tsx
+++ b/app/views/onboarding/LocationsPermissions.tsx
@@ -67,7 +67,7 @@ const LocationsPermissions = (): JSX.Element => {
             <SvgXml xml={Icons.LocationPin} width={30} height={30} />
           </View>
           <Typography style={styles.headerText}>
-            {t('onboarding.maybe_later')}
+            {t('onboarding.notification_header')}
           </Typography>
           <View style={{ height: Spacing.medium }} />
           <Typography style={styles.contentText}>

--- a/app/views/onboarding/LocationsPermissions.tsx
+++ b/app/views/onboarding/LocationsPermissions.tsx
@@ -67,7 +67,7 @@ const LocationsPermissions = (): JSX.Element => {
             <SvgXml xml={Icons.LocationPin} width={30} height={30} />
           </View>
           <Typography style={styles.headerText}>
-            {t('onboarding.notification_header')}
+            {t('onboarding.maybe_later')}
           </Typography>
           <View style={{ height: Spacing.medium }} />
           <Typography style={styles.contentText}>

--- a/app/views/onboarding/NotificationDetails.js
+++ b/app/views/onboarding/NotificationDetails.js
@@ -3,14 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { isGPS } from '../../COVIDSafePathsConfig';
 
 import { useStrategyContent } from '../../TracingStrategyContext';
-import OnboardingTemplate from './OnboardingTemplate';
+import DescriptionTemplate from '../common/DescriptionTemplate';
 
 const NotificationDetails = (props) => {
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
   return (
-    <OnboardingTemplate
+    <DescriptionTemplate
       theme={'light'}
       invertIcon={!isGPS}
       background={StrategyAssets.notificationDetailsBackground}

--- a/app/views/onboarding/NotificationDetails.tsx
+++ b/app/views/onboarding/NotificationDetails.tsx
@@ -18,9 +18,9 @@ const NotificationDetails = ({
   return (
     <DescriptionTemplate
       invertIcon={!isGPS}
-      background={StrategyAssets.notificationDetailsBackground}
+      backgroundImage={StrategyAssets.notificationDetailsBackground}
       iconXml={StrategyAssets.notificationDetailsIcon}
-      title={StrategyCopy.notificationDetailsHeader}
+      header={StrategyCopy.notificationDetailsHeader}
       body={StrategyCopy.notificationDetailsSubheader}
       primaryButtonLabel={t('label.launch_next')}
       primaryButtonOnPress={() => navigation.replace('ShareDiagnosis')}

--- a/app/views/onboarding/NotificationDetails.tsx
+++ b/app/views/onboarding/NotificationDetails.tsx
@@ -15,7 +15,7 @@ const NotificationDetails = ({
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
-  const descriptionTemplateContent = {
+  const explanationScreenContent = {
     backgroundImage: StrategyAssets.notificationDetailsBackground,
     icon: StrategyAssets.notificationDetailsIcon,
     header: StrategyCopy.notificationDetailsHeader,
@@ -25,19 +25,19 @@ const NotificationDetails = ({
 
   const iconStyle = isGPS ? IconStyle.Blue : IconStyle.Gold;
 
-  const descriptionTemplateStyles = {
+  const explanationScreenStyles = {
     iconStyle: iconStyle,
   };
 
-  const descriptionTemplateActions = {
+  const explanationScreenActions = {
     primaryButtonOnPress: () => navigation.replace('ShareDiagnosis'),
   };
 
   return (
     <ExplanationScreen
-      descriptionTemplateContent={descriptionTemplateContent}
-      descriptionTemplateStyles={descriptionTemplateStyles}
-      descriptionTemplateActions={descriptionTemplateActions}
+      explanationScreenContent={explanationScreenContent}
+      explanationScreenStyles={explanationScreenStyles}
+      explanationScreenActions={explanationScreenActions}
     />
   );
 };

--- a/app/views/onboarding/NotificationDetails.tsx
+++ b/app/views/onboarding/NotificationDetails.tsx
@@ -5,20 +5,25 @@ import { isGPS } from '../../COVIDSafePathsConfig';
 import { useStrategyContent } from '../../TracingStrategyContext';
 import DescriptionTemplate from '../common/DescriptionTemplate';
 
-const NotificationDetails = (props) => {
+interface NotificationDetailsProps {
+  navigation: any;
+}
+
+const NotificationDetails = ({
+  navigation,
+}: NotificationDetailsProps): JSX.Element => {
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
   return (
     <DescriptionTemplate
-      theme={'light'}
       invertIcon={!isGPS}
       background={StrategyAssets.notificationDetailsBackground}
       iconXml={StrategyAssets.notificationDetailsIcon}
       title={StrategyCopy.notificationDetailsHeader}
       body={StrategyCopy.notificationDetailsSubheader}
-      buttonLabel={t('label.launch_next')}
-      buttonOnPress={() => props.navigation.replace('ShareDiagnosis')}
+      primaryButtonLabel={t('label.launch_next')}
+      primaryButtonOnPress={() => navigation.replace('ShareDiagnosis')}
     />
   );
 };

--- a/app/views/onboarding/NotificationDetails.tsx
+++ b/app/views/onboarding/NotificationDetails.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { isGPS } from '../../COVIDSafePathsConfig';
 
 import { useStrategyContent } from '../../TracingStrategyContext';
-import DescriptionTemplate from '../common/DescriptionTemplate';
+import ExplanationScreen, { IconStyle } from '../common/ExplanationScreen';
 
 interface NotificationDetailsProps {
   navigation: any;
@@ -16,7 +16,6 @@ const NotificationDetails = ({
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
   const descriptionTemplateContent = {
-    invertIcon: !isGPS,
     backgroundImage: StrategyAssets.notificationDetailsBackground,
     icon: StrategyAssets.notificationDetailsIcon,
     header: StrategyCopy.notificationDetailsHeader,
@@ -24,13 +23,20 @@ const NotificationDetails = ({
     primaryButtonLabel: t('label.launch_next'),
   };
 
+  const iconStyle = isGPS ? IconStyle.Blue : IconStyle.Gold;
+
+  const descriptionTemplateStyles = {
+    iconStyle: iconStyle,
+  };
+
   const descriptionTemplateActions = {
     primaryButtonOnPress: () => navigation.replace('ShareDiagnosis'),
   };
 
   return (
-    <DescriptionTemplate
+    <ExplanationScreen
       descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateStyles={descriptionTemplateStyles}
       descriptionTemplateActions={descriptionTemplateActions}
     />
   );

--- a/app/views/onboarding/NotificationDetails.tsx
+++ b/app/views/onboarding/NotificationDetails.tsx
@@ -15,15 +15,23 @@ const NotificationDetails = ({
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
+  const descriptionTemplateContent = {
+    invertIcon: !isGPS,
+    backgroundImage: StrategyAssets.notificationDetailsBackground,
+    iconXml: StrategyAssets.notificationDetailsIcon,
+    header: StrategyCopy.notificationDetailsHeader,
+    body: StrategyCopy.notificationDetailsSubheader,
+    primaryButtonLabel: t('label.launch_next'),
+  };
+
+  const descriptionTemplateActions = {
+    primaryButtonOnPress: () => navigation.replace('ShareDiagnosis'),
+  };
+
   return (
     <DescriptionTemplate
-      invertIcon={!isGPS}
-      backgroundImage={StrategyAssets.notificationDetailsBackground}
-      iconXml={StrategyAssets.notificationDetailsIcon}
-      header={StrategyCopy.notificationDetailsHeader}
-      body={StrategyCopy.notificationDetailsSubheader}
-      primaryButtonLabel={t('label.launch_next')}
-      primaryButtonOnPress={() => navigation.replace('ShareDiagnosis')}
+      descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateActions={descriptionTemplateActions}
     />
   );
 };

--- a/app/views/onboarding/NotificationDetails.tsx
+++ b/app/views/onboarding/NotificationDetails.tsx
@@ -18,7 +18,7 @@ const NotificationDetails = ({
   const descriptionTemplateContent = {
     invertIcon: !isGPS,
     backgroundImage: StrategyAssets.notificationDetailsBackground,
-    iconXml: StrategyAssets.notificationDetailsIcon,
+    icon: StrategyAssets.notificationDetailsIcon,
     header: StrategyCopy.notificationDetailsHeader,
     body: StrategyCopy.notificationDetailsSubheader,
     primaryButtonLabel: t('label.launch_next'),

--- a/app/views/onboarding/PersonalPrivacy.js
+++ b/app/views/onboarding/PersonalPrivacy.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useStatusBarEffect } from '../../navigation';
 import { useStrategyContent } from '../../TracingStrategyContext';
-import OnboardingTemplate from './OnboardingTemplate';
+import DescriptionTemplate from '../common/DescriptionTemplate';
 
 const PersonalPrivacy = (props) => {
   useStatusBarEffect('dark-content');
@@ -11,7 +11,7 @@ const PersonalPrivacy = (props) => {
   const { StrategyAssets, StrategyCopy } = useStrategyContent();
 
   return (
-    <OnboardingTemplate
+    <DescriptionTemplate
       background={StrategyAssets.personalPrivacyBackground}
       iconXml={StrategyAssets.personalPrivacyIcon}
       title={StrategyCopy.personalPrivacyHeader}

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -5,7 +5,11 @@ import { useStatusBarEffect } from '../../navigation';
 import { useStrategyContent } from '../../TracingStrategyContext';
 import DescriptionTemplate from '../common/DescriptionTemplate';
 
-const PersonalPrivacy = (props) => {
+interface PersonalPrivacyProps {
+  navigation: any;
+}
+
+const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
   useStatusBarEffect('dark-content');
   const { t } = useTranslation();
   const { StrategyAssets, StrategyCopy } = useStrategyContent();
@@ -16,8 +20,8 @@ const PersonalPrivacy = (props) => {
       iconXml={StrategyAssets.personalPrivacyIcon}
       title={StrategyCopy.personalPrivacyHeader}
       body={StrategyCopy.personalPrivacySubheader}
-      buttonLabel={t('label.launch_next')}
-      buttonOnPress={() => props.navigation.replace('NotificatioNDetails')}
+      primaryButtonLabel={t('label.launch_next')}
+      primaryButtonOnPress={() => navigation.replace('NotificatioNDetails')}
     />
   );
 };

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -16,7 +16,7 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
 
   const descriptionTemplateContent = {
     backgroundImage: StrategyAssets.personalPrivacyBackground,
-    iconXml: StrategyAssets.personalPrivacyIcon,
+    icon: StrategyAssets.personalPrivacyIcon,
     header: StrategyCopy.personalPrivacyHeader,
     body: StrategyCopy.personalPrivacySubheader,
     primaryButtonLabel: t('label.launch_next'),

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -16,9 +16,9 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
 
   return (
     <DescriptionTemplate
-      background={StrategyAssets.personalPrivacyBackground}
+      backgroundImage={StrategyAssets.personalPrivacyBackground}
       iconXml={StrategyAssets.personalPrivacyIcon}
-      title={StrategyCopy.personalPrivacyHeader}
+      header={StrategyCopy.personalPrivacyHeader}
       body={StrategyCopy.personalPrivacySubheader}
       primaryButtonLabel={t('label.launch_next')}
       primaryButtonOnPress={() => navigation.replace('NotificatioNDetails')}

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useStatusBarEffect } from '../../navigation';
 import { useStrategyContent } from '../../TracingStrategyContext';
-import DescriptionTemplate from '../common/DescriptionTemplate';
+import ExplanationScreen, { IconStyle } from '../common/ExplanationScreen';
 
 interface PersonalPrivacyProps {
   navigation: any;
@@ -22,13 +22,18 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
     primaryButtonLabel: t('label.launch_next'),
   };
 
+  const descriptionTemplateStyles = {
+    iconStyle: IconStyle.Blue,
+  };
+
   const descriptionTemplateActions = {
     primaryButtonOnPress: () => navigation.replace('NotificatioNDetails'),
   };
 
   return (
-    <DescriptionTemplate
+    <ExplanationScreen
       descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateStyles={descriptionTemplateStyles}
       descriptionTemplateActions={descriptionTemplateActions}
     />
   );

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -14,7 +14,7 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
   const { t } = useTranslation();
   const { StrategyAssets, StrategyCopy } = useStrategyContent();
 
-  const descriptionTemplateContent = {
+  const explanationScreenContent = {
     backgroundImage: StrategyAssets.personalPrivacyBackground,
     icon: StrategyAssets.personalPrivacyIcon,
     header: StrategyCopy.personalPrivacyHeader,
@@ -22,19 +22,19 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
     primaryButtonLabel: t('label.launch_next'),
   };
 
-  const descriptionTemplateStyles = {
+  const explanationScreenStyles = {
     iconStyle: IconStyle.Blue,
   };
 
-  const descriptionTemplateActions = {
+  const explanationScreenActions = {
     primaryButtonOnPress: () => navigation.replace('NotificatioNDetails'),
   };
 
   return (
     <ExplanationScreen
-      descriptionTemplateContent={descriptionTemplateContent}
-      descriptionTemplateStyles={descriptionTemplateStyles}
-      descriptionTemplateActions={descriptionTemplateActions}
+      explanationScreenContent={explanationScreenContent}
+      explanationScreenStyles={explanationScreenStyles}
+      explanationScreenActions={explanationScreenActions}
     />
   );
 };

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -14,14 +14,22 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
   const { t } = useTranslation();
   const { StrategyAssets, StrategyCopy } = useStrategyContent();
 
+  const descriptionTemplateContent = {
+    backgroundImage: StrategyAssets.personalPrivacyBackground,
+    iconXml: StrategyAssets.personalPrivacyIcon,
+    header: StrategyCopy.personalPrivacyHeader,
+    body: StrategyCopy.personalPrivacySubheader,
+    primaryButtonLabel: t('label.launch_next'),
+  };
+
+  const descriptionTemplateActions = {
+    primaryButtonOnPress: () => navigation.replace('NotificatioNDetails'),
+  };
+
   return (
     <DescriptionTemplate
-      backgroundImage={StrategyAssets.personalPrivacyBackground}
-      iconXml={StrategyAssets.personalPrivacyIcon}
-      header={StrategyCopy.personalPrivacyHeader}
-      body={StrategyCopy.personalPrivacySubheader}
-      primaryButtonLabel={t('label.launch_next')}
-      primaryButtonOnPress={() => navigation.replace('NotificatioNDetails')}
+      descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateActions={descriptionTemplateActions}
     />
   );
 };

--- a/app/views/onboarding/ShareDiagnosis.js
+++ b/app/views/onboarding/ShareDiagnosis.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import OnboardingTemplate from './OnboardingTemplate';
+import DescriptionTemplate from '../common/DescriptionTemplate';
 import { isGPS } from '../../COVIDSafePathsConfig';
 import { Screens } from '../../navigation';
 import { isPlatformiOS } from '../../Util';
@@ -25,7 +25,7 @@ const ShareDiagnosis = (props) => {
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 
   return (
-    <OnboardingTemplate
+    <DescriptionTemplate
       theme={'light'}
       invertIcon={isGPS}
       background={StrategyAssets.shareDiagnosisBackground}

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import DescriptionTemplate from '../common/DescriptionTemplate';
 import { isGPS } from '../../COVIDSafePathsConfig';
 import { Screens } from '../../navigation';
 import { isPlatformiOS } from '../../Util';
 import { useStrategyContent } from '../../TracingStrategyContext';
+import ExplanationScreen, { IconStyle } from '../common/ExplanationScreen';
 
 interface ShareDiagnosisProps {
   navigation: any;
@@ -28,7 +28,6 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 
   const descriptionTemplateContent = {
-    invertIcon: isGPS,
     backgroundImage: StrategyAssets.shareDiagnosisBackground,
     icon: StrategyAssets.shareDiagnosisIcon,
     header: StrategyCopy.shareDiagnosisHeader,
@@ -36,13 +35,20 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
     primaryButtonLabel: t('label.launch_set_up_phone_location'),
   };
 
+  const iconStyle = isGPS ? IconStyle.Gold : IconStyle.Blue;
+
+  const descriptionTemplateStyles = {
+    iconStyle: iconStyle,
+  };
+
   const descriptionTemplateActions = {
     primaryButtonOnPress: handleOnPressNext,
   };
 
   return (
-    <DescriptionTemplate
+    <ExplanationScreen
       descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateStyles={descriptionTemplateStyles}
       descriptionTemplateActions={descriptionTemplateActions}
     />
   );

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -27,15 +27,23 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
 
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 
+  const descriptionTemplateContent = {
+    invertIcon: isGPS,
+    backgroundImage: StrategyAssets.shareDiagnosisBackground,
+    iconXml: StrategyAssets.shareDiagnosisIcon,
+    header: StrategyCopy.shareDiagnosisHeader,
+    body: StrategyCopy.shareDiagnosisSubheader,
+    primaryButtonLabel: t('label.launch_set_up_phone_location'),
+  };
+
+  const descriptionTemplateActions = {
+    primaryButtonOnPress: handleOnPressNext,
+  };
+
   return (
     <DescriptionTemplate
-      invertIcon={isGPS}
-      backgroundImage={StrategyAssets.shareDiagnosisBackground}
-      iconXml={StrategyAssets.shareDiagnosisIcon}
-      header={StrategyCopy.shareDiagnosisHeader}
-      body={StrategyCopy.shareDiagnosisSubheader}
-      primaryButtonLabel={t('label.launch_set_up_phone_location')}
-      primaryButtonOnPress={handleOnPressNext}
+      descriptionTemplateContent={descriptionTemplateContent}
+      descriptionTemplateActions={descriptionTemplateActions}
     />
   );
 };

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -27,7 +27,7 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
 
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 
-  const descriptionTemplateContent = {
+  const explanationScreenContent = {
     backgroundImage: StrategyAssets.shareDiagnosisBackground,
     icon: StrategyAssets.shareDiagnosisIcon,
     header: StrategyCopy.shareDiagnosisHeader,
@@ -37,19 +37,19 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
 
   const iconStyle = isGPS ? IconStyle.Gold : IconStyle.Blue;
 
-  const descriptionTemplateStyles = {
+  const explanationScreenStyles = {
     iconStyle: iconStyle,
   };
 
-  const descriptionTemplateActions = {
+  const explanationScreenActions = {
     primaryButtonOnPress: handleOnPressNext,
   };
 
   return (
     <ExplanationScreen
-      descriptionTemplateContent={descriptionTemplateContent}
-      descriptionTemplateStyles={descriptionTemplateStyles}
-      descriptionTemplateActions={descriptionTemplateActions}
+      explanationScreenContent={explanationScreenContent}
+      explanationScreenStyles={explanationScreenStyles}
+      explanationScreenActions={explanationScreenActions}
     />
   );
 };

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -7,33 +7,35 @@ import { Screens } from '../../navigation';
 import { isPlatformiOS } from '../../Util';
 import { useStrategyContent } from '../../TracingStrategyContext';
 
-const ShareDiagnosis = (props) => {
+interface ShareDiagnosisProps {
+  navigation: any;
+}
+
+const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
   const gpsNext = () =>
-    props.navigation.replace(
+    navigation.replace(
       // Skip notification permissions on android
       isPlatformiOS()
         ? Screens.OnboardingNotificationPermissions
         : Screens.OnboardingLocationPermissions,
     );
 
-  const btNext = () =>
-    props.navigation.replace(Screens.NotificationPermissionsBT);
+  const btNext = () => navigation.replace(Screens.NotificationPermissionsBT);
 
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 
   return (
     <DescriptionTemplate
-      theme={'light'}
       invertIcon={isGPS}
       background={StrategyAssets.shareDiagnosisBackground}
       iconXml={StrategyAssets.shareDiagnosisIcon}
       title={StrategyCopy.shareDiagnosisHeader}
       body={StrategyCopy.shareDiagnosisSubheader}
-      buttonLabel={t('label.launch_set_up_phone_location')}
-      buttonOnPress={handleOnPressNext}
+      primaryButtonLabel={t('label.launch_set_up_phone_location')}
+      primaryButtonOnPress={handleOnPressNext}
     />
   );
 };

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -30,7 +30,7 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
   const descriptionTemplateContent = {
     invertIcon: isGPS,
     backgroundImage: StrategyAssets.shareDiagnosisBackground,
-    iconXml: StrategyAssets.shareDiagnosisIcon,
+    icon: StrategyAssets.shareDiagnosisIcon,
     header: StrategyCopy.shareDiagnosisHeader,
     body: StrategyCopy.shareDiagnosisSubheader,
     primaryButtonLabel: t('label.launch_set_up_phone_location'),

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -30,9 +30,9 @@ const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
   return (
     <DescriptionTemplate
       invertIcon={isGPS}
-      background={StrategyAssets.shareDiagnosisBackground}
+      backgroundImage={StrategyAssets.shareDiagnosisBackground}
       iconXml={StrategyAssets.shareDiagnosisIcon}
-      title={StrategyCopy.shareDiagnosisHeader}
+      header={StrategyCopy.shareDiagnosisHeader}
       body={StrategyCopy.shareDiagnosisSubheader}
       primaryButtonLabel={t('label.launch_set_up_phone_location')}
       primaryButtonOnPress={handleOnPressNext}


### PR DESCRIPTION
#### Description:
- Refactors the `OnboardingTemplate` component to be more configurable and renames it to `ExplanationScreen`
- Uses the new `ExplanationScreen` component on a few more screens in the onboarding flow

#### Linked issues:
https://trello.com/c/JsfKPfSg/142-as-a-developer-i-would-like-a-shared-template-that-i-can-implement-for-the-similarly-styled-onboarding-export-and-self-assessmen

#### Screenshots:
![demo](https://user-images.githubusercontent.com/39350030/86293257-43925580-bbc0-11ea-9730-a1800a74ccdf.gif)

#### How to test:
Go through the onboarding flow and verify the screens looks correct.

Co-authored-by: Jeff Stolz <jstolz123@gmail.com>
Co-authored-by: Eric Bailey <eric.w.bailey@gmail.com>