### PR TITLE
Remove exposure likely from history legend

### DIFF
--- a/app/views/ExposureHistory/LegendModal.tsx
+++ b/app/views/ExposureHistory/LegendModal.tsx
@@ -43,13 +43,6 @@ const LegendModal = ({
   const { t } = useTranslation();
   const legendItems: LegendItem[] = [
     {
-      backgroundStyle: styles.expectedExposureIcon,
-      badgeStyle: null,
-      textStyle: styles.expectedExposureText,
-      iconContent: '1',
-      itemText: t('exposure_history.legend.exposure_likely'),
-    },
-    {
       backgroundStyle: styles.possibleExposureIcon,
       badgeStyle: null,
       textStyle: styles.possibleExposureText,


### PR DESCRIPTION
Why:
We currently don't handle the exposure is likely indicator for the
Exposure history screen so we would like to remove it from the legend.
We plan to add something similar back when we have that data to present
to the user.


<img width="584" alt="Screen Shot 2020-07-02 at 12 03 13 PM" src="https://user-images.githubusercontent.com/16049495/86388965-a12bae00-bc63-11ea-91bc-85e61d07648f.png">
