### PR TITLE
Add spec coverage for possible exposure indicator

### DIFF
--- a/app/views/ExposureHistory/Calendar.spec.tsx
+++ b/app/views/ExposureHistory/Calendar.spec.tsx
@@ -10,7 +10,7 @@ afterEach(cleanup);
 
 describe('Calendar', () => {
   it('renders', () => {
-    const exposureHistory = buildExposureHistory();
+    const exposureHistory = buildBlankExposureHistory();
     const onSelectDate = () => {};
     const selectedDatum = exposureHistory[0];
 
@@ -26,7 +26,7 @@ describe('Calendar', () => {
   });
 });
 
-const buildExposureHistory = () => {
+const buildBlankExposureHistory = () => {
   const datum = factories.exposureDatum.build();
   const exposureInfo = {
     [datum.date]: datum,

--- a/app/views/ExposureHistory/Calendar.tsx
+++ b/app/views/ExposureHistory/Calendar.tsx
@@ -52,6 +52,7 @@ const Calendar = ({
           return (
             <TouchableOpacity
               key={`calendar-day-${datum.date}`}
+              testID={`calendar-day-${datum.date}`}
               onPress={() => onSelectDate(datum)}>
               <ExposureDatumIndicator
                 isSelected={isSelected}

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -63,6 +63,7 @@ const PossibleExposureDetail = ({
       </View>
       <View style={styles.ctaContainer}>
         <TouchableOpacity
+          testID={'exposure-history-next-steps-button'}
           style={styles.nextStepsButton}
           onPress={handleOnPressNextSteps}>
           <Typography style={styles.nextStepsButtonText}>

--- a/app/views/ExposureHistory/History.spec.tsx
+++ b/app/views/ExposureHistory/History.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  fireEvent,
+  wait,
+  cleanup,
+  render,
+} from '@testing-library/react-native';
+
+import { calendarDays, toExposureHistory } from '../../exposureHistory';
+import { DateTimeUtils } from '../../helpers';
+import { factories } from '../../factories';
+
+import History from './History';
+
+const CALENDAR_LENGTH = 21;
+
+afterEach(cleanup);
+
+describe('History', () => {
+  it('renders', () => {
+    const exposureHistory = buildBlankExposureHistory();
+
+    const { getByTestId } = render(
+      <History exposureHistory={exposureHistory} />,
+    );
+
+    expect(getByTestId('exposure-history-calendar')).not.toBeNull();
+  });
+
+  describe('when given an exposure history that has a possible exposure', () => {
+    describe('and the user taps the date of that exposure', () => {
+      it("shows a 'Next Steps' button", async () => {
+        const twoDaysAgo = DateTimeUtils.beginningOfDay(
+          DateTimeUtils.daysAgo(2),
+        );
+        const datum = factories.exposureDatum.build({
+          kind: 'Possible',
+          date: twoDaysAgo,
+        });
+        const exposureInfo = {
+          [datum.date]: datum,
+        };
+        const calendar = calendarDays(Date.now(), CALENDAR_LENGTH);
+        const exposureHistory = toExposureHistory(exposureInfo, calendar);
+
+        const { queryByTestId, getByTestId } = render(
+          <History exposureHistory={exposureHistory} />,
+        );
+
+        const twoDaysAgoIndicator = getByTestId(`calendar-day-${twoDaysAgo}`);
+
+        expect(queryByTestId('exposure-history-next-steps-button')).toBeNull();
+
+        fireEvent.press(twoDaysAgoIndicator);
+
+        await wait(() => {
+          expect(
+            getByTestId('exposure-history-next-steps-button'),
+          ).not.toBeNull();
+        });
+      });
+    });
+  });
+});
+
+const buildBlankExposureHistory = () => {
+  const datum = factories.exposureDatum.build();
+  const exposureInfo = {
+    [datum.date]: datum,
+  };
+  const calendar = calendarDays(Date.now(), CALENDAR_LENGTH);
+  return toExposureHistory(exposureInfo, calendar);
+};

--- a/app/views/ExposureHistory/History.tsx
+++ b/app/views/ExposureHistory/History.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import {
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ScrollView,
+  SafeAreaView,
+} from 'react-native';
+import { SvgXml } from 'react-native-svg';
+import { useTranslation } from 'react-i18next';
+import { useNavigation } from '@react-navigation/native';
+
+import { ExposureDatum, ExposureHistory } from '../../exposureHistory';
+import { Typography } from '../../components/Typography';
+import ExposureDatumDetail from './ExposureDatumDetail';
+import { DateTimeUtils } from '../../helpers';
+import Calendar from './Calendar';
+import { Screens } from '../../navigation';
+import { isGPS } from '../../COVIDSafePathsConfig';
+
+import { Icons } from '../../assets';
+import {
+  Buttons,
+  Spacing,
+  Typography as TypographyStyles,
+  Colors,
+} from '../../styles';
+import dayjs from 'dayjs';
+
+interface HistoryProps {
+  exposureHistory: ExposureHistory;
+}
+
+const History = ({ exposureHistory }: HistoryProps): JSX.Element => {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+  const [selectedDatum, setSelectedDatum] = useState<ExposureDatum | null>(
+    null,
+  );
+
+  const isTodayOrBefore = (date: number) => {
+    return !dayjs(date).isAfter(dayjs(), 'day');
+  };
+
+  const handleOnSelectDate = (datum: ExposureDatum) => {
+    if (isTodayOrBefore(datum.date)) {
+      setSelectedDatum(datum);
+    }
+  };
+
+  const handleOnPressMoreInfo = () => {
+    navigation.navigate(Screens.MoreInfo);
+  };
+
+  const titleText = t('screen_titles.exposure_history');
+  const lastDaysText = t('exposure_history.last_days');
+
+  const showExposureDetail =
+    selectedDatum && !DateTimeUtils.isInFuture(selectedDatum.date);
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <ScrollView style={styles.container} alwaysBounceVertical={false}>
+        <View>
+          <View style={styles.headerRow}>
+            <Typography style={styles.headerText}>{titleText}</Typography>
+            <TouchableOpacity
+              onPress={handleOnPressMoreInfo}
+              style={styles.moreInfoButton}>
+              <SvgXml
+                xml={Icons.QuestionMark}
+                style={styles.moreInfoButtonIcon}
+              />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.headerRow}>
+            {!isGPS ? (
+              <Typography style={styles.subHeaderText}>
+                {lastDaysText}
+              </Typography>
+            ) : null}
+          </View>
+        </View>
+        <View style={styles.calendarContainer}>
+          <Calendar
+            exposureHistory={exposureHistory}
+            onSelectDate={handleOnSelectDate}
+            selectedDatum={selectedDatum}
+          />
+        </View>
+        <View style={styles.detailsContainer}>
+          {selectedDatum && showExposureDetail ? (
+            <ExposureDatumDetail exposureDatum={selectedDatum} />
+          ) : null}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: Spacing.medium,
+    backgroundColor: Colors.primaryBackground,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: Spacing.xSmall,
+  },
+  headerText: {
+    ...TypographyStyles.header2,
+    marginRight: Spacing.medium,
+  },
+  subHeaderText: {
+    ...TypographyStyles.header4,
+    ...TypographyStyles.bold,
+  },
+  moreInfoButton: {
+    ...Buttons.tinyTeritiaryRounded,
+    minHeight: Spacing.xHuge,
+    minWidth: Spacing.xHuge,
+  },
+  moreInfoButtonIcon: {
+    minHeight: Spacing.small,
+    minWidth: Spacing.small,
+  },
+  calendarContainer: {
+    marginTop: Spacing.xxLarge,
+  },
+  detailsContainer: {
+    flex: 1,
+    marginTop: Spacing.small,
+    marginBottom: Spacing.huge,
+  },
+});
+
+export default History;

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -1,138 +1,20 @@
-import React, { useState, useContext } from 'react';
-import {
-  StyleSheet,
-  TouchableOpacity,
-  View,
-  ScrollView,
-  SafeAreaView,
-} from 'react-native';
-import { SvgXml } from 'react-native-svg';
-import { useTranslation } from 'react-i18next';
-import { useNavigation } from '@react-navigation/native';
+import React, { useContext } from 'react';
+import { SafeAreaView } from 'react-native';
 
 import ExposureHistoryContext from '../../ExposureHistoryContext';
-import { ExposureDatum } from '../../exposureHistory';
-import { Typography } from '../../components/Typography';
-import ExposureDatumDetail from './ExposureDatumDetail';
-import { DateTimeUtils } from '../../helpers';
-import Calendar from './Calendar';
-import { Screens, useStatusBarEffect } from '../../navigation';
-import { isGPS } from '../../COVIDSafePathsConfig';
-
-import { Icons } from '../../assets';
-import {
-  Buttons,
-  Spacing,
-  Typography as TypographyStyles,
-  Colors,
-} from '../../styles';
-import dayjs from 'dayjs';
+import { useStatusBarEffect } from '../../navigation';
+import History from './History';
 
 const ExposureHistoryScreen = (): JSX.Element => {
-  const { t } = useTranslation();
-  const navigation = useNavigation();
   const { exposureHistory } = useContext(ExposureHistoryContext);
-  const [selectedDatum, setSelectedDatum] = useState<ExposureDatum | null>(
-    null,
-  );
 
   useStatusBarEffect('dark-content');
 
-  const isTodayOrBefore = (date: number) => {
-    return !dayjs(date).isAfter(dayjs(), 'day');
-  };
-
-  const handleOnSelectDate = (datum: ExposureDatum) => {
-    if (isTodayOrBefore(datum.date)) {
-      setSelectedDatum(datum);
-    }
-  };
-
-  const handleOnPressMoreInfo = () => {
-    navigation.navigate(Screens.MoreInfo);
-  };
-
-  const titleText = t('screen_titles.exposure_history');
-  const lastDaysText = t('exposure_history.last_days');
-
-  const showExposureDetail =
-    selectedDatum && !DateTimeUtils.isInFuture(selectedDatum.date);
-
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView style={styles.container} alwaysBounceVertical={false}>
-        <View>
-          <View style={styles.headerRow}>
-            <Typography style={styles.headerText}>{titleText}</Typography>
-            <TouchableOpacity
-              onPress={handleOnPressMoreInfo}
-              style={styles.moreInfoButton}>
-              <SvgXml
-                xml={Icons.QuestionMark}
-                style={styles.moreInfoButtonIcon}
-              />
-            </TouchableOpacity>
-          </View>
-          <View style={styles.headerRow}>
-            {!isGPS ? (
-              <Typography style={styles.subHeaderText}>
-                {lastDaysText}
-              </Typography>
-            ) : null}
-          </View>
-        </View>
-        <View style={styles.calendarContainer}>
-          <Calendar
-            exposureHistory={exposureHistory}
-            onSelectDate={handleOnSelectDate}
-            selectedDatum={selectedDatum}
-          />
-        </View>
-        <View style={styles.detailsContainer}>
-          {selectedDatum && showExposureDetail ? (
-            <ExposureDatumDetail exposureDatum={selectedDatum} />
-          ) : null}
-        </View>
-      </ScrollView>
+      <History exposureHistory={exposureHistory} />
     </SafeAreaView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    padding: Spacing.medium,
-    backgroundColor: Colors.primaryBackground,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginTop: Spacing.xSmall,
-  },
-  headerText: {
-    ...TypographyStyles.header2,
-    marginRight: Spacing.medium,
-  },
-  subHeaderText: {
-    ...TypographyStyles.header4,
-    ...TypographyStyles.bold,
-  },
-  moreInfoButton: {
-    ...Buttons.tinyTeritiaryRounded,
-    minHeight: Spacing.xHuge,
-    minWidth: Spacing.xHuge,
-  },
-  moreInfoButtonIcon: {
-    minHeight: Spacing.small,
-    minWidth: Spacing.small,
-  },
-  calendarContainer: {
-    marginTop: Spacing.xxLarge,
-  },
-  detailsContainer: {
-    flex: 1,
-    marginTop: Spacing.small,
-    marginBottom: Spacing.huge,
-  },
-});
 
 export default ExposureHistoryScreen;


### PR DESCRIPTION
Why:
Currently the feature of showing a 'Next Steps' button on the
ExposureHistory screen has not test coverage. As this is an important
part of the user flow, we would like to add some basic test coverage.