### PR TITLE
Limit Exposure Detection to at most once every 3 hours

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -14,6 +14,14 @@ final class ExposureManager: NSObject {
   let manager = ENManager()
   
   var detectingExposures = false
+
+  var detectionPermitted: Bool {
+    if let lastDetectionDate = BTSecureStorage.shared.$dateLastPerformedExposureDetection.wrappedValue,
+      Calendar.current.dateComponents([.hour], from: lastDetectionDate, to: Date()).hour ?? 0 < 3 {
+      return false
+    }
+    return true
+  }
   
   enum EnabledState: String {
     case ENABLED, DISABLED
@@ -81,6 +89,11 @@ final class ExposureManager: NSObject {
   var localUncompressedURLs = [URL]()
   
   @discardableResult func detectExposures(completionHandler: ((Error?) -> Void)? = nil) -> Progress {
+
+    // Exit if last detection date was < 3 hours ago
+    if !detectionPermitted {
+      completionHandler?(nil)
+    }
     
     let progress = Progress()
     

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -14,6 +14,10 @@ extension ExposureManager {
         }
       }
     case .detectExposuresNow:
+      guard ExposureManager.shared.detectionPermitted else {
+        callback(["Exposure detection error: you must wait until 3 hours have passed since last detection", NSNull()])
+        return
+      }
       detectExposures { error in
         if let error = error {
           callback(["Exposure detection error: \((error as NSError).userInfo)", NSNull()])


### PR DESCRIPTION
### Why
The `Exposure Detection` framework will error out if keys are submitted >20 times per day.

### This Commit
This commit ensures that exposure detection will be run at most 8 times per day. On iOS we do not have the ability to schedule the exact interval at which our background task is run, but we can make sure that when it is run, we check that at least 3 hours have elapsed since the last execution before submitting keys to the framework.

![IMG_1913 2](https://user-images.githubusercontent.com/2637355/86597607-f6b8d100-bf69-11ea-84d8-9c7ad29e5d94.PNG)
