### PR TITLE
Check EN Permission Status Each Time App Resumes

### DIFF
--- a/android/app/src/bt/java/covidsafepaths/bt/exposurenotifications/utils/CallbackMessages.java
+++ b/android/app/src/bt/java/covidsafepaths/bt/exposurenotifications/utils/CallbackMessages.java
@@ -9,4 +9,5 @@ public class CallbackMessages {
     public static final String EN_ENABLEMENT_DISABLED = "DISABLED";
     public static final String EN_AUTHORIZATION_AUTHORIZED = "AUTHORIZED";
     public static final String EN_AUTHORIZATION_UNAUTHORIZED = "UNAUTHORIZED";
+    public static final String EN_STATUS_EVENT = "onEnabledStatusUpdated";
 }


### PR DESCRIPTION
#### Description:
Check EN permission status every time the app resumes. This handles the case where the user enables EN for a different app, then navigates back to PathCheck, and our app still shows EN are enabled. Checking on resume ensures the user sees the most up to date states.

#### How to test:
1. Fresh install PathCheck.
2. Fresh install another EN app like the Google sample [project](https://github.com/google/exposure-notifications-android).
3. Open PathCheck and enable EN.
4. Navigate to other EN app and enable EN there.
5. Navigate back to PathCheck and observe the message is displayed that EN are no longer enabled. Before this PR, the user would have had to close the app (swipe it away) and reopen it to see the updated EN status.

