### PR TITLE
[SAF-785] Exposure notification localisation

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -102,6 +102,16 @@
     "what_if_no_symptoms": "What if I’m not showing symptoms?",
     "what_if_no_symptoms_para": "If you have no symptoms but still would like to be tested you can go to your nearest testing site.\n\nIndividuals who don't exhibit symptoms can sometimes still carry the infection and infect others. Being careful about social distancing and coming in contact with large groups or at risk individuals (the elderly, those with significant other medical issues) is important to manage both your risk and the risk to others."
   },
+  "exposure_datum": {
+    "possible": {
+      "duration": "Possible Exposure Time: {{duration}}",
+      "explanation": "For {{duration}}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.",
+      "what_next": "What should I do next?"
+    },
+    "no_known": {
+      "explanation": "Your exposure history will be updated if this changes in the future."
+    }
+  },
   "exposure_history": {
     "legend_button": "LEGEND",
     "last_days": "Last 21 days",
@@ -121,6 +131,12 @@
     "gps": {
       "why_did_i_get_an_en_para": "You will receive exposure notifications when your PathCheck app estimates that your phone was, for an extended period, within 100 feet of another individual who later received a positive diagnosis and chose to share their location diary with their local Health Department.",
       "how_does_this_work_para": "Whenever location access is enabled for your PathCheck app, the app saves the following information about each place you take your phone: the GPS coordinates, date, and times your phone was at that location.\n\nThis information is stored in an encrypted list within your phone for 14 days. If one or more of your local or regional Health Departments has partnered with PathCheck, and you have elected to receive exposure notifications from them in your PathCheck app, they can send your app encrypted collections of anonymized GPS coordinates, dates, and times gathered from their community members who later received positive diagnoses and chose to share.\n\nYour phone then locally (within your app) compares your encrypted location history to the data shared by your selected local Health Departments to inform you about possible exposures."
+    },
+    "next_steps": {
+      "ha_self_assessment": "{{healthAuthority}} recommends you take a self-assessment",
+      "possible_crossed_paths": "It is possible that you may have crossed paths with somebody who has been diagnosed with COVID-19.",
+      "possible_infection_precaution": "This does not mean that you are infected, but you should take precautions anyway. People who don't exhibit symptoms can sometimes still be contagious.",
+      "button_text": "Take Self Assessment"
     }
   },
   "import": {

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 
 import { ExposureDatum, Possible, NoKnown } from '../../exposureHistory';
@@ -42,15 +43,19 @@ const PossibleExposureDetail = ({
 }: PossibleExposureDetailProps) => {
   const exposureDurationText = TimeHelpers.durationMsToString(duration);
   const navigation = useNavigation();
+  const { t } = useTranslation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
-  const exposureTime = `Possible Exposure Time: ${exposureDurationText}`;
-  const explanationContent = `For ${exposureDurationText}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.`;
+  const exposureTime = t('exposure_datum.possible.duration', {
+    duration: exposureDurationText,
+  });
+  const explanationContent = t('exposure_datum.possible.explanation', {
+    duration: exposureDurationText,
+  });
+  const nextStepsButtonText = t('exposure_datum.possible.what_next');
 
   const handleOnPressNextSteps = () => {
     navigation.navigate(Screens.NextSteps);
   };
-
-  const nextStepsButtonText = 'What should I do next?';
 
   return (
     <>
@@ -82,9 +87,9 @@ interface NoKnownExposureDetailProps {
 const NoKnownExposureDetail = ({
   datum: { date },
 }: NoKnownExposureDetailProps) => {
+  const { t } = useTranslation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
-  const explanationContent =
-    'Your exposure history will be updated if this changes in the future.';
+  const explanationContent = t('exposure_datum.no_known.explanation');
   return (
     <View style={styles.container}>
       <Typography style={styles.date}>{exposureDate}</Typography>

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, View, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useTranslation } from 'react-i18next';
 
 import { Typography } from '../../components/Typography';
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
@@ -12,21 +13,23 @@ import { AUTHORITY_NAME as healthAuthority } from '../../constants/authorities';
 
 const NextSteps = (): JSX.Element => {
   const navigation = useNavigation();
+  const { t } = useTranslation();
   useStatusBarEffect('light-content');
 
   const handleOnBackPress = () => {
     navigation.goBack();
   };
 
-  const headerText = `${healthAuthority} recommends you take a self-assessment`;
-
-  const contentTextOne =
-    'It is possible that you may have crossed paths with somebody who has been diagnosed with COVID-19.';
-
-  const contentTextTwo =
-    "This does not mean that you are infected, but you should take precautions anyway. People who don't exhibit symptoms can sometimes still be contagious.";
-
-  const buttonText = 'Take Self Assessment';
+  const headerText = t('exposure_history.next_steps.ha_self_assessment', {
+    healthAuthority,
+  });
+  const contentTextOne = t(
+    'exposure_history.next_steps.possible_crossed_paths',
+  );
+  const contentTextTwo = t(
+    'exposure_history.next_steps.possible_infection_precaution',
+  );
+  const buttonText = t('exposure_history.next_steps.button_text');
 
   const handleOnPressTakeAssessment = () => {
     navigation.navigate(Screens.SelfAssessment);

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -9,7 +9,7 @@ import { Screens, useStatusBarEffect } from '../../navigation';
 
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 
-import { AUTHORITY_NAME as healthAuthority } from '../../constants/authorities';
+import { AUTHORITY_NAME as healthAuthorityName } from '../../constants/authorities';
 
 const NextSteps = (): JSX.Element => {
   const navigation = useNavigation();
@@ -21,7 +21,7 @@ const NextSteps = (): JSX.Element => {
   };
 
   const headerText = t('exposure_history.next_steps.ha_self_assessment', {
-    healthAuthority,
+    healthAuthorityName,
   });
   const contentTextOne = t(
     'exposure_history.next_steps.possible_crossed_paths',


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:
This PR adds missing localisation strings for the exposure history/notifications screen.
<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
