### PR TITLE
Update react native config to 1.2.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -193,7 +193,7 @@ PODS:
   - React-jsinspector (0.61.5)
   - react-native-background-timer (2.2.0):
     - React
-  - react-native-config (0.11.7):
+  - react-native-config (1.2.1):
     - React
   - react-native-document-picker (3.2.0):
     - React
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: d5525f9ed5f782fdbacb64b9b01a43a9323d2386
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
   react-native-background-timer: 1f7d560647b40e6a60b01c452ba29c54bf581fc4
-  react-native-config: 8f6b2b9e017f6a5e92a97353c768e19e67294bb1
+  react-native-config: ae9ef3bdbf539f2d14ebaf4ebeba508f766e066a
   react-native-document-picker: e3516aff0dcf65ee0785d9bcf190eb10e2261154
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-safe-area-context: e768fca90207ee68924b3d0877633f2ce9cc9d68

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-native-app-intro-slider": "^3.0.0",
     "react-native-background-fetch": "^3.0.4",
     "react-native-background-timer": "^2.2.0",
-    "react-native-config": "luggit/react-native-config#1eb6ac01991210ddad2989857359a0f6ee35d734",
+    "react-native-config": "^1.2.1",
     "react-native-document-picker": "github:rparet/react-native-document-picker",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7174,9 +7174,10 @@ react-native-background-timer@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-native-background-timer/-/react-native-background-timer-2.2.0.tgz#ff82d30899209b924983cc00e6ce174b8de5054a"
 
-react-native-config@luggit/react-native-config#1eb6ac01991210ddad2989857359a0f6ee35d734:
-  version "0.11.7"
-  resolved "https://codeload.github.com/luggit/react-native-config/tar.gz/1eb6ac01991210ddad2989857359a0f6ee35d734"
+react-native-config@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.2.1.tgz#f80454fc58ea89b549819ccb4bdab26518a9f0db"
+  integrity sha512-u7MDku3fUUKAtxfUFLLwnj4htBYO840EBGdlDB9ry/eX1TY+asHwULaUkAj9x+pJo4vSpIp8GtYxxi8dLzDtJw==
 
 "react-native-document-picker@github:rparet/react-native-document-picker":
   version "3.2.0"


### PR DESCRIPTION
Why:
----
The version for the library was fixed to commit 1eb6ac01991210ddad2989857359a0f6ee35d734
and an issue exists with our environment variables specifically for the
Bluetooth build, in an effort for troubleshooting it a first step is to
use the latest version of the library. The diff for the versions can be
examined [here]

[here]: https://github.com/luggit/react-native-config/commit/1eb6ac01991210ddad2989857359a0f6ee35d734?diff=split

This Commit:
----
- Upgrade `react-native-config` to latest version (1.2.1)
