### PR TITLE
Download only keys that haven't already been checked locally from the GAEN server

### DIFF
--- a/ios/BT/API/Model/ExposureConfiguration.swift
+++ b/ios/BT/API/Model/ExposureConfiguration.swift
@@ -15,7 +15,7 @@ struct ExposureConfiguration: Codable {
 extension ExposureConfiguration {
 
   static var placeholder: ExposureConfiguration = {
-    ExposureConfiguration(minimumRiskScore: 1,
+    ExposureConfiguration(minimumRiskScore: 0,
                           attenuationDurationThresholds: [50, 70],
                           attenuationLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
                           daysSinceLastExposureLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],

--- a/ios/BT/Extensions/Foundation/Int+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Int+Extensions.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Int {
+  static let keyBatchMaxSize = 1000
+}

--- a/ios/BT/Extensions/Foundation/Notification+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Notification+Extensions.swift
@@ -4,5 +4,6 @@ extension Notification.Name {
   public static let DateLastPerformedExposureDetectionDidChange = Notification.Name(rawValue: "BTSecureStorageDateLastPerformedExposureDetectionDidChange")
   public static let ExposuresDidChange = Notification.Name(rawValue: "onExposureRecordUpdated")
   public static let AuthorizationStatusDidChange = Notification.Name(rawValue: "onEnabledStatusUpdated")
+  public static let NextDiagnosisKeyFileIndexDidChange = Notification.Name(rawValue: "BTSecureStorageNextDiagnosisKeyFileIndexDidChange")
 }
 

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -8,6 +8,7 @@ extension String {
   static let keyPathExposureDetectionErrorLocalizedDescription = "exposureDetectionErrorLocalizedDescription"
   static let keyPathDateLastPerformedExposureDetection = "dateLastPerformedExposureDetection"
   static let keyPathExposures = "exposures"
+  static let keyPathNextDiagnosisKeyFileIndex = "nextDiagnosisKeyFileIndex"
   static let postKeysUrl = "POST_DIAGNOSIS_KEYS_URL"
   static let downloadBaseUrl = "DOWNLOAD_BASE_URL"
   static let downloadPath = "DOWNLOAD_PATH"
@@ -21,8 +22,13 @@ extension String {
   static let exposureDetectionErrorNotificationIdentifier = "expososure-notification-error"
   static let genericSuccess = "success"
 
-  var gaenFilePaths: [String] {
-    split(separator: "\n").map { String($0) }.filter { $0.contains(ReactNativeConfig.env(for: .downloadPath)) }
+  func gaenFilePaths(startingAt idx: Int, batchSize: Int) -> [String] {
+    guard !self.isEmpty else {
+      return []
+    }
+    let relevantUrls = split(separator: "\n").map { String($0) }.filter { $0.contains(ReactNativeConfig.env(for: .downloadPath)) }
+    let endIndex = Int(min(relevantUrls.count, idx + batchSize))
+    return Array(relevantUrls[idx..<endIndex])
   }
 
   var localized: String {

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -14,10 +14,6 @@ extension ExposureManager {
         }
       }
     case .detectExposuresNow:
-      guard ExposureManager.shared.detectionPermitted else {
-        callback(["Exposure detection error: you must wait until 3 hours have passed since last detection", NSNull()])
-        return
-      }
       detectExposures { error in
         if let error = error {
           callback(["Exposure detection error: \((error as NSError).userInfo)", NSNull()])

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -66,6 +66,9 @@ final class BTSecureStorage: SafePathsSecureStorage {
              notificationName: .DateLastPerformedExposureDetectionDidChange, defaultValue: nil)
   var dateLastPerformedExposureDetection: Date?
 
+  @Persisted(keyPath: .keyPathNextDiagnosisKeyFileIndex, notificationName: .NextDiagnosisKeyFileIndexDidChange, defaultValue: 0)
+  var nextDiagnosisKeyFileIndex: Int
+
   @Persisted(keyPath: .keyPathExposureDetectionErrorLocalizedDescription, notificationName:
     .StorageExposureDetectionErrorLocalizedDescriptionDidChange, defaultValue: .default)
   var exposureDetectionErrorLocalizedDescription: String

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		B596C0722488127D00943B79 /* ENPermissionsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B596C0712488127D00943B79 /* ENPermissionsModule.m */; };
 		B5E29D54249E3BE100E686DC /* ExposureManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E29D53249E3BE100E686DC /* ExposureManager+Extensions.swift */; };
 		B5E79437249E666B00BD8596 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E79436249E666B00BD8596 /* Array+Extensions.swift */; };
+		B5FAB2B124B4BED600F2C638 /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAB2B024B4BED600F2C638 /* Int+Extensions.swift */; };
 		B5FB3B43248BD61A001DB1D5 /* DebugMenuModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB3B42248BD61A001DB1D5 /* DebugMenuModule.m */; };
 		B5FBB0BD2490339900433980 /* DiagnosisKeyUrlRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FBB0BC2490339900433980 /* DiagnosisKeyUrlRequests.swift */; };
 		B5FBB0CF24916A4C00433980 /* DebugAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FBB0CE24916A4C00433980 /* DebugAction.swift */; };
@@ -334,6 +335,7 @@
 		B5C490A72498F84000588A5F /* Region.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Region.swift; sourceTree = "<group>"; };
 		B5E29D53249E3BE100E686DC /* ExposureManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExposureManager+Extensions.swift"; sourceTree = "<group>"; };
 		B5E79436249E666B00BD8596 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
+		B5FAB2B024B4BED600F2C638 /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 		B5FB3B42248BD61A001DB1D5 /* DebugMenuModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DebugMenuModule.m; sourceTree = "<group>"; };
 		B5FBB0BC2490339900433980 /* DiagnosisKeyUrlRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosisKeyUrlRequests.swift; sourceTree = "<group>"; };
 		B5FBB0CE24916A4C00433980 /* DebugAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugAction.swift; sourceTree = "<group>"; };
@@ -745,6 +747,7 @@
 			isa = PBXGroup;
 			children = (
 				B5FBB0D224916B3600433980 /* String+Extensions.swift */,
+				B5FAB2B024B4BED600F2C638 /* Int+Extensions.swift */,
 				B5E79436249E666B00BD8596 /* Array+Extensions.swift */,
 				B576CC3D24993F4C00CDD9D9 /* Date+Extensions.swift */,
 				B576CC4024993F4C00CDD9D9 /* Encodable+Extensions.swift */,
@@ -1398,6 +1401,7 @@
 				B596C0722488127D00943B79 /* ENPermissionsModule.m in Sources */,
 				B5FC37D8248A784F006474EB /* DiagnosisKeyRequests.swift in Sources */,
 				B5FBB0D324916B3600433980 /* String+Extensions.swift in Sources */,
+				B5FAB2B124B4BED600F2C638 /* Int+Extensions.swift in Sources */,
 				B507A9EE24A197FF00E039D5 /* DownloadedPackage.swift in Sources */,
 				B5FC37F6248A9968006474EB /* ENTemporaryExposureKey+Extensions.swift in Sources */,
 				B5E29D54249E3BE100E686DC /* ExposureManager+Extensions.swift in Sources */,


### PR DESCRIPTION
### Why
We'd like the user to download only keys they haven't already checked from the GAEN server

### This Commit
This commit tracks the index of the last key checked from the GAEN server, and ensures that only keys that have not already been checked will be downloaded and submitted to the EN framework. 