### PR TITLE
Start the background service only on gps builds

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ import { store, persistor } from './app/store';
 import btStrategy from './app/bt';
 import gpsStrategy from './app/gps';
 import BackgroundTaskService from './app/services/BackgroundTaskService';
+import { isGPS } from './app/COVIDSafePathsConfig';
 
 const determineTracingStrategy = () => {
   switch (Config.TRACING_STRATEGY) {
@@ -46,7 +47,7 @@ const App = () => {
   useEffect(() => {
     SplashScreen.hide();
     VersionCheckService.start();
-    BackgroundTaskService.start();
+    isGPS && BackgroundTaskService.start();
   }, []);
 
   return (


### PR DESCRIPTION
Why:
----
The `IntersectionService` was returning null when the build is BT
because the location services are not available. This was resulting on
multiple un-handled rejections when building the app for BT.

This Commit:
----
- Add check for GPS strategy before starting the background service

[trello](https://trello.com/c/V5zjN6zm)