### PR TITLE
allow export from manually entered HA

### DIFF
--- a/app/gps/Export/ExportSelectHA.js
+++ b/app/gps/Export/ExportSelectHA.js
@@ -18,6 +18,7 @@ import NoAuthoritiesMessage from '../../components/NoAuthoritiesMessage';
 import { Theme } from '../../constants/themes';
 import getHealthcareAuthorities from '../../store/actions/healthcareAuthorities/getHealthcareAuthoritiesAction';
 import healthcareAuthorityOptionsSelector from '../../store/selectors/healthcareAuthorityOptionsSelector';
+import customUrlhealthcareAuthorityOptionsSelector from '../../store/selectors/customUrlhealthcareAuthorityOptionsSelector';
 
 import { Screens } from '../../navigation';
 
@@ -32,7 +33,13 @@ export const ExportSelectHA = ({ navigation }) => {
     dispatch(getHealthcareAuthorities());
   }, [dispatch]);
 
-  const authorities = useSelector(healthcareAuthorityOptionsSelector);
+  const authorityOptions = useSelector(healthcareAuthorityOptionsSelector);
+  const authorityOptionsFromCustomUrl = useSelector(
+    customUrlhealthcareAuthorityOptionsSelector,
+  );
+
+  const authorities = [...authorityOptions, ...authorityOptionsFromCustomUrl];
+
   const [selectedAuthority, setSelectedAuthority] = useState(null);
 
   const toggleSelected = (HA) => {


### PR DESCRIPTION
Previously we only allowed selecting a manually entered HA on the `PartnersEdit` screen. 

Addresses QA need for dynamic testing