### PR TITLE
Fix cyclic dependency warning

### DIFF
--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -32,7 +32,7 @@ import {
 import { MIN_LOCATION_UPDATE_MS } from '../services/LocationService';
 import languages from '../locales/languages';
 
-import { store } from '../store';
+import StoreAccessor from '../store/StoreAccessor';
 
 import getCursor from '../api/healthcareAuthorities/getCursorApi';
 
@@ -426,6 +426,14 @@ async function asyncCheckIntersect(healthcareAuthorities, bypassTimer = false) {
   // we also need locally saved data so we can know the last read page for each HA
   let localHAData = await GetStoreData(AUTHORITY_SOURCE_SETTINGS, false);
   if (!localHAData) localHAData = [];
+
+  const store = StoreAccessor.getStore();
+
+  if (store === null) {
+    throw Error.new(
+      'Attempting to access a not set store checking for intersect',
+    );
+  }
 
   let selectedAuthorities = healthcareAuthorities
     ? healthcareAuthorities

--- a/app/store/StoreAccessor.ts
+++ b/app/store/StoreAccessor.ts
@@ -1,0 +1,22 @@
+import { Store } from 'redux';
+
+/*
+ * This accessor is added for the SOLE purpose of avoiding cyclic imports from
+ * the IntersectService to the Intersect helper and again to the store. The
+ * accessor serves as a bridge for the consumers.
+ * */
+class StoreAccessor {
+  store: Store | null = null;
+
+  setStore = (store: Store | null) => {
+    this.store = store;
+  };
+
+  getStore = () => {
+    return this.store;
+  };
+}
+
+const singleton = new StoreAccessor();
+
+export default singleton;

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -5,6 +5,7 @@ import { createMigrate, persistReducer, persistStore } from 'redux-persist';
 import thunk from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension';
 
+import StoreAccessor from './StoreAccessor';
 import onChangedSelectedHealthAuthorities from './middleware/onChangedSelectedHealthAuthorities';
 
 import migrations from './migrations';
@@ -31,4 +32,5 @@ const persistConfig = {
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 export const store = createStore(persistedReducer, {}, enhancers);
+StoreAccessor.setStore(store);
 export const persistor = persistStore(store);


### PR DESCRIPTION
Why:
----
Since the store needs to be made available when checking for intersects for the health authority access, there is a cyclic dependency warning that shows up every time the application builds. We need a way to avoid this cyclic dependency from happening.

How:
----
The approach was to add a getter and a setter singleton to access the store via a third file from `Intersect.js`. A possible future approach could be to move the intersect logic onto the redux store but it is future work to be done since it will involve a more in-depth rework of the logic.

This Commit:
----
- Add a `StoreAccessor` to make the store available without importing the actual store.
- Use the StoreAccessor from the `Intersect` helper

How to test:
----
- After building the GPS flavor, go to the partners screen and after selecting  one of the partners we should not see output in the console with the error:
```
Attempting to access a not set store checking for intersect
```

[trello](https://trello.com/c/Cb9wAu2f)

Co-Authored-By: Jacob Jaffe <jacobmaxjaffe@gmail.com>