### PR TITLE
Remove migrate old data logic

### DIFF
--- a/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
+++ b/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
@@ -24,9 +24,4 @@ class SecureStorageManager(reactContext: ReactApplicationContext) : ReactContext
   fun importGoogleLocations(locations: ReadableArray, promise: Promise) {
     SecureStorage.importLocations(locations, SOURCE_GOOGLE, promise)
   }
-
-  @ReactMethod
-  fun migrateExistingLocations(locations: ReadableArray, promise: Promise) {
-    SecureStorage.importLocations(locations, SOURCE_MIGRATION, promise)
-  }
 }

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -1,4 +1,3 @@
-export const LOCATION_DATA = 'LOCATION_DATA';
 export const CONTACT_DATA = 'CONTACT_DATA';
 export const PARTICIPATE = 'PARTICIPATE';
 export const MY_UUIDs = 'MY_UUIDs';

--- a/app/helpers/General.ts
+++ b/app/helpers/General.ts
@@ -36,14 +36,6 @@ export async function SetStoreData(
   }
 }
 
-export async function RemoveStoreData(key: string): Promise<void> {
-  try {
-    return await AsyncStorage.removeItem(key);
-  } catch (error) {
-    console.log(error.message);
-  }
-}
-
 export async function pickFile(): Promise<string | null> {
   // Pick a single file - returns actual path on Android, file:// uri on iOS
   try {

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -21,14 +21,9 @@ import {
   AUTHORITY_SOURCE_SETTINGS,
   CROSSED_PATHS,
   LAST_CHECKED,
-  LOCATION_DATA,
 } from '../constants/storage';
 import { DEBUG_MODE } from '../constants/storage';
-import {
-  GetStoreData,
-  RemoveStoreData,
-  SetStoreData,
-} from '../helpers/General';
+import { GetStoreData, SetStoreData } from '../helpers/General';
 import { MIN_LOCATION_UPDATE_MS } from '../services/LocationService';
 import languages from '../locales/languages';
 
@@ -352,27 +347,6 @@ function roundExposure(diffMS, gpsPeriodMS) {
 }
 
 /**
- * Migrates the old GPS data into secure storage (Realm)
- *
- * @returns {Promise<boolean>} Boolean for whether there was any data to migrate
- */
-export async function migrateOldData() {
-  const locations = await GetStoreData(LOCATION_DATA, false);
-
-  if (Array.isArray(locations) && locations.length > 0) {
-    await NativeModules.SecureStorageManager.migrateExistingLocations(
-      locations,
-    );
-    await RemoveStoreData(LOCATION_DATA);
-    return true; // data was migrated
-  }
-  return false; // nothing to migrate
-}
-
-/** The old data has been migrated already for this session/app. */
-let hasMigratedOldData = false;
-
-/**
  * Kicks off the intersection process.  Immediately returns after starting the
  * background intersection.  Typically would be run about every 12 hours, but
  * but might get run more frequently, e.g. when the user changes authority settings
@@ -389,12 +363,6 @@ export async function checkIntersect(
     `[intersect] tick entering on ${isPlatformiOS() ? 'iOS' : 'Android'}; `,
     `is bypassing timer = ${bypassTimer}`,
   );
-
-  // TODO: remove this after June 1 once 14 day old history is irrelevant
-  if (!hasMigratedOldData) {
-    await migrateOldData();
-    hasMigratedOldData = true;
-  }
 
   const result = await asyncCheckIntersect(healthcareAuthorities, bypassTimer);
   console.log(`[intersect] ${result ? 'completed' : 'skipped'}`);

--- a/ios/GPS/bridge/SecureStorageManager.m
+++ b/ios/GPS/bridge/SecureStorageManager.m
@@ -20,10 +20,4 @@ RCT_EXTERN_METHOD(
                   resolve: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
 )
-
-RCT_EXTERN_METHOD(
-                  migrateExistingLocations: (NSArray)locations
-                  resolve: (RCTPromiseResolveBlock)resolve
-                  rejecter: (RCTPromiseRejectBlock)reject
-)
 @end

--- a/ios/GPS/bridge/SecureStorageManager.swift
+++ b/ios/GPS/bridge/SecureStorageManager.swift
@@ -24,9 +24,4 @@ class SecureStorageManager: NSObject {
   func importGoogleLocations(_ locations: NSArray, resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
     GPSSecureStorage.shared.importLocations(locations: locations, source: Location.SOURCE_GOOGLE, resolve: resolve, reject: reject)
   }
-  
-  @objc
-  func migrateExistingLocations(_ locations: NSArray, resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-    GPSSecureStorage.shared.importLocations(locations: locations, source: Location.SOURCE_MIGRATION, resolve: resolve, reject: reject)
-  }
 }


### PR DESCRIPTION
Why:
----
According to this TODO:
```
// TODO: remove this after June 1 once 14 day old history is irrelevant
```
The `migrateOldData` logic is irrelevant right now.

This PR:
----
- Remove the `migrateOldData` logic and related native code