### PR TITLE
Fix typo on NotificationDetails and type warning

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -34,7 +34,7 @@ import ImportScreen from './views/Import';
 import { EnableExposureNotifications } from './views/onboarding/EnableExposureNotifications';
 import Welcome from './views/onboarding/Welcome';
 import PersonalPrivacy from './views/onboarding/PersonalPrivacy';
-import NotificatioNDetails from './views/onboarding/NotificationDetails';
+import NotificationDetails from './views/onboarding/NotificationDetails';
 import ShareDiagnosis from './views/onboarding/ShareDiagnosis';
 import NotificationsPermissions from './views/onboarding/NotificationsPermissions';
 import LocationsPermissions from './views/onboarding/LocationsPermissions';
@@ -260,8 +260,8 @@ const OnboardingStack = () => (
     <Stack.Screen name={Screens.Welcome} component={Welcome} />
     <Stack.Screen name={Screens.PersonalPrivacy} component={PersonalPrivacy} />
     <Stack.Screen
-      name={Screens.NotificatioNDetails}
-      component={NotificatioNDetails}
+      name={Screens.NotificationDetails}
+      component={NotificationDetails}
     />
     <Stack.Screen name={Screens.ShareDiagnosis} component={ShareDiagnosis} />
     <Stack.Screen

--- a/app/navigation/index.ts
+++ b/app/navigation/index.ts
@@ -37,7 +37,7 @@ export type Screen =
   | 'ImportFromUrl'
   | 'Welcome'
   | 'PersonalPrivacy'
-  | 'NotificatioNDetails'
+  | 'NotificationDetails'
   | 'ShareDiagnosis'
   | 'OnboardingLocationPermissions'
   | 'OnboardingNotificationPermissions'
@@ -81,7 +81,7 @@ export const Screens: { [key in Screen]: Screen } = {
   ImportFromUrl: 'ImportFromUrl',
   Welcome: 'Welcome',
   PersonalPrivacy: 'PersonalPrivacy',
-  NotificatioNDetails: 'NotificatioNDetails',
+  NotificationDetails: 'NotificationDetails',
   ShareDiagnosis: 'ShareDiagnosis',
   OnboardingLocationPermissions: 'OnboardingLocationPermissions',
   OnboardingNotificationPermissions: 'OnboardingNotificationPermissions',

--- a/app/views/onboarding/PersonalPrivacy.tsx
+++ b/app/views/onboarding/PersonalPrivacy.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigation } from '@react-navigation/native';
 
 import { useStatusBarEffect } from '../../navigation';
 import { useStrategyContent } from '../../TracingStrategyContext';
 import ExplanationScreen, { IconStyle } from '../common/ExplanationScreen';
+import { Screens } from '../../navigation';
 
-interface PersonalPrivacyProps {
-  navigation: any;
-}
-
-const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
+const PersonalPrivacy: FunctionComponent = () => {
+  const navigation = useNavigation();
   useStatusBarEffect('dark-content');
   const { t } = useTranslation();
   const { StrategyAssets, StrategyCopy } = useStrategyContent();
@@ -27,7 +26,8 @@ const PersonalPrivacy = ({ navigation }: PersonalPrivacyProps): JSX.Element => {
   };
 
   const explanationScreenActions = {
-    primaryButtonOnPress: () => navigation.replace('NotificatioNDetails'),
+    primaryButtonOnPress: () =>
+      navigation.navigate(Screens.NotificationDetails),
   };
 
   return (

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigation } from '@react-navigation/native';
 
 import { isGPS } from '../../COVIDSafePathsConfig';
 import { Screens } from '../../navigation';
@@ -7,23 +8,20 @@ import { isPlatformiOS } from '../../Util';
 import { useStrategyContent } from '../../TracingStrategyContext';
 import ExplanationScreen, { IconStyle } from '../common/ExplanationScreen';
 
-interface ShareDiagnosisProps {
-  navigation: any;
-}
-
-const ShareDiagnosis = ({ navigation }: ShareDiagnosisProps): JSX.Element => {
+const ShareDiagnosis: FunctionComponent = () => {
+  const navigation = useNavigation();
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
   const gpsNext = () =>
-    navigation.replace(
+    navigation.navigate(
       // Skip notification permissions on android
       isPlatformiOS()
         ? Screens.OnboardingNotificationPermissions
         : Screens.OnboardingLocationPermissions,
     );
 
-  const btNext = () => navigation.replace(Screens.NotificationPermissionsBT);
+  const btNext = () => navigation.navigate(Screens.NotificationPermissionsBT);
 
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 

--- a/e2e/helpers/onboarding.js
+++ b/e2e/helpers/onboarding.js
@@ -1,7 +1,7 @@
 import FinishSetup from '../pages/FinishSetup.po.js';
 import Welcome from '../pages/Welcome.po.js';
 import PersonalPrivacy from '../pages/PersonalPrivacy.po.js';
-import NotificatioNDetails from '../pages/NotificationDetails.po.js';
+import NotificationDetails from '../pages/NotificationDetails.po.js';
 import ShareDiagnosis from '../pages/ShareDiagnosis.po.js';
 import SignEula from '../pages/SignEula.po.js';
 
@@ -15,8 +15,8 @@ export const navigateThroughPermissions = async (languageStrings) => {
   await PersonalPrivacy.isOnScreen(languageStrings);
   await PersonalPrivacy.tapButton(languageStrings);
 
-  await NotificatioNDetails.isOnScreen(languageStrings);
-  await NotificatioNDetails.tapButton(languageStrings);
+  await NotificationDetails.isOnScreen(languageStrings);
+  await NotificationDetails.tapButton(languageStrings);
 
   await ShareDiagnosis.isOnScreen(languageStrings);
   await ShareDiagnosis.tapButton(languageStrings);

--- a/e2e/onboarding/Onboarding.spec.js
+++ b/e2e/onboarding/Onboarding.spec.js
@@ -1,7 +1,7 @@
 import { languages } from '../helpers/language';
 import Welcome from '../pages/Welcome.po.js';
 import PersonalPrivacy from '../pages/PersonalPrivacy.po.js';
-import NotificatioNDetails from '../pages/NotificationDetails.po.js';
+import NotificationDetails from '../pages/NotificationDetails.po.js';
 import ShareDiagnosis from '../pages/ShareDiagnosis.po.js';
 import SignEula from '../pages/SignEula.po.js';
 
@@ -32,9 +32,9 @@ describe.each(languages)(
         await PersonalPrivacy.takeScreenshot();
         await PersonalPrivacy.tapButton(languageStrings);
 
-        await NotificatioNDetails.isOnScreen(languageStrings);
-        await NotificatioNDetails.takeScreenshot();
-        await NotificatioNDetails.tapButton(languageStrings);
+        await NotificationDetails.isOnScreen(languageStrings);
+        await NotificationDetails.takeScreenshot();
+        await NotificationDetails.tapButton(languageStrings);
 
         await ShareDiagnosis.isOnScreen(languageStrings);
         await ShareDiagnosis.takeScreenshot();

--- a/e2e/pages/NotificationDetails.po.js
+++ b/e2e/pages/NotificationDetails.po.js
@@ -1,9 +1,11 @@
 /* eslint-disable */
 const screenshotText = 'Onboarding - Page 3';
 
-class NotificatioNDetails {
+class NotificationDetails {
   async tapButton(languageStrings) {
-    await element(by.label(languageStrings.label.launch_next)).tap();
+    // replacing a replace for a navigate here leaves the previous view
+    // compressed and the `Next` label shows up in the tree
+    await element(by.label(languageStrings.label.launch_next)).atIndex(0).tap();
   }
 
   async takeScreenshot() {
@@ -18,4 +20,4 @@ class NotificatioNDetails {
   }
 }
 
-export default new NotificatioNDetails();
+export default new NotificationDetails();


### PR DESCRIPTION
Why:
----
We have a type on the `NotificationDetails` component being exported as
'NotificatioNDetails`.
There is an explicit any on a couple of files that were using the
navigation.

This Commit:
----
- Use the `useNavigation` hook in favor of untyped props interface
- Replace uses of `NotificatioNDetails` for `NotificationDetails`
