### PR TITLE
Run Key Detection Job at Most Once per 24 hr Period

### DIFF
--- a/ios/BT/API/Model/ExposureConfiguration.swift
+++ b/ios/BT/API/Model/ExposureConfiguration.swift
@@ -15,7 +15,7 @@ struct ExposureConfiguration: Codable {
 extension ExposureConfiguration {
 
   static var placeholder: ExposureConfiguration = {
-    ExposureConfiguration(minimumRiskScore: 1,
+    ExposureConfiguration(minimumRiskScore: 0,
                           attenuationDurationThresholds: [50, 70],
                           attenuationLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],
                           daysSinceLastExposureLevelValues: [1, 2, 3, 4, 5, 6, 7, 8],

--- a/ios/BT/API/Requests/IndexFileRequests.swift
+++ b/ios/BT/API/Requests/IndexFileRequests.swift
@@ -14,7 +14,7 @@ enum IndexFileRequest: APIRequest {
   }
 
   var path: String {
-    "spl/index.txt"
+    (ReactNativeConfig.env(for: .downloadPath)) + "/index.txt"
   }
 
 }

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -17,7 +17,7 @@ final class ExposureManager: NSObject {
 
   var detectionPermitted: Bool {
     if let lastDetectionDate = BTSecureStorage.shared.$dateLastPerformedExposureDetection.wrappedValue,
-      Calendar.current.dateComponents([.hour], from: lastDetectionDate, to: Date()).hour ?? 0 < 3 {
+      Calendar.current.dateComponents([.hour], from: lastDetectionDate, to: Date()).day ?? 0 == 0 {
       return false
     }
     return true
@@ -90,7 +90,7 @@ final class ExposureManager: NSObject {
   
   @discardableResult func detectExposures(completionHandler: ((Error?) -> Void)? = nil) -> Progress {
 
-    // Exit if last detection date was < 3 hours ago
+    // Exit if last detection date was < 24 hours ago
     if !detectionPermitted {
       completionHandler?(nil)
     }

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -22,7 +22,7 @@ extension String {
   static let genericSuccess = "success"
 
   var gaenFilePaths: [String] {
-    split(separator: "\n").map { String($0) }.filter { $0.contains(ReactNativeConfig.env(for: .downloadPath)) }
+    split(separator: "\n").map { String($0) }
   }
 
   var localized: String {

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -15,7 +15,7 @@ extension ExposureManager {
       }
     case .detectExposuresNow:
       guard ExposureManager.shared.detectionPermitted else {
-        callback(["Exposure detection error: you must wait until 3 hours have passed since last detection", NSNull()])
+        callback(["Exposure detection error: you must wait until 24 hours have passed since last detection", NSNull()])
         return
       }
       detectExposures { error in


### PR DESCRIPTION
### Why
We'd like to run the key detection task at most every 24 hours to accommodate potentially large numbers of keys and the necessity of a very long-running job

### This Commit
This commit increases the duration between runs of the exposure detection task to 24 hours updates the download path to point to the correct endpoint. It also lowers the exposure risk threshold for testing pruposes.