### PR TITLE
Submit code to verification server

### DIFF
--- a/app/bt/AffectedUserFlow/verificationAPI.ts
+++ b/app/bt/AffectedUserFlow/verificationAPI.ts
@@ -1,0 +1,118 @@
+import Config from 'react-native-config';
+
+const baseUrl = Config.GAEN_VERIFY_URL;
+const verifyUrl = `${baseUrl}/api/verify`;
+const certificateUrl = `${baseUrl}/api/certificate`;
+
+const defaultHeaders = {
+  'content-type': 'application/json',
+  accept: 'application/json',
+  'X-API-Key': Config.GAEN_VERIFY_API_TOKEN,
+};
+
+export type Token = string;
+
+interface NetworkSuccess<T> {
+  kind: 'success';
+  body: T;
+}
+interface NetworkFailure<U> {
+  kind: 'failure';
+  error: U;
+}
+
+export type NetworkResponse<T, U = 'Unknown'> =
+  | NetworkSuccess<T>
+  | NetworkFailure<U>;
+
+type CodeVerificationSuccess = VerifiedCodeResponse;
+
+export type CodeVerificationError =
+  | 'InvalidCode'
+  | 'VerificationCodeUsed'
+  | 'Unknown';
+
+interface VerifiedCodeResponse {
+  error: string;
+  testDate: string;
+  testType: string;
+  token: Token;
+}
+
+export const postVerificationCode = async (
+  code: string,
+): Promise<NetworkResponse<CodeVerificationSuccess, CodeVerificationError>> => {
+  const data = {
+    code,
+  };
+
+  try {
+    const response = await fetch(verifyUrl, {
+      method: 'POST',
+      headers: defaultHeaders,
+      body: JSON.stringify(data),
+    });
+
+    const json = await response.json();
+    if (response.ok) {
+      const body: VerifiedCodeResponse = {
+        error: json.error,
+        testDate: json.testdate,
+        testType: json.testtype,
+        token: json.token,
+      };
+      return { kind: 'success', body };
+    } else {
+      switch (json.error) {
+        case 'internal serer error':
+          return { kind: 'failure', error: 'InvalidCode' };
+        case 'verification code used':
+          return { kind: 'failure', error: 'VerificationCodeUsed' };
+        default:
+          return { kind: 'failure', error: 'Unknown' };
+      }
+    }
+  } catch (e) {
+    return { kind: 'failure', error: 'Unknown' };
+  }
+};
+
+type VerificationTokenSuccess = 'Success';
+
+type VerificationTokenFailure = 'InvalidToken' | 'Unknown';
+
+export const postVerificationToken = async (
+  token: Token,
+  hmac: string,
+): Promise<
+  NetworkResponse<VerificationTokenSuccess, VerificationTokenFailure>
+> => {
+  const data = {
+    token,
+    ekeyhmac: hmac,
+  };
+
+  try {
+    const response = await fetch(certificateUrl, {
+      method: 'POST',
+      headers: defaultHeaders,
+      body: JSON.stringify(data),
+    });
+
+    const json = await response.json();
+    if (response.ok) {
+      return { kind: 'success', body: 'Success' };
+    } else {
+      switch (json.error) {
+        case 'invalid_token': {
+          return { kind: 'failure', error: 'InvalidToken' };
+        }
+        default: {
+          return { kind: 'failure', error: 'Unknown' };
+        }
+      }
+    }
+  } catch (e) {
+    return { kind: 'failure', error: 'Unknown' };
+  }
+};

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -63,11 +63,17 @@
     "next": "Next",
     "ok": "Ok",
     "something_went_wrong": "Something went wrong",
-    "start": "Start"
+    "start": "Start",
+    "submit": "Submit"
   },
   "export": {
+    "error": {
+      "verification_code_used": "Verification code has already been used",
+      "invalid_code": "Try a different code",
+      "unknown_code_verification_error": "Try a different code"
+    },
     "code_input_body": "The representative from {{name}} will provide a verification code over the phone to link your data with {{name}}.",
-    "code_input_body_bluetooth": "Type in your verification code.",
+    "code_input_body_bluetooth": "Enter your verification code",
     "code_input_error": "Try a different code",
     "code_input_title": "Enter your verification code",
     "code_input_title_bluetooth": "Verify your diagnosis",

--- a/app/styles/buttons.ts
+++ b/app/styles/buttons.ts
@@ -35,6 +35,7 @@ const rounded: ViewStyle = {
 };
 
 // Color
+
 const primaryBlue: ViewStyle = {
   backgroundColor: Colors.primaryBlue,
   borderColor: Colors.primaryBlue,
@@ -48,6 +49,11 @@ const secondaryBlue: ViewStyle = {
 const white: ViewStyle = {
   backgroundColor: Colors.white,
   borderColor: Colors.white,
+};
+
+const disabled: ViewStyle = {
+  backgroundColor: Colors.mediumGray,
+  borderColor: Colors.mediumGray,
 };
 
 const tertiary: ViewStyle = {
@@ -128,6 +134,12 @@ export const primary: ViewStyle = {
   ...base,
   ...large,
   ...primaryBlue,
+};
+
+export const primaryDisabled: ViewStyle = {
+  ...base,
+  ...large,
+  ...disabled,
 };
 
 export const primaryInverted: ViewStyle = {

--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -72,6 +72,7 @@ export const quaternaryViolet = melrose;
 export const transparent = 'rgba(0, 0, 0, 0)';
 export const transparentWhite = applyOpacity(white, 0.1);
 export const transparentGray = applyOpacity(gray, 0.1);
+export const transparentDarkGray = applyOpacity(lighterGray, 0.8);
 export const transparentYellow = 'rgba(100, 100, 77, 0.4)';
 export const transparentDark = 'rgba(0,0,0,0.7)';
 

--- a/app/styles/layout.ts
+++ b/app/styles/layout.ts
@@ -12,12 +12,14 @@ export const baseScreenPadding = Spacing.xSmall;
 
 export const xxSmallWidth = 0.05 * screenWidth;
 export const mediumWidth = 0.4 * screenWidth;
+export const halfWidth = 0.5 * screenWidth;
 export const largeWidth = 0.6 * screenWidth;
 
 export const xxSmallHeight = 0.03 * screenHeight;
 export const smallHeight = 0.05 * screenHeight;
 export const oneTenthHeight = 0.1 * screenHeight;
 export const mediumHeight = 0.45 * screenHeight;
+export const halfHeight = 0.5 * screenHeight;
 
 export const tappableHeight = 0.1 * screenHeight;
 
@@ -31,3 +33,8 @@ export const fullWidthWithMediumMargin =
   screenWidth - horizontalMarginMedium * 2;
 
 export const navBar = tappableHeight;
+
+// zIndex
+export const level1 = 1;
+export const level2 = 2;
+export const level3 = 3;

--- a/app/styles/typography.ts
+++ b/app/styles/typography.ts
@@ -244,6 +244,11 @@ export const buttonTextPrimary: TextStyle = {
   color: Colors.white,
 };
 
+export const buttonTextPrimaryDisabled: TextStyle = {
+  ...buttonText,
+  color: Colors.white,
+};
+
 export const buttonTextPrimaryInverted: TextStyle = {
   ...buttonText,
   color: Colors.primaryViolet,

--- a/example.env.bt
+++ b/example.env.bt
@@ -2,4 +2,8 @@ TRACING_STRATEGY=bt
 POST_DIAGNOSIS_KEYS_URL=gaen_server_url_here
 DOWNLOAD_KEY_FILE_URL=gaen_server_url_here
 INDEX_FILE_URL=gaen_server_url_here
+HMAC_KEY=abcd1234
+GAEN_VERIFY_URL=https://example.com
+GAEN_VERIFY_API_TOKEN=abcd1234
+
 AUTHORITIES_YAML_ROUTE=yaml_route_here


### PR DESCRIPTION
Why:
When a user has received a verification code from their health provider
they need to be able to submit the code to the verification server in
order to receive a certificate to be able to then submit their exposure
tokens.

This commit:
Wires up the network logic for submitting the code to a verification
server and provided some error handling for rejected requests. Note that
we have not finished the work for the next step of submitting the
received token to generated a signed certificate, but we have that api
function started. A future commit will finish this interaction.

Co-Authored-By: devinjameson <devin@thoughtbot.com>

### GIF

![verification-code](https://user-images.githubusercontent.com/16049495/86961194-cf5f3100-c12e-11ea-9fa8-32a7f53284ac.gif)
