### PR TITLE
Ability to remove all locations from Realm

### DIFF
--- a/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
+++ b/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
@@ -24,4 +24,10 @@ class SecureStorageManager(reactContext: ReactApplicationContext) : ReactContext
   fun importMockLocations(locations: ReadableArray, promise: Promise) {
     SecureStorage.importLocations(locations, SOURCE_GOOGLE, promise)
   }
+
+  @ReactMethod
+  fun removeAllLocations(promise: Promise) {
+//    TODO: Implement the following method in SecureStorage
+//    SecureStorage.removeAllLocations(promise)
+  }
 }

--- a/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
+++ b/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
@@ -21,7 +21,7 @@ class SecureStorageManager(reactContext: ReactApplicationContext) : ReactContext
   }
 
   @ReactMethod
-  fun importGoogleLocations(locations: ReadableArray, promise: Promise) {
+  fun importMockLocations(locations: ReadableArray, promise: Promise) {
     SecureStorage.importLocations(locations, SOURCE_GOOGLE, promise)
   }
 }

--- a/app/helpers/GoogleTakeOutAutoImport.js
+++ b/app/helpers/GoogleTakeOutAutoImport.js
@@ -111,7 +111,7 @@ export async function importTakeoutData(filePath) {
         });
 
         let googleLocations = extractLocations(JSON.parse(contents));
-        await NativeModules.SecureStorageManager.importGoogleLocations(
+        await NativeModules.SecureStorageManager.importMockLocations(
           googleLocations,
         );
         console.log('[INFO] Imported file:', filepath);

--- a/app/helpers/tests/GoogleTakeOutAutoImport.spec.js
+++ b/app/helpers/tests/GoogleTakeOutAutoImport.spec.js
@@ -68,7 +68,7 @@ describe('importTakeoutData', () => {
   });
 
   it(`locations successfully added to local store`, async () => {
-    const importGoogleLocations = jest.fn();
+    const importMockLocations = jest.fn();
     jest.doMock('react-native', () => {
       return {
         Platform: {
@@ -77,7 +77,7 @@ describe('importTakeoutData', () => {
         NativeModules: {
           ...ReactNative.NativeModules,
           SecureStorageManager: {
-            importGoogleLocations: importGoogleLocations,
+            importMockLocations: importMockLocations,
           },
         },
       };
@@ -121,8 +121,8 @@ describe('importTakeoutData', () => {
 
     const { importTakeoutData } = require('../GoogleTakeOutAutoImport');
     await importTakeoutData('file://test.zip');
-    expect(importGoogleLocations).toHaveBeenCalledWith([location1, location2]);
-    expect(importGoogleLocations).toHaveBeenCalledWith([location3, location4]);
+    expect(importMockLocations).toHaveBeenCalledWith([location1, location2]);
+    expect(importMockLocations).toHaveBeenCalledWith([location3, location4]);
   });
 });
 

--- a/app/views/Settings/ImportFromUrl.tsx
+++ b/app/views/Settings/ImportFromUrl.tsx
@@ -32,7 +32,7 @@ const ImportFromUrl = ({ navigation }: ImportFromUrlProps): JSX.Element => {
       // Data must be an array of objects!
       const mockData = await importLocationsApi(url);
 
-      await NativeModules.SecureStorageManager.importGoogleLocations(mockData);
+      await NativeModules.SecureStorageManager.importMockLocations(mockData);
       return navigation.goBack();
     } catch (e) {
       return Alert.alert(t('import.mockData.invalid_url'), e.message);

--- a/ios/COVIDSafePathsTests/RealmSecureStorageTest.swift
+++ b/ios/COVIDSafePathsTests/RealmSecureStorageTest.swift
@@ -335,6 +335,38 @@ class GPSSecureStorageTest: XCTestCase {
     
     XCTAssertEqual(0, assumedLocations.count)
   }
+
+  func testRemoveAllLocations() {
+    let location1Date = Date().addingTimeInterval(GPSSecureStorage.LOCATION_INTERVAL)
+    let location1Time = location1Date.timeIntervalSince1970
+    let backgroundLocation1 = TestMAURLocation(latitude: 40.730610, longitude: -73.935242, date: location1Date)
+    let location2Date = Date()
+    let location2Time = location2Date.timeIntervalSince1970
+    let backgroundLocation2 = TestMAURLocation(latitude: 40.730610, longitude: -73.935242, date: location2Date)
+
+    let expect1 = XCTestExpectation(description: "Save Device Location 1")
+    let expect2 = XCTestExpectation(description: "Save Device Location 2")
+    let expect3 = XCTestExpectation(description: "Remove All Locations")
+
+    secureStorage!.saveDeviceLocation(backgroundLocation1, backfill: false) {
+      expect1.fulfill()
+    }
+    secureStorage!.saveDeviceLocation(backgroundLocation2, backfill: false) {
+      expect2.fulfill()
+    }
+
+    wait(for: [expect1, expect2], timeout: 5)
+
+    secureStorage!.removeAllLocations(
+      resolve: resolverFulfilling(expectation: expect3),
+      reject: rejecterFulfilling(expectation: expect3)
+    )
+
+    wait(for: [expect3], timeout: 5)
+
+    XCTAssertNil(querySingleLocationByTime(time: location1Time))
+    XCTAssertNil(querySingleLocationByTime(time: location2Time))
+  }
   
   func querySingleLocationByTime(time: Double) -> Location? {
     return secureStorage!

--- a/ios/GPS/bridge/SecureStorageManager.m
+++ b/ios/GPS/bridge/SecureStorageManager.m
@@ -16,7 +16,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-                  importGoogleLocations: (NSArray)locations
+                  importMockLocations: (NSArray)locations
                   resolve: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
 )

--- a/ios/GPS/bridge/SecureStorageManager.m
+++ b/ios/GPS/bridge/SecureStorageManager.m
@@ -26,4 +26,9 @@ RCT_EXTERN_METHOD(
                   rejecter: (RCTPromiseRejectBlock)reject
 )
 
+RCT_EXTERN_METHOD(
+                  removeAllLocations: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+)
+
 @end

--- a/ios/GPS/bridge/SecureStorageManager.swift
+++ b/ios/GPS/bridge/SecureStorageManager.swift
@@ -30,4 +30,9 @@ class SecureStorageManager: NSObject {
     GPSSecureStorage.shared.getLocations(resolve: resolve, reject: reject)
   }
 
+  @objc
+  func removeAllLocations(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+    GPSSecureStorage.shared.removeAllLocations(resolve: resolve, reject: reject)
+  }
+
 }

--- a/ios/GPS/bridge/SecureStorageManager.swift
+++ b/ios/GPS/bridge/SecureStorageManager.swift
@@ -21,7 +21,7 @@ class SecureStorageManager: NSObject {
   }
   
   @objc
-  func importGoogleLocations(_ locations: NSArray, resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+  func importMockLocations(_ locations: NSArray, resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
     GPSSecureStorage.shared.importLocations(locations: locations, source: .google, resolve: resolve, reject: reject)
   }
 

--- a/ios/GPS/storage/GPSSecureStorage.swift
+++ b/ios/GPS/storage/GPSSecureStorage.swift
@@ -67,6 +67,14 @@ final class GPSSecureStorage: SafePathsSecureStorage {
     }
   }
 
+  @objc func removeAllLocations(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    queue.async {
+      autoreleasepool { [weak self] in
+        self?.removeAllLocationsImmediately(resolve: resolve, reject: reject)
+      }
+    }
+  }
+
   override func getRealmConfig() -> Realm.Configuration? {
     // TODO: Create appropriate migration blocks as needed
     if let key = getEncryptionKey() {
@@ -217,6 +225,22 @@ private extension GPSSecureStorage {
           resolve(true)
         }
       },
+      reject: reject
+    )
+  }
+
+  /// This function should be called only on self.queue
+  func removeAllLocationsImmediately(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    guard let realm = getRealmInstance() else {
+      resolve(false)
+      return
+    }
+
+    Log.storage.debug("Removing all locations")
+
+    realm.delete(
+      locations: realm.previousLocations,
+      resolve: resolve,
       reject: reject
     )
   }


### PR DESCRIPTION
## Description:

* Renames `importGoogleLocations` to `importMockLocations`
* Adds a method for removing all locations from Realm

**TODO:** Implement the removal logic in native Android code