### PR TITLE
Update affected user flow to not use modal mode

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -297,6 +297,19 @@ const PartnersStack = () => (
   </Stack.Navigator>
 );
 
+const animateFromBottom = ({ current }) => ({
+  cardStyle: {
+    transform: [
+      {
+        translateY: current.progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [Layout.screenHeight, 0],
+        }),
+      },
+    ],
+  },
+});
+
 export const Entry = () => {
   const onboardingComplete = useSelector(isOnboardingCompleteSelector);
   const tracingStrategy = useTracingStrategyContext();
@@ -314,7 +327,8 @@ export const Entry = () => {
           name={Screens.ExportFlow}
           component={tracingStrategy.affectedUserFlow}
           options={{
-            ...TransitionPresets.ModalSlideFromBottomIOS,
+            cardStyleInterpolator: animateFromBottom,
+            gestureEnabled: false,
           }}
         />
         <Stack.Screen

--- a/app/ExposureHistoryContext.tsx
+++ b/app/ExposureHistoryContext.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   useEffect,
   FunctionComponent,
+  useCallback,
 } from 'react';
 
 import {
@@ -87,10 +88,6 @@ const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
     return subscription.remove;
   }, [exposureInfoSubscription, toExposureHistory]);
 
-  useEffect(() => {
-    getCurrentExposures();
-  }, [toExposureHistory]);
-
   const observeExposures = () => {
     setUserHasNewExposure(false);
   };
@@ -99,7 +96,7 @@ const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
     setUserHasNewExposure(true);
   };
 
-  const getCurrentExposures = async () => {
+  const getCurrentExposures = useCallback(() => {
     const cb = (exposureInfo: ExposureInfo) => {
       const exposureHistory = toExposureHistory(
         exposureInfo,
@@ -108,7 +105,7 @@ const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
       setExposureHistory(exposureHistory);
     };
     exposureEventsStrategy.getCurrentExposures(cb);
-  };
+  }, [toExposureHistory, exposureEventsStrategy]);
 
   const hasBeenExposed = false;
   return (

--- a/app/bt/AffectedUserFlow/index.tsx
+++ b/app/bt/AffectedUserFlow/index.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { TouchableOpacity, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import {
-  createStackNavigator,
-  StackCardStyleInterpolator,
-} from '@react-navigation/stack';
+import { createStackNavigator } from '@react-navigation/stack';
 import { SvgXml } from 'react-native-svg';
 
 import { AffectedUserProvider } from './AffectedUserContext';
@@ -18,10 +15,6 @@ import { Colors, Spacing } from '../../styles';
 import { Screens } from '../../navigation';
 
 const Stack = createStackNavigator();
-
-const fade: StackCardStyleInterpolator = ({ current }) => ({
-  cardStyle: { opacity: current.progress },
-});
 
 const ExportStack = (): JSX.Element => {
   const BackButton = () => {
@@ -49,12 +42,7 @@ const ExportStack = (): JSX.Element => {
   return (
     <AffectedUserProvider>
       <Stack.Navigator
-        mode='modal'
         screenOptions={{
-          cardStyleInterpolator: fade,
-          cardStyle: {
-            backgroundColor: 'transparent', // prevent white flash on Android
-          },
           headerShown: false,
           gestureEnabled: false,
         }}


### PR DESCRIPTION
Why: prior to this commit, the affected user flow stack was being
displayed within a modal using React Navigation. However, it is not
possible (as of now) to disable the "swipe down to close" gesture for
modals presented via React Navigation. Given that we want to disable
this gesture, we had to take a different approach.

This commit:
- Removes the modal mode from the options for the affected user flow
  stack
- Instead uses a custom cardStyleInterpolator to achieve the
  animateFromBottom transition when opening this stack

## Before
![demob4](https://user-images.githubusercontent.com/39350030/87066023-dbef9200-c1df-11ea-852e-108950f08659.gif)

## After
![demo](https://user-images.githubusercontent.com/39350030/87066030-df831900-c1df-11ea-8e23-42c7d06a5922.gif)