### PR TITLE
Refactor method of displaying screens over tab bar

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -18,7 +18,8 @@ import PartnersEditScreen from './views/Partners/PartnersEdit';
 import PartnersCustomUrlScreen from './views/Partners/PartnersCustomUrlScreen';
 
 import { LicensesScreen } from './views/Licenses';
-import { ExportStart, ExportLocally } from './gps/Export';
+import { ExportSelectHA, ExportStart, ExportLocally } from './gps/Export';
+import ExportStack from './bt/AffectedUserFlow';
 
 import NotificationPermissionsBT from './bt/NotificationPermissionsBT';
 import ExposureHistoryScreen from './views/ExposureHistory';
@@ -96,8 +97,6 @@ const SelfAssessmentStack = () => (
 );
 
 const MoreTabStack = () => {
-  const tracingStrategy = useTracingStrategyContext();
-
   return (
     <Stack.Navigator screenOptions={SCREEN_OPTIONS}>
       <Stack.Screen name={Screens.Settings} component={SettingsScreen} />
@@ -116,7 +115,7 @@ const MoreTabStack = () => {
       />
       <Stack.Screen
         name={Screens.ExportFlow}
-        component={tracingStrategy.affectedUserFlow}
+        component={ExportStack}
         options={{
           ...TransitionPresets.ModalSlideFromBottomIOS,
           gestureEnabled: false,
@@ -133,11 +132,34 @@ const MoreTabStack = () => {
   );
 };
 
-const screensWithNoTabBar = [Screens.ExportFlow];
+const screensWithNoTabBar = [Screens.ExportSelectHA, Screens.ExportFlow];
 
 const determineTabBarVisibility = (route) => {
   const routeName = route.state?.routes[route.state.index].name;
   return !screensWithNoTabBar.includes(routeName);
+};
+
+const GPSExportStack = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name={Screens.ExportStart}
+        component={ExportStart}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name={Screens.ExportSelectHA}
+        component={ExportSelectHA}
+        options={{
+          ...TransitionPresets.ModalSlideFromBottomIOS,
+          headerShown: false,
+          gestureEnabled: false,
+        }}
+      />
+    </Stack.Navigator>
+  );
 };
 
 const MainAppTabs = () => {
@@ -207,9 +229,10 @@ const MainAppTabs = () => {
       />
       {isGPS && (
         <Tab.Screen
-          name={Screens.ExportStart}
-          component={ExportStart}
-          options={{
+          name={'Export Start'}
+          component={GPSExportStack}
+          options={({ route }) => ({
+            tabBarVisible: determineTabBarVisibility(route),
             tabBarLabel: t('navigation.locations'),
             tabBarIcon: ({ focused, size }) => (
               <SvgXml
@@ -218,7 +241,7 @@ const MainAppTabs = () => {
                 height={size}
               />
             ),
-          }}
+          })}
         />
       )}
       {isGPS ? (

--- a/app/Entry.js
+++ b/app/Entry.js
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { SvgXml } from 'react-native-svg';
 import { NavigationContainer } from '@react-navigation/native';
 import {
-  CardStyleInterpolators,
   TransitionPresets,
   createStackNavigator,
 } from '@react-navigation/stack';
@@ -45,11 +44,10 @@ import { Screens, Stacks } from './navigation';
 import ExposureHistoryContext from './ExposureHistoryContext';
 import isOnboardingCompleteSelector from './store/selectors/isOnboardingCompleteSelector';
 import { isGPS } from './COVIDSafePathsConfig';
-import { isPlatformAndroid } from './Util';
 import { useTracingStrategyContext } from './TracingStrategyContext';
 
 import * as Icons from './assets/svgs/TabBarNav';
-import { Layout, Affordances, Spacing, Colors } from './styles';
+import { Layout, Affordances, Colors } from './styles';
 
 const Tab = createBottomTabNavigator();
 const Stack = createStackNavigator();
@@ -57,10 +55,6 @@ const Stack = createStackNavigator();
 const fade = ({ current }) => ({ cardStyle: { opacity: current.progress } });
 
 const SCREEN_OPTIONS = {
-  cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-  cardStyle: {
-    backgroundColor: 'transparent', // prevent white flash on Android
-  },
   headerShown: false,
 };
 
@@ -101,24 +95,50 @@ const SelfAssessmentStack = () => (
   </Stack.Navigator>
 );
 
-const MoreTabStack = () => (
-  <Stack.Navigator screenOptions={SCREEN_OPTIONS}>
-    <Stack.Screen name={Screens.Settings} component={SettingsScreen} />
-    <Stack.Screen name={Screens.About} component={AboutScreen} />
-    <Stack.Screen name={Screens.Licenses} component={LicensesScreen} />
-    <Stack.Screen name={Screens.FeatureFlags} component={FeatureFlagsScreen} />
-    <Stack.Screen name={Screens.Import} component={ImportScreen} />
-    <Stack.Screen name={Screens.ImportFromUrl} component={ImportFromUrl} />
-    <Stack.Screen name={Screens.ENDebugMenu} component={ENDebugMenu} />
-    <Stack.Screen
-      name={Screens.ENLocalDiagnosisKey}
-      component={ENLocalDiagnosisKeyScreen}
-    />
-    {isGPS ? (
-      <Stack.Screen name={Screens.ExportLocally} component={ExportLocally} />
-    ) : null}
-  </Stack.Navigator>
-);
+const MoreTabStack = () => {
+  const tracingStrategy = useTracingStrategyContext();
+
+  return (
+    <Stack.Navigator screenOptions={SCREEN_OPTIONS}>
+      <Stack.Screen name={Screens.Settings} component={SettingsScreen} />
+      <Stack.Screen name={Screens.About} component={AboutScreen} />
+      <Stack.Screen name={Screens.Licenses} component={LicensesScreen} />
+      <Stack.Screen
+        name={Screens.FeatureFlags}
+        component={FeatureFlagsScreen}
+      />
+      <Stack.Screen name={Screens.Import} component={ImportScreen} />
+      <Stack.Screen name={Screens.ImportFromUrl} component={ImportFromUrl} />
+      <Stack.Screen name={Screens.ENDebugMenu} component={ENDebugMenu} />
+      <Stack.Screen
+        name={Screens.LanguageSelection}
+        component={LanguageSelection}
+      />
+      <Stack.Screen
+        name={Screens.ExportFlow}
+        component={tracingStrategy.affectedUserFlow}
+        options={{
+          ...TransitionPresets.ModalSlideFromBottomIOS,
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name={Screens.ENLocalDiagnosisKey}
+        component={ENLocalDiagnosisKeyScreen}
+      />
+      {isGPS ? (
+        <Stack.Screen name={Screens.ExportLocally} component={ExportLocally} />
+      ) : null}
+    </Stack.Navigator>
+  );
+};
+
+const screensWithNoTabBar = [Screens.ExportFlow];
+
+const determineTabBarVisibility = (route) => {
+  const routeName = route.state?.routes[route.state.index].name;
+  return !screensWithNoTabBar.includes(routeName);
+};
 
 const MainAppTabs = () => {
   const { t } = useTranslation();
@@ -150,7 +170,6 @@ const MainAppTabs = () => {
         style: {
           backgroundColor: Colors.navBar,
           borderTopColor: Colors.navBar,
-          paddingTop: isPlatformAndroid() ? 0 : Spacing.xSmall,
           height: Layout.navBar,
         },
       }}>
@@ -240,7 +259,8 @@ const MainAppTabs = () => {
       <Tab.Screen
         name={Stacks.More}
         component={MoreTabStack}
-        options={{
+        options={({ route }) => ({
+          tabBarVisible: determineTabBarVisibility(route),
           tabBarLabel: t('navigation.more'),
           tabBarIcon: ({ focused, size }) => (
             <SvgXml
@@ -249,7 +269,7 @@ const MainAppTabs = () => {
               height={size}
             />
           ),
-        }}
+        })}
       />
     </Tab.Navigator>
   );
@@ -297,22 +317,8 @@ const PartnersStack = () => (
   </Stack.Navigator>
 );
 
-const animateFromBottom = ({ current }) => ({
-  cardStyle: {
-    transform: [
-      {
-        translateY: current.progress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [Layout.screenHeight, 0],
-        }),
-      },
-    ],
-  },
-});
-
 export const Entry = () => {
   const onboardingComplete = useSelector(isOnboardingCompleteSelector);
-  const tracingStrategy = useTracingStrategyContext();
 
   return (
     <NavigationContainer>
@@ -322,22 +328,6 @@ export const Entry = () => {
         ) : (
           <Stack.Screen name={Stacks.Onboarding} component={OnboardingStack} />
         )}
-        {/* Modal Views: */}
-        <Stack.Screen
-          name={Screens.ExportFlow}
-          component={tracingStrategy.affectedUserFlow}
-          options={{
-            cardStyleInterpolator: animateFromBottom,
-            gestureEnabled: false,
-          }}
-        />
-        <Stack.Screen
-          name={Screens.LanguageSelection}
-          component={LanguageSelection}
-          options={{
-            ...TransitionPresets.ModalSlideFromBottomIOS,
-          }}
-        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/app/gps/Export/ExportStart.js
+++ b/app/gps/Export/ExportStart.js
@@ -7,7 +7,10 @@ import { Screens } from '../../navigation';
 export const ExportStart = ({ navigation }) => {
   const { t } = useTranslation();
 
-  const onNext = () => navigation.navigate(Screens.ExportFlow);
+  const onNext = () => {
+    navigation.navigate(Screens.ExportSelectHA);
+  };
+
   return (
     <ExportTemplate
       onNext={onNext}

--- a/app/gps/ExportStack.tsx
+++ b/app/gps/ExportStack.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  CardStyleInterpolators,
-  createStackNavigator,
-  StackCardStyleInterpolator,
-} from '@react-navigation/stack';
+import { createStackNavigator } from '@react-navigation/stack';
 
 import ExportCodeInput from './Export/ExportCodeInput';
 import ExportComplete from './Export/ExportComplete';
@@ -17,24 +13,10 @@ import { Screens } from '../navigation';
 
 const Stack = createStackNavigator();
 
-const fade: StackCardStyleInterpolator = ({ current }) => ({
-  cardStyle: { opacity: current.progress },
-});
-
-const SCREEN_OPTIONS = {
-  cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-  cardStyle: {
-    backgroundColor: 'transparent', // prevent white flash on Android
-  },
-  headerShown: false,
-};
-
 const ExportStack = (): JSX.Element => (
   <Stack.Navigator
-    mode='modal'
     screenOptions={{
-      ...SCREEN_OPTIONS,
-      cardStyleInterpolator: fade,
+      headerShown: false,
       gestureEnabled: false,
     }}
     initialRouteName={Screens.ExportSelectHA}>

--- a/app/styles/layout.ts
+++ b/app/styles/layout.ts
@@ -29,7 +29,7 @@ export const fullWidthWithSmallMargin = screenWidth - horizontalMarginSmall * 2;
 export const fullWidthWithMediumMargin =
   screenWidth - horizontalMarginMedium * 2;
 
-export const navBar = tappableHeight;
+export const navBar = tappableHeight + Spacing.xSmall;
 
 // zIndex
 export const level1 = 1;

--- a/app/views/LanguageSelection.tsx
+++ b/app/views/LanguageSelection.tsx
@@ -31,7 +31,10 @@ const LanguageSelection = (): JSX.Element => {
   };
 
   return (
-    <NavigationBarWrapper title={' '} includeBackButton={false}>
+    <NavigationBarWrapper
+      title={'Choose Language'}
+      includeBackButton
+      onBackPress={navigation.goBack}>
       <FlatList
         keyExtractor={(_, i) => `${i}`}
         data={localeList}


### PR DESCRIPTION
Why: prior to this commit, we were displaying modals that show over the
tab bar by including them in the top-level stack navigator, even though
they are structurally within individual tabs. This pattern is
non-optimal.

This commit:
- Moves the affected user flow and language selection to within the
settings tab
- Hides the tab bar when the affected user flow is mounted
- Moves the language selection out of a modal view for consistency with
  the other settings screens

## Before
![before](https://user-images.githubusercontent.com/39350030/87078127-2da11800-c1f2-11ea-8567-41df07098394.gif)

## After
![after](https://user-images.githubusercontent.com/39350030/87078126-2d088180-c1f2-11ea-8420-7a6630a16e85.gif)