### PR TITLE
Update test preset to allow for text matchers and add test to affected user flow

### DIFF
--- a/app/bt/AffectedUserFlow/CodeInput.spec.tsx
+++ b/app/bt/AffectedUserFlow/CodeInput.spec.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { cleanup, render } from '@testing-library/react-native';
+import {
+  cleanup,
+  render,
+  fireEvent,
+  wait,
+} from '@testing-library/react-native';
 import '@testing-library/jest-native/extend-expect';
 
 import CodeInputScreen from './CodeInput';
 import { AffectedUserProvider } from './AffectedUserContext';
+import * as API from './verificationAPI';
 
 afterEach(cleanup);
 
@@ -17,5 +23,78 @@ describe('CodeInputScreen', () => {
 
     expect(getByTestId('affected-user-code-input-screen')).not.toBeNull();
     expect(getByTestId('code-input')).toHaveTextContent('');
+  });
+
+  describe('validates the verification code', () => {
+    it('informs of an invalid code error', async () => {
+      const error = 'InvalidCode' as const;
+      const wrongTokenResponse = {
+        kind: 'failure' as const,
+        error,
+      };
+      jest
+        .spyOn(API, 'postVerificationCode')
+        .mockResolvedValueOnce(wrongTokenResponse);
+
+      const { getByTestId, getByLabelText, getByText } = render(
+        <AffectedUserProvider>
+          <CodeInputScreen />
+        </AffectedUserProvider>,
+      );
+      fireEvent.changeText(getByTestId('code-input'), '12345678');
+      fireEvent.press(getByLabelText('Submit'));
+
+      await wait(() => {
+        expect(getByText('Try a different code')).toBeDefined();
+      });
+    });
+
+    it('informs of a used verification code', async () => {
+      const error = 'VerificationCodeUsed' as const;
+      const wrongTokenResponse = {
+        kind: 'failure' as const,
+        error,
+      };
+      jest
+        .spyOn(API, 'postVerificationCode')
+        .mockResolvedValueOnce(wrongTokenResponse);
+
+      const { getByTestId, getByLabelText, getByText } = render(
+        <AffectedUserProvider>
+          <CodeInputScreen />
+        </AffectedUserProvider>,
+      );
+      fireEvent.changeText(getByTestId('code-input'), '12345678');
+      fireEvent.press(getByLabelText('Submit'));
+
+      await wait(() => {
+        expect(
+          getByText('Verification code has already been used'),
+        ).toBeDefined();
+      });
+    });
+
+    it('informs of an unknown error', async () => {
+      const error = 'Unknown' as const;
+      const wrongTokenResponse = {
+        kind: 'failure' as const,
+        error,
+      };
+      jest
+        .spyOn(API, 'postVerificationCode')
+        .mockResolvedValueOnce(wrongTokenResponse);
+
+      const { getByTestId, getByLabelText, getByText } = render(
+        <AffectedUserProvider>
+          <CodeInputScreen />
+        </AffectedUserProvider>,
+      );
+      fireEvent.changeText(getByTestId('code-input'), '12345678');
+      fireEvent.press(getByLabelText('Submit'));
+
+      await wait(() => {
+        expect(getByText('Try a different code')).toBeDefined();
+      });
+    });
   });
 });

--- a/app/bt/Home/__snapshots__/index.spec.tsx.snap
+++ b/app/bt/Home/__snapshots__/index.spec.tsx.snap
@@ -156,10 +156,8 @@ exports[`HomeScreen renders 1`] = `
             Enable Exposure Notifications to receive information about possible exposures
           </Text>
         </View>
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
+        <TouchableOpacity
+          activeOpacity={0.2}
           style={
             Object {
               "alignItems": "center",
@@ -168,7 +166,6 @@ exports[`HomeScreen renders 1`] = `
               "borderRadius": 8,
               "flexDirection": "row",
               "justifyContent": "center",
-              "opacity": 1,
               "paddingBottom": 25,
               "paddingTop": 24,
               "width": "100%",
@@ -198,7 +195,7 @@ exports[`HomeScreen renders 1`] = `
           >
             Allow Exposure Notifications
           </Text>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
   </View>

--- a/app/components/__tests__/__snapshots__/IconButton.spec.js.snap
+++ b/app/components/__tests__/__snapshots__/IconButton.spec.js.snap
@@ -10,15 +10,12 @@ exports[`allows size override 1`] = `
     }
   }
 >
-  <View
-    accessible={true}
-    focusable={false}
-    isTVSelectable={true}
+  <TouchableOpacity
+    activeOpacity={0.2}
     style={
       Object {
         "alignContent": "center",
         "alignItems": "center",
-        "opacity": 1,
       }
     }
   >
@@ -28,7 +25,7 @@ exports[`allows size override 1`] = `
       width={48}
       xml="<g />"
     />
-  </View>
+  </TouchableOpacity>
 </View>
 `;
 
@@ -42,16 +39,13 @@ exports[`renders the icon in a touchable opacity 1`] = `
     }
   }
 >
-  <View
+  <TouchableOpacity
     accessibilityLabel="Label"
-    accessible={true}
-    focusable={false}
-    isTVSelectable={true}
+    activeOpacity={0.2}
     style={
       Object {
         "alignContent": "center",
         "alignItems": "center",
-        "opacity": 1,
       }
     }
   >
@@ -61,6 +55,6 @@ exports[`renders the icon in a touchable opacity 1`] = `
       width={24}
       xml="<g />"
     />
-  </View>
+  </TouchableOpacity>
 </View>
 `;

--- a/app/components/__tests__/__snapshots__/Switch.spec.js.snap
+++ b/app/components/__tests__/__snapshots__/Switch.spec.js.snap
@@ -10,18 +10,15 @@ exports[`renders as off by default 1`] = `
     }
   }
 >
-  <RCTSwitch
-    accessibilityRole="button"
-    onTintColor="#41dca4"
-    style={
+  <Switch
+    testID="switch"
+    thumbColor="#ffffff"
+    trackColor={
       Object {
-        "height": 31,
-        "width": 51,
+        "false": "#4e4e4e",
+        "true": "#41dca4",
       }
     }
-    testID="switch"
-    thumbTintColor="#ffffff"
-    tintColor="#4e4e4e"
     value={false}
   />
 </View>
@@ -37,18 +34,15 @@ exports[`renders on 1`] = `
     }
   }
 >
-  <RCTSwitch
-    accessibilityRole="button"
-    onTintColor="#41dca4"
-    style={
+  <Switch
+    testID="switch"
+    thumbColor="#ffffff"
+    trackColor={
       Object {
-        "height": 31,
-        "width": 51,
+        "false": "#4e4e4e",
+        "true": "#41dca4",
       }
     }
-    testID="switch"
-    thumbTintColor="#ffffff"
-    tintColor="#4e4e4e"
     value={true}
   />
 </View>

--- a/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Import component renders correctly 1`] = `
-<RCTSafeAreaView
-  emulateUnlessSupported={true}
+<SafeAreaView
   style={
     Object {
       "backgroundColor": "#1f2c9b",
@@ -30,22 +29,9 @@ exports[`Import component renders correctly 1`] = `
         }
       }
     >
-      <View
-        accessible={true}
-        focusable={true}
-        isTVSelectable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
       >
         <SvgXml
           color="#ffffff"
@@ -60,7 +46,7 @@ exports[`Import component renders correctly 1`] = `
   </svg>
 "
         />
-      </View>
+      </TouchableOpacity>
     </View>
     <View
       style={
@@ -112,230 +98,201 @@ exports[`Import component renders correctly 1`] = `
       }
     }
   >
-    <RCTScrollView
+    <ScrollView
       style={
         Object {
           "padding": 20,
         }
       }
     >
-      <View>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 17,
-                "lineHeight": 24,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "marginBottom": 16,
-              },
-            ]
-          }
-        >
-          Adding location data from Google will give you a head start on building your recent locations.
-        </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 17,
-                "lineHeight": 24,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "marginBottom": 16,
-              },
-            ]
-          }
-        >
-          Before you can import, you must first "Take out" your location data from Google.
-        </Text>
-        <Text
-          style={
-            Array [
-              Object {
-                "color": "#2e2e2e",
-                "fontFamily": "IBMPlexSans",
-                "fontSize": 17,
-                "lineHeight": 24,
-              },
-              Object {
-                "writingDirection": "ltr",
-              },
-              Object {
-                "marginBottom": 16,
-              },
-            ]
-          }
-        >
-          Visit Google Takeout and export your Location History using the following settings: 
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 17,
+              "lineHeight": 24,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
+            Object {
+              "marginBottom": 16,
+            },
+          ]
+        }
+      >
+        Adding location data from Google will give you a head start on building your recent locations.
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 17,
+              "lineHeight": 24,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
+            Object {
+              "marginBottom": 16,
+            },
+          ]
+        }
+      >
+        Before you can import, you must first "Take out" your location data from Google.
+      </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "#2e2e2e",
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 17,
+              "lineHeight": 24,
+            },
+            Object {
+              "writingDirection": "ltr",
+            },
+            Object {
+              "marginBottom": 16,
+            },
+          ]
+        }
+      >
+        Visit Google Takeout and export your Location History using the following settings: 
 1. Delivery method: "Add to Drive" 
 2. Frequency: "Export once" 
 3. File type & size: ".zip" and "1GB"
 4. Google sends an email when the export is ready 
 5. Return here to import locations from Google Drive
+      </Text>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#4051db",
+            "borderColor": "#4051db",
+            "borderRadius": 8,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "marginBottom": 20,
+            "paddingHorizontal": 20,
+            "paddingVertical": 16,
+          }
+        }
+        testID="google-takeout-link"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
+                "fontSize": 17,
+                "lineHeight": 24,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#ffffff",
+                "fontSize": 19,
+                "fontWeight": "500",
+              },
+            ]
+          }
+        >
+          Visit Google Takeout
         </Text>
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#4051db",
-              "borderColor": "#4051db",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "marginBottom": 20,
-              "opacity": 1,
-              "paddingHorizontal": 20,
-              "paddingVertical": 16,
-            }
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#4051db",
+            "borderColor": "#4051db",
+            "borderRadius": 8,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "marginBottom": 20,
+            "paddingHorizontal": 20,
+            "paddingVertical": 16,
           }
-          testID="google-takeout-link"
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontFamily": "IBMPlexSans",
-                  "fontSize": 17,
-                  "lineHeight": 24,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#ffffff",
-                  "fontSize": 19,
-                  "fontWeight": "500",
-                },
-              ]
-            }
-          >
-            Visit Google Takeout
-          </Text>
-        </View>
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+        }
+        testID="google-takeout-import-btn"
+      >
+        <Text
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#4051db",
-              "borderColor": "#4051db",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "marginBottom": 20,
-              "opacity": 1,
-              "paddingHorizontal": 20,
-              "paddingVertical": 16,
-            }
-          }
-          testID="google-takeout-import-btn"
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontFamily": "IBMPlexSans",
-                  "fontSize": 17,
-                  "lineHeight": 24,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#ffffff",
-                  "fontSize": 19,
-                  "fontWeight": "500",
-                },
-              ]
-            }
-          >
-            Import Locations
-          </Text>
-        </View>
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#4051db",
-              "borderColor": "#4051db",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "marginBottom": 20,
-              "opacity": 1,
-              "paddingHorizontal": 20,
-              "paddingVertical": 16,
-            }
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
+                "fontSize": 17,
+                "lineHeight": 24,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#ffffff",
+                "fontSize": 19,
+                "fontWeight": "500",
+              },
+            ]
           }
         >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontFamily": "IBMPlexSans",
-                  "fontSize": 17,
-                  "lineHeight": 24,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#ffffff",
-                  "fontSize": 19,
-                  "fontWeight": "500",
-                },
-              ]
-            }
-          >
-            Import from URL
-          </Text>
-        </View>
-      </View>
-    </RCTScrollView>
+          Import Locations
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        onPress={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "#4051db",
+            "borderColor": "#4051db",
+            "borderRadius": 8,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "marginBottom": 20,
+            "paddingHorizontal": 20,
+            "paddingVertical": 16,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
+                "fontSize": 17,
+                "lineHeight": 24,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#ffffff",
+                "fontSize": 19,
+                "fontWeight": "500",
+              },
+            ]
+          }
+        >
+          Import from URL
+        </Text>
+      </TouchableOpacity>
+    </ScrollView>
   </View>
-</RCTSafeAreaView>
+</SafeAreaView>
 `;

--- a/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
@@ -10,8 +10,7 @@ exports[`LicensesScreen renders correctly 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <SafeAreaView
     style={
       Object {
         "backgroundColor": "#1f2c9b",
@@ -39,15 +38,8 @@ exports[`LicensesScreen renders correctly 1`] = `
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
         >
           <SvgXml
             color="#ffffff"
@@ -62,7 +54,7 @@ exports[`LicensesScreen renders correctly 1`] = `
   </svg>
 "
           />
-        </View>
+        </TouchableOpacity>
       </View>
       <View
         style={
@@ -114,7 +106,7 @@ exports[`LicensesScreen renders correctly 1`] = `
         }
       }
     >
-      <RCTScrollView
+      <ScrollView
         alwaysBounceVertical={false}
         contentContainerStyle={
           Object {
@@ -125,16 +117,42 @@ exports[`LicensesScreen renders correctly 1`] = `
         }
       >
         <View>
-          <View>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
+                undefined,
+              ]
+            }
+            testID="licenses-legal-header"
+          >
+            PathCheck GPS
+          </Text>
+          <View
+            style={
+              Object {
+                "paddingLeft": 20,
+                "paddingTop": 12,
+              }
+            }
+          >
             <Text
               style={
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "color": "#4e4e4e",
+                    "fontFamily": "IBMPlexSans",
+                    "fontSize": 17,
+                    "lineHeight": 24,
                   },
                   Object {
                     "writingDirection": "ltr",
@@ -142,102 +160,71 @@ exports[`LicensesScreen renders correctly 1`] = `
                   undefined,
                 ]
               }
-              testID="licenses-legal-header"
             >
-              PathCheck GPS
+              PathCheck Foundation
+58 Day Street
+Box 441621
+Somerville, MA 02144
             </Text>
             <View
               style={
                 Object {
-                  "paddingLeft": 20,
-                  "paddingTop": 12,
+                  "height": 20,
                 }
               }
-            >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#4e4e4e",
-                      "fontFamily": "IBMPlexSans",
-                      "fontSize": 17,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                PathCheck Foundation
-58 Day Street
-Box 441621
-Somerville, MA 02144
-              </Text>
-              <View
-                style={
+            />
+            <Text
+              style={
+                Array [
                   Object {
-                    "height": 20,
-                  }
-                }
-              />
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#4e4e4e",
-                      "fontFamily": "IBMPlexSans",
-                      "fontSize": 17,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "textDecorationLine": "underline",
-                    },
-                  ]
-                }
-              >
-                info@pathcheck.org
-              </Text>
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#4e4e4e",
-                      "fontFamily": "IBMPlexSans",
-                      "fontSize": 17,
-                      "lineHeight": 24,
-                    },
-                    Object {
-                      "writingDirection": "ltr",
-                    },
-                    Object {
-                      "color": "#1f2c9b",
-                      "textDecorationLine": "underline",
-                    },
-                  ]
-                }
-              >
-                pathcheck.org
-              </Text>
-            </View>
+                    "color": "#4e4e4e",
+                    "fontFamily": "IBMPlexSans",
+                    "fontSize": 17,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {
+                    "color": "#1f2c9b",
+                    "textDecorationLine": "underline",
+                  },
+                ]
+              }
+            >
+              info@pathcheck.org
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#4e4e4e",
+                    "fontFamily": "IBMPlexSans",
+                    "fontSize": 17,
+                    "lineHeight": 24,
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {
+                    "color": "#1f2c9b",
+                    "textDecorationLine": "underline",
+                  },
+                ]
+              }
+            >
+              pathcheck.org
+            </Text>
           </View>
         </View>
-      </RCTScrollView>
-      <View
-        accessible={true}
-        focusable={true}
-        isTVSelectable={true}
+      </ScrollView>
+      <TouchableOpacity
+        activeOpacity={0.2}
         style={
           Object {
             "backgroundColor": "#4051db",
             "flexDirection": "row",
             "justifyContent": "space-between",
-            "opacity": 1,
             "paddingHorizontal": 15,
             "paddingVertical": 25,
           }
@@ -280,8 +267,8 @@ Somerville, MA 02144
             }
           />
         </View>
-      </View>
+      </TouchableOpacity>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/__snapshots__/Button.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Button.spec.js.snap
@@ -10,15 +10,9 @@ exports[`base 1`] = `
     }
   }
 >
-  <View
-    accessible={true}
-    focusable={false}
-    isTVSelectable={true}
-    style={
-      Object {
-        "opacity": 1,
-      }
-    }
+  <TouchableOpacity
+    activeOpacity={0.2}
+    disabled={false}
     testID="assessment-button"
   >
     <View
@@ -64,7 +58,7 @@ exports[`base 1`] = `
         Next
       </Text>
     </View>
-  </View>
+  </TouchableOpacity>
 </View>
 `;
 
@@ -78,15 +72,9 @@ exports[`color 1`] = `
     }
   }
 >
-  <View
-    accessible={true}
-    focusable={false}
-    isTVSelectable={true}
-    style={
-      Object {
-        "opacity": 1,
-      }
-    }
+  <TouchableOpacity
+    activeOpacity={0.2}
+    disabled={false}
     testID="assessment-button"
   >
     <View
@@ -132,7 +120,7 @@ exports[`color 1`] = `
         Next
       </Text>
     </View>
-  </View>
+  </TouchableOpacity>
 </View>
 `;
 
@@ -146,15 +134,9 @@ exports[`disabled 1`] = `
     }
   }
 >
-  <View
-    accessible={true}
-    focusable={false}
-    isTVSelectable={true}
-    style={
-      Object {
-        "opacity": 1,
-      }
-    }
+  <TouchableOpacity
+    activeOpacity={0.2}
+    disabled={true}
     testID="assessment-button"
   >
     <View
@@ -200,6 +182,6 @@ exports[`disabled 1`] = `
         Next
       </Text>
     </View>
-  </View>
+  </TouchableOpacity>
 </View>
 `;

--- a/app/views/assessment/__tests__/__snapshots__/Info.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Info.spec.js.snap
@@ -10,8 +10,7 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <SafeAreaView
     style={
       Object {
         "borderTopWidth": 0,
@@ -48,27 +47,25 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-      </RCTScrollView>
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        />
+      </ScrollView>
       <View
         style={
           Object {
@@ -77,6 +74,6 @@ exports[`base 1`] = `
         }
       />
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/__snapshots__/Option.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Option.spec.js.snap
@@ -10,15 +10,8 @@ exports[`SCREEN_TYPE_CHECKBOX 1`] = `
     }
   }
 >
-  <View
-    accessible={true}
-    focusable={true}
-    isTVSelectable={true}
-    style={
-      Object {
-        "opacity": 1,
-      }
-    }
+  <TouchableOpacity
+    activeOpacity={0.2}
     testID="option"
   >
     <View
@@ -92,7 +85,7 @@ exports[`SCREEN_TYPE_CHECKBOX 1`] = `
         </Text>
       </View>
     </View>
-  </View>
+  </TouchableOpacity>
 </View>
 `;
 
@@ -106,15 +99,8 @@ exports[`SCREEN_TYPE_RADIO 1`] = `
     }
   }
 >
-  <View
-    accessible={true}
-    focusable={true}
-    isTVSelectable={true}
-    style={
-      Object {
-        "opacity": 1,
-      }
-    }
+  <TouchableOpacity
+    activeOpacity={0.2}
     testID="option"
   >
     <View
@@ -188,6 +174,6 @@ exports[`SCREEN_TYPE_RADIO 1`] = `
         </Text>
       </View>
     </View>
-  </View>
+  </TouchableOpacity>
 </View>
 `;

--- a/app/views/assessment/__tests__/__snapshots__/Question.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Question.spec.js.snap
@@ -10,8 +10,7 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
-    emulateUnlessSupported={true}
+  <SafeAreaView
     style={
       Object {
         "backgroundColor": "#f8f8ff",
@@ -19,250 +18,234 @@ exports[`base 1`] = `
       }
     }
   >
-    <RCTScrollView
+    <ScrollView
       style={
         Object {
           "flex": 1,
         }
       }
     >
-      <View>
-        <View
-          style={
-            Object {
-              "marginTop": 16,
-              "paddingHorizontal": 20,
-            }
+      <View
+        style={
+          Object {
+            "marginTop": 16,
+            "paddingHorizontal": 20,
           }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#1f2c9b",
-                  "fontFamily": "IBMPlexSans-Bold",
-                  "fontSize": 28,
-                  "fontWeight": "500",
-                  "lineHeight": 32,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                undefined,
-              ]
-            }
-          >
-            What is the answer?
-          </Text>
-        </View>
-        <View
+        }
+      >
+        <Text
           style={
-            Object {
-              "paddingHorizontal": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#2e2e2e",
-                  "fontFamily": "IBMPlexSans",
-                  "fontSize": 17,
-                  "lineHeight": 24,
-                },
-                Object {
-                  "writingDirection": "ltr",
-                },
-                Object {
-                  "color": "#4754C5",
-                  "fontFamily": "IBMPlexSans",
-                  "fontSize": 17,
-                  "lineHeight": 16,
-                  "marginTop": 28,
-                },
-              ]
-            }
-          >
-            Select one
-          </Text>
-          <View
-            style={
+            Array [
               Object {
-                "marginTop": 20,
-              }
+                "color": "#1f2c9b",
+                "fontFamily": "IBMPlexSans-Bold",
+                "fontSize": 28,
+                "fontWeight": "500",
+                "lineHeight": 32,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              undefined,
+            ]
+          }
+        >
+          What is the answer?
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingHorizontal": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2e2e2e",
+                "fontFamily": "IBMPlexSans",
+                "fontSize": 17,
+                "lineHeight": 24,
+              },
+              Object {
+                "writingDirection": "ltr",
+              },
+              Object {
+                "color": "#4754C5",
+                "fontFamily": "IBMPlexSans",
+                "fontSize": 17,
+                "lineHeight": 16,
+                "marginTop": 28,
+              },
+            ]
+          }
+        >
+          Select one
+        </Text>
+        <View
+          style={
+            Object {
+              "marginTop": 20,
             }
+          }
+        >
+          <TouchableOpacity
+            activeOpacity={0.2}
+            testID="option"
           >
             <View
-              accessible={true}
-              focusable={true}
-              isTVSelectable={true}
               style={
-                Object {
-                  "opacity": 1,
-                }
+                Array [
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#d3d3d3",
+                    "borderRadius": 8,
+                    "borderWidth": 2,
+                    "marginBottom": 16,
+                    "paddingHorizontal": 20,
+                    "paddingVertical": 20,
+                  },
+                  false,
+                ]
               }
-              testID="option"
             >
               <View
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "#d3d3d3",
-                      "borderRadius": 8,
-                      "borderWidth": 2,
-                      "marginBottom": 16,
-                      "paddingHorizontal": 20,
-                      "paddingVertical": 20,
-                    },
-                    false,
-                  ]
+                  Object {
+                    "alignItems": "flex-start",
+                    "flexDirection": "row",
+                  }
                 }
               >
                 <View
                   style={
-                    Object {
-                      "alignItems": "flex-start",
-                      "flexDirection": "row",
-                    }
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "borderColor": "#999999",
+                        "borderRadius": 40,
+                        "borderWidth": 2,
+                        "height": 24,
+                        "justifyContent": "center",
+                        "marginRight": 24,
+                        "marginTop": 2,
+                        "width": 24,
+                      },
+                      false,
+                    ]
                   }
+                />
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontFamily": "IBMPlexSans",
+                        "fontSize": 17,
+                        "lineHeight": 24,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#2e2e2e",
+                        "flex": 1,
+                        "flexWrap": "wrap",
+                        "fontFamily": "IBMPlexSans-Bold",
+                        "fontSize": 19,
+                        "fontWeight": "500",
+                        "lineHeight": 24,
+                      },
+                    ]
+                  }
+                  testID="label"
                 >
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "alignItems": "center",
-                          "borderColor": "#999999",
-                          "borderRadius": 40,
-                          "borderWidth": 2,
-                          "height": 24,
-                          "justifyContent": "center",
-                          "marginRight": 24,
-                          "marginTop": 2,
-                          "width": 24,
-                        },
-                        false,
-                      ]
-                    }
-                  />
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "color": "#2e2e2e",
-                          "fontFamily": "IBMPlexSans",
-                          "fontSize": 17,
-                          "lineHeight": 24,
-                        },
-                        Object {
-                          "writingDirection": "ltr",
-                        },
-                        Object {
-                          "color": "#2e2e2e",
-                          "flex": 1,
-                          "flexWrap": "wrap",
-                          "fontFamily": "IBMPlexSans-Bold",
-                          "fontSize": 19,
-                          "fontWeight": "500",
-                          "lineHeight": 24,
-                        },
-                      ]
-                    }
-                    testID="label"
-                  >
-                    A
-                  </Text>
-                </View>
+                  A
+                </Text>
               </View>
             </View>
+          </TouchableOpacity>
+          <TouchableOpacity
+            activeOpacity={0.2}
+            testID="option"
+          >
             <View
-              accessible={true}
-              focusable={true}
-              isTVSelectable={true}
               style={
-                Object {
-                  "opacity": 1,
-                }
+                Array [
+                  Object {
+                    "backgroundColor": "#ffffff",
+                    "borderColor": "#d3d3d3",
+                    "borderRadius": 8,
+                    "borderWidth": 2,
+                    "marginBottom": 16,
+                    "paddingHorizontal": 20,
+                    "paddingVertical": 20,
+                  },
+                  false,
+                ]
               }
-              testID="option"
             >
               <View
                 style={
-                  Array [
-                    Object {
-                      "backgroundColor": "#ffffff",
-                      "borderColor": "#d3d3d3",
-                      "borderRadius": 8,
-                      "borderWidth": 2,
-                      "marginBottom": 16,
-                      "paddingHorizontal": 20,
-                      "paddingVertical": 20,
-                    },
-                    false,
-                  ]
+                  Object {
+                    "alignItems": "flex-start",
+                    "flexDirection": "row",
+                  }
                 }
               >
                 <View
                   style={
-                    Object {
-                      "alignItems": "flex-start",
-                      "flexDirection": "row",
-                    }
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "borderColor": "#999999",
+                        "borderRadius": 40,
+                        "borderWidth": 2,
+                        "height": 24,
+                        "justifyContent": "center",
+                        "marginRight": 24,
+                        "marginTop": 2,
+                        "width": 24,
+                      },
+                      false,
+                    ]
                   }
+                />
+                <Text
+                  style={
+                    Array [
+                      Object {
+                        "color": "#2e2e2e",
+                        "fontFamily": "IBMPlexSans",
+                        "fontSize": 17,
+                        "lineHeight": 24,
+                      },
+                      Object {
+                        "writingDirection": "ltr",
+                      },
+                      Object {
+                        "color": "#2e2e2e",
+                        "flex": 1,
+                        "flexWrap": "wrap",
+                        "fontFamily": "IBMPlexSans-Bold",
+                        "fontSize": 19,
+                        "fontWeight": "500",
+                        "lineHeight": 24,
+                      },
+                    ]
+                  }
+                  testID="label"
                 >
-                  <View
-                    style={
-                      Array [
-                        Object {
-                          "alignItems": "center",
-                          "borderColor": "#999999",
-                          "borderRadius": 40,
-                          "borderWidth": 2,
-                          "height": 24,
-                          "justifyContent": "center",
-                          "marginRight": 24,
-                          "marginTop": 2,
-                          "width": 24,
-                        },
-                        false,
-                      ]
-                    }
-                  />
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "color": "#2e2e2e",
-                          "fontFamily": "IBMPlexSans",
-                          "fontSize": 17,
-                          "lineHeight": 24,
-                        },
-                        Object {
-                          "writingDirection": "ltr",
-                        },
-                        Object {
-                          "color": "#2e2e2e",
-                          "flex": 1,
-                          "flexWrap": "wrap",
-                          "fontFamily": "IBMPlexSans-Bold",
-                          "fontSize": 19,
-                          "fontWeight": "500",
-                          "lineHeight": 24,
-                        },
-                      ]
-                    }
-                    testID="label"
-                  >
-                    B
-                  </Text>
-                </View>
+                  B
+                </Text>
               </View>
             </View>
-          </View>
+          </TouchableOpacity>
         </View>
       </View>
-    </RCTScrollView>
+    </ScrollView>
     <View
       style={
         Object {
@@ -270,15 +253,9 @@ exports[`base 1`] = `
         }
       }
     >
-      <View
-        accessible={true}
-        focusable={true}
-        isTVSelectable={true}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
+      <TouchableOpacity
+        activeOpacity={0.2}
+        disabled={true}
         testID="assessment-button"
       >
         <View
@@ -324,8 +301,8 @@ exports[`base 1`] = `
             Next
           </Text>
         </View>
-      </View>
+      </TouchableOpacity>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/__snapshots__/Start.spec.js.snap
+++ b/app/views/assessment/__tests__/__snapshots__/Start.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#F8F8FF"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -54,84 +53,82 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          >
-            <SvgXml
-              xml="
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <SvgXml
+            xml="
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M48.3723 23.6277C44.8687 20.1241 39.209 20.1241 35.7054 23.6277L35.0316 24.3352L34.3241 23.6277C30.8205 20.1241 25.1608 20.1241 21.6572 23.6277C18.1199 27.1313 18.1199 32.791 21.6235 36.2946L33.2124 47.8498C34.2231 48.8268 35.8064 48.8268 36.8171 47.8498L48.3723 36.2946C51.8759 32.791 51.8759 27.1313 48.3723 23.6277ZM45.5088 31.1403H43.4201V33.229C43.4201 33.9364 42.8474 34.5091 42.1399 34.5091C41.4324 34.5091 40.8597 33.9364 40.8597 33.229V31.1403H38.771C38.0636 31.1403 37.4909 30.5676 37.4909 29.8601C37.4909 29.1526 38.0636 28.5799 38.771 28.5799H40.8597V26.4912C40.8597 25.7838 41.4324 25.2111 42.1399 25.2111C42.8474 25.2111 43.4201 25.7838 43.4201 26.4912V28.5799H45.5088C46.2162 28.5799 46.7889 29.1526 46.7889 29.8601C46.8226 30.5676 46.2162 31.1403 45.5088 31.1403Z\\" fill=\\"#4754C5\\"/>
 </svg>
 "
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-            >
-              Answer questions about your symptoms and medical history to learn what to do next about COVID-19
-            </Text>
-            <Text
-              style={
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Answer questions about your symptoms and medical history to learn what to do next about COVID-19
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 17,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#2e2e2e",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 17,
-                    "lineHeight": 24,
+                    "marginBottom": 20,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-              testID="description"
-            >
-              Your information is private, anonymized, and encrypted. No data leaves your device unless you give permission.
-            </Text>
-          </View>
+                  undefined,
+                ],
+              ]
+            }
+            testID="description"
+          >
+            Your information is private, anonymized, and encrypted. No data leaves your device unless you give permission.
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -139,15 +136,9 @@ exports[`base 1`] = `
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -193,9 +184,9 @@ exports[`base 1`] = `
               Start
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Caregiver.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Caregiver.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#f8f8f8"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -54,27 +53,26 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          >
-            <SvgXml
-              xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <SvgXml
+            xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M23.8065 42.3764L19.3627 46.8699C19.247 46.9865 19.1554 47.1248 19.0931 47.2769C19.0309 47.429 18.9993 47.5918 19 47.7561C19.0008 47.9204 19.0339 48.083 19.0976 48.2345C19.1612 48.386 19.2541 48.5234 19.371 48.6389C19.4878 48.7545 19.6263 48.8459 19.7784 48.9078C19.9306 48.9698 20.0935 49.0012 20.2578 49.0001C20.4221 48.9991 20.5846 48.9656 20.736 48.9017C20.8874 48.8378 21.0247 48.7446 21.14 48.6276L25.5837 44.1341C25.6995 44.0175 25.7911 43.8792 25.8533 43.7272C25.9156 43.5751 25.9472 43.4122 25.9464 43.2479C25.9457 43.0836 25.9125 42.9211 25.8489 42.7696C25.7852 42.6181 25.6923 42.4806 25.5755 42.3651C25.4587 42.2496 25.3202 42.1582 25.168 42.0962C25.0158 42.0342 24.8529 42.0029 24.6886 42.0039C24.5243 42.005 24.3618 42.0384 24.2105 42.1023C24.0591 42.1663 23.9218 42.2594 23.8065 42.3764Z\\" fill=\\"#2434B6\\"/>
@@ -84,60 +82,59 @@ exports[`base 1`] = `
 <path d=\\"M34.0008 25.25C29.3691 25.25 25.8762 28.474 25.8762 32.7496C25.8762 33.0811 26.0079 33.399 26.2423 33.6334C26.4767 33.8678 26.7946 33.9995 27.1262 33.9995C27.4577 33.9995 27.7756 33.8678 28.01 33.6334C28.2444 33.399 28.3761 33.0811 28.3761 32.7496C28.3596 31.884 28.5848 31.0311 29.0264 30.2865C29.468 29.5419 30.1085 28.9351 30.8759 28.5345V47.7487C30.8759 48.0802 31.0076 48.3982 31.242 48.6326C31.4764 48.867 31.7944 48.9987 32.1259 48.9987C32.4574 48.9987 32.7753 48.867 33.0097 48.6326C33.2441 48.3982 33.3758 48.0802 33.3758 47.7487V38.3743H34.6257V47.7487C34.6257 48.0802 34.7574 48.3982 34.9918 48.6326C35.2262 48.867 35.5442 48.9987 35.8757 48.9987C36.2072 48.9987 36.5251 48.867 36.7595 48.6326C36.9939 48.3982 37.1256 48.0802 37.1256 47.7487V28.5344C37.893 28.9351 38.5335 29.5418 38.9751 30.2864C39.4167 31.031 39.6419 31.884 39.6255 32.7496C39.6255 33.0811 39.7571 33.399 39.9915 33.6334C40.226 33.8678 40.5439 33.9995 40.8754 33.9995C41.2069 33.9995 41.5248 33.8678 41.7592 33.6334C41.9936 33.399 42.1253 33.0811 42.1253 32.7496C42.1253 28.474 38.6325 25.25 34.0008 25.25Z\\" fill=\\"#2434B6\\"/>
 <path d=\\"M34.0006 23.9997C35.3812 23.9997 36.5005 22.8805 36.5005 21.4999C36.5005 20.1192 35.3812 19 34.0006 19C32.62 19 31.5007 20.1192 31.5007 21.4999C31.5007 22.8805 32.62 23.9997 34.0006 23.9997Z\\" fill=\\"#2434B6\\"/>
 </svg>"
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-            >
-              Notify Caregiver
-            </Text>
-            <Text
-              style={
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Notify Caregiver
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 17,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#2e2e2e",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 17,
-                    "lineHeight": 24,
+                    "marginBottom": 20,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-              testID="description"
-            >
-              Notify a healthcare provider in your long-term care facility. Living in a long-term care facility or nursing home may put you at risk for severe illness.
+                  undefined,
+                ],
+              ]
+            }
+            testID="description"
+          >
+            Notify a healthcare provider in your long-term care facility. Living in a long-term care facility or nursing home may put you at risk for severe illness.
 
 Tell a caregiver at the facility that you are sick and need to see a medical provider as soon as possible.
-            </Text>
-          </View>
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -145,15 +142,9 @@ Tell a caregiver at the facility that you are sick and need to see a medical pro
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -199,9 +190,9 @@ Tell a caregiver at the facility that you are sick and need to see a medical pro
               Next
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Complete.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Complete.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#f8f8f8"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -54,84 +53,82 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          >
-            <SvgXml
-              xml="
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <SvgXml
+            xml="
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M48.3723 23.6277C44.8687 20.1241 39.209 20.1241 35.7054 23.6277L35.0316 24.3352L34.3241 23.6277C30.8205 20.1241 25.1608 20.1241 21.6572 23.6277C18.1199 27.1313 18.1199 32.791 21.6235 36.2946L33.2124 47.8498C34.2231 48.8268 35.8064 48.8268 36.8171 47.8498L48.3723 36.2946C51.8759 32.791 51.8759 27.1313 48.3723 23.6277ZM45.5088 31.1403H43.4201V33.229C43.4201 33.9364 42.8474 34.5091 42.1399 34.5091C41.4324 34.5091 40.8597 33.9364 40.8597 33.229V31.1403H38.771C38.0636 31.1403 37.4909 30.5676 37.4909 29.8601C37.4909 29.1526 38.0636 28.5799 38.771 28.5799H40.8597V26.4912C40.8597 25.7838 41.4324 25.2111 42.1399 25.2111C42.8474 25.2111 43.4201 25.7838 43.4201 26.4912V28.5799H45.5088C46.2162 28.5799 46.7889 29.1526 46.7889 29.8601C46.8226 30.5676 46.2162 31.1403 45.5088 31.1403Z\\" fill=\\"#4754C5\\"/>
 </svg>
 "
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-            >
-              Thanks for keeping your community safe!
-            </Text>
-            <Text
-              style={
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Thanks for keeping your community safe!
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 17,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#2e2e2e",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 17,
-                    "lineHeight": 24,
+                    "marginBottom": 20,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-              testID="description"
-            >
-              By sharing your health status and location history anonymously with your community, you are being proactive about fighting the spread of COVID-19.
-            </Text>
-          </View>
+                  undefined,
+                ],
+              ]
+            }
+            testID="description"
+          >
+            By sharing your health status and location history anonymously with your community, you are being proactive about fighting the spread of COVID-19.
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -139,15 +136,9 @@ exports[`base 1`] = `
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={false}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -193,9 +184,9 @@ exports[`base 1`] = `
               Done
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Distancing.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Distancing.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#f8f8f8"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -54,27 +53,26 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          >
-            <SvgXml
-              xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <SvgXml
+            xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M23.8065 42.3764L19.3627 46.8699C19.247 46.9865 19.1554 47.1248 19.0931 47.2769C19.0309 47.429 18.9993 47.5918 19 47.7561C19.0008 47.9204 19.0339 48.083 19.0976 48.2345C19.1612 48.386 19.2541 48.5234 19.371 48.6389C19.4878 48.7545 19.6263 48.8459 19.7784 48.9078C19.9306 48.9698 20.0935 49.0012 20.2578 49.0001C20.4221 48.9991 20.5846 48.9656 20.736 48.9017C20.8874 48.8378 21.0247 48.7446 21.14 48.6276L25.5837 44.1341C25.6995 44.0175 25.7911 43.8792 25.8533 43.7272C25.9156 43.5751 25.9472 43.4122 25.9464 43.2479C25.9457 43.0836 25.9125 42.9211 25.8489 42.7696C25.7852 42.6181 25.6923 42.4806 25.5755 42.3651C25.4587 42.2496 25.3202 42.1582 25.168 42.0962C25.0158 42.0342 24.8529 42.0029 24.6886 42.0039C24.5243 42.005 24.3618 42.0384 24.2105 42.1023C24.0591 42.1663 23.9218 42.2594 23.8065 42.3764Z\\" fill=\\"#2434B6\\"/>
@@ -84,58 +82,57 @@ exports[`base 1`] = `
 <path d=\\"M34.0008 25.25C29.3691 25.25 25.8762 28.474 25.8762 32.7496C25.8762 33.0811 26.0079 33.399 26.2423 33.6334C26.4767 33.8678 26.7946 33.9995 27.1262 33.9995C27.4577 33.9995 27.7756 33.8678 28.01 33.6334C28.2444 33.399 28.3761 33.0811 28.3761 32.7496C28.3596 31.884 28.5848 31.0311 29.0264 30.2865C29.468 29.5419 30.1085 28.9351 30.8759 28.5345V47.7487C30.8759 48.0802 31.0076 48.3982 31.242 48.6326C31.4764 48.867 31.7944 48.9987 32.1259 48.9987C32.4574 48.9987 32.7753 48.867 33.0097 48.6326C33.2441 48.3982 33.3758 48.0802 33.3758 47.7487V38.3743H34.6257V47.7487C34.6257 48.0802 34.7574 48.3982 34.9918 48.6326C35.2262 48.867 35.5442 48.9987 35.8757 48.9987C36.2072 48.9987 36.5251 48.867 36.7595 48.6326C36.9939 48.3982 37.1256 48.0802 37.1256 47.7487V28.5344C37.893 28.9351 38.5335 29.5418 38.9751 30.2864C39.4167 31.031 39.6419 31.884 39.6255 32.7496C39.6255 33.0811 39.7571 33.399 39.9915 33.6334C40.226 33.8678 40.5439 33.9995 40.8754 33.9995C41.2069 33.9995 41.5248 33.8678 41.7592 33.6334C41.9936 33.399 42.1253 33.0811 42.1253 32.7496C42.1253 28.474 38.6325 25.25 34.0008 25.25Z\\" fill=\\"#2434B6\\"/>
 <path d=\\"M34.0006 23.9997C35.3812 23.9997 36.5005 22.8805 36.5005 21.4999C36.5005 20.1192 35.3812 19 34.0006 19C32.62 19 31.5007 20.1192 31.5007 21.4999C31.5007 22.8805 32.62 23.9997 34.0006 23.9997Z\\" fill=\\"#2434B6\\"/>
 </svg>"
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-            >
-              Distancing & PPE
-            </Text>
-            <Text
-              style={
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Distancing & PPE
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 17,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#2e2e2e",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 17,
-                    "lineHeight": 24,
+                    "marginBottom": 20,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-              testID="description"
-            >
-              Please follow your local, state, or national guidelines for social distancing and Personal Protection Equipment (PPE) like masks and/or gloves. No additional action is needed at this time.
-            </Text>
-          </View>
+                  undefined,
+                ],
+              ]
+            }
+            testID="description"
+          >
+            Please follow your local, state, or national guidelines for social distancing and Personal Protection Equipment (PPE) like masks and/or gloves. No additional action is needed at this time.
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -143,15 +140,9 @@ exports[`base 1`] = `
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -197,9 +188,9 @@ exports[`base 1`] = `
               Next
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Emergency.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Emergency.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#f8f8f8"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -49,92 +48,90 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                Object {
-                  "alignItems": "center",
-                },
-              ]
-            }
-          >
-            <SvgXml
-              xml="
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              Object {
+                "alignItems": "center",
+              },
+            ]
+          }
+        >
+          <SvgXml
+            xml="
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M48.3723 23.6277C44.8687 20.1241 39.209 20.1241 35.7054 23.6277L35.0316 24.3352L34.3241 23.6277C30.8205 20.1241 25.1608 20.1241 21.6572 23.6277C18.1199 27.1313 18.1199 32.791 21.6235 36.2946L33.2124 47.8498C34.2231 48.8268 35.8064 48.8268 36.8171 47.8498L48.3723 36.2946C51.8759 32.791 51.8759 27.1313 48.3723 23.6277ZM45.5088 31.1403H43.4201V33.229C43.4201 33.9364 42.8474 34.5091 42.1399 34.5091C41.4324 34.5091 40.8597 33.9364 40.8597 33.229V31.1403H38.771C38.0636 31.1403 37.4909 30.5676 37.4909 29.8601C37.4909 29.1526 38.0636 28.5799 38.771 28.5799H40.8597V26.4912C40.8597 25.7838 41.4324 25.2111 42.1399 25.2111C42.8474 25.2111 43.4201 25.7838 43.4201 26.4912V28.5799H45.5088C46.2162 28.5799 46.7889 29.1526 46.7889 29.8601C46.8226 30.5676 46.2162 31.1403 45.5088 31.1403Z\\" fill=\\"#4754C5\\"/>
 </svg>
 "
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
                   Object {
-                    "writingDirection": "ltr",
+                    "textAlign": "center",
                   },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    Object {
-                      "textAlign": "center",
-                    },
-                  ],
-                ]
-              }
-            >
-              Call Emergency Services
-            </Text>
-            <Text
-              style={
+                ],
+              ]
+            }
+          >
+            Call Emergency Services
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 17,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#2e2e2e",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 17,
+                    "marginBottom": 20,
+                  },
+                  Object {
+                    "fontSize": 18,
                     "lineHeight": 24,
+                    "textAlign": "center",
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    Object {
-                      "fontSize": 18,
-                      "lineHeight": 24,
-                      "textAlign": "center",
-                    },
-                  ],
-                ]
-              }
-              testID="description"
-            >
-               Based on your reported symptoms, you should seek care immediately.
-            </Text>
-          </View>
+                ],
+              ]
+            }
+            testID="description"
+          >
+             Based on your reported symptoms, you should seek care immediately.
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -142,15 +139,9 @@ exports[`base 1`] = `
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -199,9 +190,9 @@ exports[`base 1`] = `
               Call 911
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Isolate.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Isolate.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#f8f8f8"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -54,27 +53,26 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          >
-            <SvgXml
-              xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <SvgXml
+            xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M23.8065 42.3764L19.3627 46.8699C19.247 46.9865 19.1554 47.1248 19.0931 47.2769C19.0309 47.429 18.9993 47.5918 19 47.7561C19.0008 47.9204 19.0339 48.083 19.0976 48.2345C19.1612 48.386 19.2541 48.5234 19.371 48.6389C19.4878 48.7545 19.6263 48.8459 19.7784 48.9078C19.9306 48.9698 20.0935 49.0012 20.2578 49.0001C20.4221 48.9991 20.5846 48.9656 20.736 48.9017C20.8874 48.8378 21.0247 48.7446 21.14 48.6276L25.5837 44.1341C25.6995 44.0175 25.7911 43.8792 25.8533 43.7272C25.9156 43.5751 25.9472 43.4122 25.9464 43.2479C25.9457 43.0836 25.9125 42.9211 25.8489 42.7696C25.7852 42.6181 25.6923 42.4806 25.5755 42.3651C25.4587 42.2496 25.3202 42.1582 25.168 42.0962C25.0158 42.0342 24.8529 42.0029 24.6886 42.0039C24.5243 42.005 24.3618 42.0384 24.2105 42.1023C24.0591 42.1663 23.9218 42.2594 23.8065 42.3764Z\\" fill=\\"#2434B6\\"/>
@@ -84,58 +82,57 @@ exports[`base 1`] = `
 <path d=\\"M34.0008 25.25C29.3691 25.25 25.8762 28.474 25.8762 32.7496C25.8762 33.0811 26.0079 33.399 26.2423 33.6334C26.4767 33.8678 26.7946 33.9995 27.1262 33.9995C27.4577 33.9995 27.7756 33.8678 28.01 33.6334C28.2444 33.399 28.3761 33.0811 28.3761 32.7496C28.3596 31.884 28.5848 31.0311 29.0264 30.2865C29.468 29.5419 30.1085 28.9351 30.8759 28.5345V47.7487C30.8759 48.0802 31.0076 48.3982 31.242 48.6326C31.4764 48.867 31.7944 48.9987 32.1259 48.9987C32.4574 48.9987 32.7753 48.867 33.0097 48.6326C33.2441 48.3982 33.3758 48.0802 33.3758 47.7487V38.3743H34.6257V47.7487C34.6257 48.0802 34.7574 48.3982 34.9918 48.6326C35.2262 48.867 35.5442 48.9987 35.8757 48.9987C36.2072 48.9987 36.5251 48.867 36.7595 48.6326C36.9939 48.3982 37.1256 48.0802 37.1256 47.7487V28.5344C37.893 28.9351 38.5335 29.5418 38.9751 30.2864C39.4167 31.031 39.6419 31.884 39.6255 32.7496C39.6255 33.0811 39.7571 33.399 39.9915 33.6334C40.226 33.8678 40.5439 33.9995 40.8754 33.9995C41.2069 33.9995 41.5248 33.8678 41.7592 33.6334C41.9936 33.399 42.1253 33.0811 42.1253 32.7496C42.1253 28.474 38.6325 25.25 34.0008 25.25Z\\" fill=\\"#2434B6\\"/>
 <path d=\\"M34.0006 23.9997C35.3812 23.9997 36.5005 22.8805 36.5005 21.4999C36.5005 20.1192 35.3812 19 34.0006 19C32.62 19 31.5007 20.1192 31.5007 21.4999C31.5007 22.8805 32.62 23.9997 34.0006 23.9997Z\\" fill=\\"#2434B6\\"/>
 </svg>"
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#1f2c9b",
+                  "fontFamily": "IBMPlexSans-Bold",
+                  "fontSize": 28,
+                  "fontWeight": "500",
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#1f2c9b",
-                    "fontFamily": "IBMPlexSans-Bold",
-                    "fontSize": 28,
-                    "fontWeight": "500",
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-            >
-              Isolate Yourself
-            </Text>
-            <Text
-              style={
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Isolate Yourself
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#2e2e2e",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 17,
+                  "lineHeight": 24,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#2e2e2e",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 17,
-                    "lineHeight": 24,
+                    "marginBottom": 20,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-              testID="description"
-            >
-              You have some symptoms that may be related to COVID-19. Call your healthcare provider if your symptoms get worse. Start home isolation.
-            </Text>
-          </View>
+                  undefined,
+                ],
+              ]
+            }
+            testID="description"
+          >
+            You have some symptoms that may be related to COVID-19. Call your healthcare provider if your symptoms get worse. Start home isolation.
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -143,15 +140,9 @@ exports[`base 1`] = `
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -197,9 +188,9 @@ exports[`base 1`] = `
               Next
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/assessment/__tests__/endScreens/__snapshots__/Share.spec.js.snap
+++ b/app/views/assessment/__tests__/endScreens/__snapshots__/Share.spec.js.snap
@@ -10,9 +10,8 @@ exports[`base 1`] = `
     }
   }
 >
-  <RCTSafeAreaView
+  <SafeAreaView
     backgroundColor="#4051db"
-    emulateUnlessSupported={true}
     style={
       Object {
         "borderTopWidth": 0,
@@ -49,87 +48,85 @@ exports[`base 1`] = `
           ]
         }
       />
-      <RCTScrollView
+      <ScrollView
         style={
           Object {
             "flex": 1,
           }
         }
       >
-        <View>
-          <View
-            style={
-              Array [
-                Object {
-                  "borderTopWidth": 0,
-                  "padding": 20,
-                },
-                undefined,
-              ]
-            }
-          >
-            <SvgXml
-              xml="
+        <View
+          style={
+            Array [
+              Object {
+                "borderTopWidth": 0,
+                "padding": 20,
+              },
+              undefined,
+            ]
+          }
+        >
+          <SvgXml
+            xml="
 <svg width=\\"69\\" height=\\"69\\" viewBox=\\"0 0 69 69\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\">
 <circle cx=\\"34.5\\" cy=\\"34.5\\" r=\\"34.5\\" fill=\\"#D3D7F8\\"/>
 <path d=\\"M34.4487 30.8714C32.3095 30.8714 30.5593 32.6567 30.5593 34.8392C30.5593 37.0218 32.3095 38.8073 34.4487 38.8073C36.5879 38.8073 38.3382 37.0219 38.3382 34.8392C38.3382 32.6567 36.5879 30.8714 34.4487 30.8714ZM46.118 34.8391C46.118 28.2923 40.8665 22.9356 34.4487 22.9356C28.0309 22.9356 22.7795 28.2923 22.7795 34.8391C22.7795 39.2043 25.1134 43.0723 28.6137 45.156L30.5593 41.6841C28.2243 40.295 26.6691 37.8152 26.6691 34.8391C26.6691 30.4748 30.1693 26.9036 34.4487 26.9036C38.7285 26.9036 42.2283 30.4748 42.2283 34.8391C42.2283 37.8152 40.6731 40.295 38.3382 41.6841L40.2837 45.156C43.7838 43.0724 46.118 39.2043 46.118 34.8391ZM34.4487 15C23.7516 15 15 23.9276 15 34.8391C15 42.1801 18.889 48.5282 24.7244 52L26.6691 48.5282C22.0015 45.7509 18.889 40.6923 18.889 34.8392C18.889 26.1102 25.8916 18.968 34.4487 18.968C43.0059 18.968 50.0083 26.1102 50.0083 34.8392C50.0083 40.6923 46.8961 45.8497 42.2283 48.5282L44.1731 52C50.0083 48.5282 53.8974 42.1801 53.8974 34.8391C53.8974 23.9276 45.1458 15 34.4487 15Z\\" fill=\\"#4754C5\\"/>
 </svg>
 "
-            />
-            <Text
-              style={
+          />
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#ffffff",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 22,
+                  "lineHeight": 32,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#ffffff",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 22,
-                    "lineHeight": 32,
+                    "marginVertical": 30,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginVertical": 30,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-            >
-              Publish anonymized data
-            </Text>
-            <Text
-              style={
+                  undefined,
+                ],
+              ]
+            }
+          >
+            Publish anonymized data
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#ffffff",
+                  "fontFamily": "IBMPlexSans",
+                  "fontSize": 15,
+                  "lineHeight": 20,
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
                 Array [
                   Object {
-                    "color": "#ffffff",
-                    "fontFamily": "IBMPlexSans",
-                    "fontSize": 15,
-                    "lineHeight": 20,
+                    "marginBottom": 20,
                   },
-                  Object {
-                    "writingDirection": "ltr",
-                  },
-                  Array [
-                    Object {
-                      "marginBottom": 20,
-                    },
-                    undefined,
-                  ],
-                ]
-              }
-              testID="description"
-            >
-              Your anonymous data helps the Boston Public Health Commission analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.
+                  undefined,
+                ],
+              ]
+            }
+            testID="description"
+          >
+            Your anonymous data helps the Boston Public Health Commission analyze, track, and contain the spread of COVID-19. Your data will be aggregated that from other PathCheck users who choose to share.
 
 Your data contains your survey responses and zip code, but no additional or personally-identifying information.
 
 The Boston Public Health Commission will retain your anonymous data for a specific period of time.
-            </Text>
-          </View>
+          </Text>
         </View>
-      </RCTScrollView>
+      </ScrollView>
       <View
         style={
           Object {
@@ -137,15 +134,9 @@ The Boston Public Health Commission will retain your anonymous data for a specif
           }
         }
       >
-        <View
-          accessible={true}
-          focusable={true}
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
+        <TouchableOpacity
+          activeOpacity={0.2}
+          disabled={false}
           testID="assessment-button"
         >
           <View
@@ -191,9 +182,9 @@ The Boston Public Health Commission will retain your anonymous data for a specif
               I understand and consent
             </Text>
           </View>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </SafeAreaView>
 </View>
 `;

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NotificationsOff.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/NotificationsOff.spec.js.snap
@@ -161,24 +161,25 @@ exports[`notifications off screen matches snapshot 1`] = `
         >
           You will not receive notifications about possible exposures nor when new Health Departments are added in your area
         </Text>
-        <View
+        <TouchableOpacity
           accessibilityLabel="Allow Notifications"
           accessibilityRole="button"
           accessible={true}
-          focusable={true}
-          isTVSelectable={true}
+          activeOpacity={0.2}
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#ffffff",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "opacity": 1,
-              "paddingBottom": 25,
-              "paddingTop": 24,
-            }
+            Array [
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#ffffff",
+                "borderRadius": 8,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "paddingBottom": 25,
+                "paddingTop": 24,
+              },
+              undefined,
+            ]
           }
         >
           <Text
@@ -203,7 +204,7 @@ exports[`notifications off screen matches snapshot 1`] = `
           >
             Allow Notifications
           </Text>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
   </View>

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/SelectAuthority.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/SelectAuthority.spec.js.snap
@@ -161,24 +161,25 @@ exports[`select authority screen matches snapshot 1`] = `
         >
           Allow PathCheck to add your local Health Department or select one yourself to receive info about COVID-19 in your area
         </Text>
-        <View
+        <TouchableOpacity
           accessibilityLabel="Add Health Department"
           accessibilityRole="button"
           accessible={true}
-          focusable={true}
-          isTVSelectable={true}
+          activeOpacity={0.2}
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#ffffff",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "opacity": 1,
-              "paddingBottom": 25,
-              "paddingTop": 24,
-            }
+            Array [
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#ffffff",
+                "borderRadius": 8,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "paddingBottom": 25,
+                "paddingTop": 24,
+              },
+              undefined,
+            ]
           }
         >
           <Text
@@ -203,7 +204,7 @@ exports[`select authority screen matches snapshot 1`] = `
           >
             Add Health Department
           </Text>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
   </View>

--- a/app/views/main/ServiceOffScreens/__tests__/__snapshots__/TracingOff.spec.js.snap
+++ b/app/views/main/ServiceOffScreens/__tests__/__snapshots__/TracingOff.spec.js.snap
@@ -161,24 +161,25 @@ exports[`tracing off screen matches snapshot 1`] = `
         >
           PathCheck needs location access in Settings to privately save the places you visit
         </Text>
-        <View
+        <TouchableOpacity
           accessibilityLabel="Allow Location Access"
           accessibilityRole="button"
           accessible={true}
-          focusable={true}
-          isTVSelectable={true}
+          activeOpacity={0.2}
           style={
-            Object {
-              "alignItems": "center",
-              "backgroundColor": "#ffffff",
-              "borderColor": "#ffffff",
-              "borderRadius": 8,
-              "flexDirection": "row",
-              "justifyContent": "center",
-              "opacity": 1,
-              "paddingBottom": 25,
-              "paddingTop": 24,
-            }
+            Array [
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#ffffff",
+                "borderRadius": 8,
+                "flexDirection": "row",
+                "justifyContent": "center",
+                "paddingBottom": 25,
+                "paddingTop": 24,
+              },
+              undefined,
+            ]
           }
         >
           <Text
@@ -203,7 +204,7 @@ exports[`tracing off screen matches snapshot 1`] = `
           >
             Allow Location Access
           </Text>
-        </View>
+        </TouchableOpacity>
       </View>
     </View>
   </View>

--- a/jest/config.js
+++ b/jest/config.js
@@ -1,8 +1,14 @@
+const jestPreset = require('@testing-library/react-native/jest-preset');
+
 module.exports = {
-  preset: 'react-native',
+  preset: '@testing-library/react-native',
   setupFiles: [
     './jest/setupFile.js',
+    ...jestPreset.setupFiles,
     './node_modules/react-native-gesture-handler/jestSetup.js',
+  ],
+  transformIgnorePatterns: [
+    'node_modules/(?!(@react-native-community|react-native|react-native-pulse|react-native-linear-gradient)/)',
   ],
   rootDir: '../',
   testPathIgnorePatterns: [

--- a/jest/setupFile.js
+++ b/jest/setupFile.js
@@ -20,6 +20,7 @@ NativeModules.ExposureEventEmitter = NativeModules.ExposureEventEmitter || {
 };
 
 jest.mock('react-native-pulse');
+jest.mock('react-native-linear-gradient');
 jest.mock('@mauron85/react-native-background-geolocation');
 
 // Silence YellowBox useNativeDriver warning


### PR DESCRIPTION
Why:
----
When we are running our tests, most of the components that get rendered into a screen are `native` powered, making it difficult for test renderers to display them in a proper way. There is a set of presets that makes this possible. In an effort to make our integration and unit tests more similar to what the user is seeing and giving us more confidence in what we can test, we need to add the react-native testing library preset that will allow us to run matchers on what is being displayed to the user on the screen. This way our tests can be more similar to the actual behavior of the application. This aligns with the philosophy of the [react-native-testing-library](https://www.native-testing-library.com/)
This change was inspired because we started adding tests to the affected user flow for the BT flavor of the application. The logic that handled the validation is outside a test harness, and we need to get it to a comfortable spot while we keep making iterations to it.

**CAVEAT**
The `happy` path and the API test are left out since those are actively being changed, but this PR puts us in a position to add the tests as we develop those features ... more tests are on the way.

For Reviewers:
----
The diff is HUGE but mostly because of snapshots upgrades. Things worth noticing are an addition to the jest config to ignore some of the packages we use when transforming them before running the test suite and one more mock inclussion.

This Commit:
----
- Add preset `@testing-library/react-native` to jest config
- Update snapshots for the new renderer result
- Stop babel from transforming modules when the test runner is working
- Test behavior of the verification code validation logic against the verification server
