### PR TITLE
Add tests for the Share Diagnosis screen

### DIFF
--- a/app/ExposureHistoryContext.tsx
+++ b/app/ExposureHistoryContext.tsx
@@ -1,4 +1,9 @@
-import React, { createContext, useState, useEffect } from 'react';
+import React, {
+  createContext,
+  useState,
+  useEffect,
+  FunctionComponent,
+} from 'react';
 
 import {
   blankExposureHistory,
@@ -40,7 +45,6 @@ export interface ExposureEventsStrategy {
 }
 
 interface ExposureHistoryProps {
-  children: JSX.Element;
   exposureEventsStrategy: ExposureEventsStrategy;
 }
 
@@ -53,10 +57,10 @@ const blankHistoryConfig: ExposureCalendarOptions = {
 
 const blankHistory = blankExposureHistory(blankHistoryConfig);
 
-const ExposureHistoryProvider = ({
+const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
   children,
   exposureEventsStrategy,
-}: ExposureHistoryProps): JSX.Element => {
+}) => {
   const {
     exposureInfoSubscription,
     toExposureHistory,

--- a/app/TracingStrategyContext.tsx
+++ b/app/TracingStrategyContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -23,14 +23,13 @@ const TracingStrategyContext = createContext<
 >(undefined);
 
 interface TracingStrategyProps {
-  children: JSX.Element;
   strategy: TracingStrategy;
 }
 
-export const TracingStrategyProvider = ({
+export const TracingStrategyProvider: FunctionComponent<TracingStrategyProps> = ({
   children,
   strategy,
-}: TracingStrategyProps): JSX.Element => {
+}) => {
   const StrategyPermissionsProvider = strategy.permissionsProvider;
 
   return (

--- a/app/bt/AffectedUserFlow/CodeInput.tsx
+++ b/app/bt/AffectedUserFlow/CodeInput.tsx
@@ -61,7 +61,6 @@ const CodeInputScreen = (): JSX.Element => {
         const token = response.body.token;
         const fakeHMAC = 'abcd1234';
         API.postVerificationToken(token, fakeHMAC);
-
         navigation.navigate(Screens.AffectedUserPublishConsent);
       } else {
         setErrorMessage(showError(response.error));

--- a/app/bt/Home/index.spec.tsx
+++ b/app/bt/Home/index.spec.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import HomeScreen from './index';
+
+jest.mock('@react-navigation/native');
+(useFocusEffect as jest.Mock).mockReturnValue(jest.fn());
 
 describe('HomeScreen', () => {
   it('renders', () => {

--- a/app/gps/index.ts
+++ b/app/gps/index.ts
@@ -13,7 +13,7 @@ const gpsExposureEventContext: ExposureEventsStrategy = {
 };
 
 const gpsStrategy: TracingStrategy = {
-  name: 'bt',
+  name: 'gps',
   exposureEventsStrategy: gpsExposureEventContext,
   permissionsProvider: PermissionsProvider,
   homeScreenComponent: Home,

--- a/app/views/ExposureHistory/History.spec.tsx
+++ b/app/views/ExposureHistory/History.spec.tsx
@@ -5,6 +5,7 @@ import {
   cleanup,
   render,
 } from '@testing-library/react-native';
+import { useNavigation } from '@react-navigation/native';
 
 import { toExposureHistory } from '../../bt/exposureNotifications';
 import { DateTimeUtils } from '../../helpers';
@@ -15,6 +16,8 @@ import History from './History';
 const CALENDAR_LENGTH = 21;
 
 afterEach(cleanup);
+jest.mock('@react-navigation/native');
+(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() });
 
 describe('History', () => {
   it('renders', () => {

--- a/app/views/__tests__/Import.spec.js
+++ b/app/views/__tests__/Import.spec.js
@@ -9,10 +9,13 @@ import {
 import React from 'react';
 import { Linking } from 'react-native';
 import renderer from 'react-test-renderer';
+import { useFocusEffect } from '@react-navigation/native';
 
 import Import from '../Import';
 
 jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.mock('@react-navigation/native');
+useFocusEffect.mockReturnValue(jest.fn());
 
 const GoogleTakeOutAutoImport = require('../../helpers/GoogleTakeOutAutoImport');
 const General = require('../../helpers/General');

--- a/app/views/__tests__/Licenses.spec.tsx
+++ b/app/views/__tests__/Licenses.spec.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import 'react-native';
 import { render } from '@testing-library/react-native';
 import '@testing-library/jest-native/extend-expect';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 
 import { TracingStrategyProvider } from '../../TracingStrategyContext';
 import gpsStrategy from '../../gps';
 import btStrategy from '../../bt';
 
 import { LicensesScreen } from '../Licenses';
+
+jest.mock('@react-navigation/native');
+(useNavigation as jest.Mock).mockReturnValue({ navigate: jest.fn() });
+(useFocusEffect as jest.Mock).mockReturnValue({ navigate: jest.fn() });
 
 describe('LicensesScreen', () => {
   it('renders correctly', () => {

--- a/app/views/main/ServiceOffScreens/__tests__/NoAuthorities.spec.js
+++ b/app/views/main/ServiceOffScreens/__tests__/NoAuthorities.spec.js
@@ -3,6 +3,12 @@ import { render } from '@testing-library/react-native';
 
 import { NoAuthoritiesScreen } from '../';
 
+jest.mock('@react-navigation/native', () => {
+  return {
+    useFocusEffect: jest.fn(),
+  };
+});
+
 it('no authorities screen matches snapshot', () => {
   const { asJSON } = render(<NoAuthoritiesScreen />);
 

--- a/app/views/main/ServiceOffScreens/__tests__/NotificationsOff.spec.js
+++ b/app/views/main/ServiceOffScreens/__tests__/NotificationsOff.spec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { NotificationsOffScreen } from '../';
 
+jest.mock('@react-navigation/native');
+useFocusEffect.mockReturnValue(jest.fn());
 it('notifications off screen matches snapshot', () => {
   const { asJSON } = render(<NotificationsOffScreen />);
 

--- a/app/views/main/ServiceOffScreens/__tests__/SelectAuthority.spec.js
+++ b/app/views/main/ServiceOffScreens/__tests__/SelectAuthority.spec.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { useNavigation } from '@react-navigation/native';
 
 import { SelectAuthorityScreen } from '../';
 
+jest.mock('@react-navigation/native');
+useNavigation.mockReturnValue({ navigate: jest.fn() });
 it('select authority screen matches snapshot', () => {
   const { asJSON } = render(<SelectAuthorityScreen />);
 

--- a/app/views/main/ServiceOffScreens/__tests__/TracingOff.spec.js
+++ b/app/views/main/ServiceOffScreens/__tests__/TracingOff.spec.js
@@ -1,7 +1,11 @@
 import { render } from '@testing-library/react-native';
 import React from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { TracingOffScreen } from '../';
+
+jest.mock('@react-navigation/native');
+useFocusEffect.mockReturnValue(jest.fn());
 
 it('tracing off screen matches snapshot', () => {
   const { asJSON } = render(<TracingOffScreen />);

--- a/app/views/onboarding/LocationsPermissions.tsx
+++ b/app/views/onboarding/LocationsPermissions.tsx
@@ -67,11 +67,11 @@ const LocationsPermissions = (): JSX.Element => {
             <SvgXml xml={Icons.LocationPin} width={30} height={30} />
           </View>
           <Typography style={styles.headerText}>
-            {t('onboarding.notification_header')}
+            {t('onboarding.location_header')}
           </Typography>
           <View style={{ height: Spacing.medium }} />
           <Typography style={styles.contentText}>
-            {t('onboarding.notification_subheader')}
+            {t('onboarding.location_subheader')}
           </Typography>
         </ScrollView>
 

--- a/app/views/onboarding/ShareDiagnosis.bt.spec.tsx
+++ b/app/views/onboarding/ShareDiagnosis.bt.spec.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { render, cleanup, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import { TracingStrategyProvider } from '../../TracingStrategyContext';
+import ShareDiagnosis from './ShareDiagnosis';
+import { Screens } from '../../navigation';
+import { isPlatformiOS } from '../../Util';
+import gpsStrategy from '../../gps';
+
+afterEach(cleanup);
+
+jest.mock('@react-navigation/native');
+jest.mock('../../Util');
+jest.mock('../../COVIDSafePathsConfig', () => ({ isGPS: false }));
+
+describe('Home', () => {
+  describe('When tracing strategy is BT', () => {
+    describe('and platform is Android', () => {
+      it('navigates next to Enable Exposure Notfications ', () => {
+        const navigateMock = jest.fn();
+
+        (useNavigation as jest.Mock).mockReturnValue({
+          navigate: navigateMock,
+        });
+        (isPlatformiOS as jest.Mock).mockReturnValue(false);
+
+        const { getByLabelText } = render(<ShareDiagnosis />, {
+          wrapper: BTWrapper,
+        });
+
+        const button = getByLabelText('Set up my phone');
+        fireEvent.press(button);
+
+        expect(navigateMock).toHaveBeenCalledWith(
+          Screens.EnableExposureNotifications,
+        );
+      });
+    });
+
+    describe('and platform is iOS', () => {
+      it('navigates next to BT Notification Permissions', () => {
+        const navigateMock = jest.fn();
+
+        (useNavigation as jest.Mock).mockReturnValue({
+          navigate: navigateMock,
+        });
+        (isPlatformiOS as jest.Mock).mockReturnValue(true);
+        const { getByLabelText } = render(<ShareDiagnosis />, {
+          wrapper: BTWrapper,
+        });
+
+        const button = getByLabelText('Set up my phone');
+        fireEvent.press(button);
+
+        expect(navigateMock).toHaveBeenCalledWith(
+          Screens.NotificationPermissionsBT,
+        );
+      });
+    });
+  });
+});
+
+const BTWrapper: FunctionComponent = ({ children }) => {
+  return (
+    <TracingStrategyProvider strategy={gpsStrategy}>
+      {children}
+    </TracingStrategyProvider>
+  );
+};

--- a/app/views/onboarding/ShareDiagnosis.gps.spec.tsx
+++ b/app/views/onboarding/ShareDiagnosis.gps.spec.tsx
@@ -1,0 +1,70 @@
+import React, { FunctionComponent } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { render, cleanup, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import gpsStrategy from '../../gps';
+import { TracingStrategyProvider } from '../../TracingStrategyContext';
+import ShareDiagnosis from './ShareDiagnosis';
+import { Screens } from '../../navigation';
+import { isPlatformiOS } from '../../Util';
+
+afterEach(cleanup);
+
+jest.mock('@react-navigation/native');
+jest.mock('../../Util');
+jest.mock('../../COVIDSafePathsConfig', () => ({ isGPS: true }));
+
+describe('Home', () => {
+  describe('When tracing strategy is GPS', () => {
+    describe('and platform is Android', () => {
+      it('navigates next to Location Permissions ', async () => {
+        const navigateMock = jest.fn();
+
+        (useNavigation as jest.Mock).mockReturnValue({
+          navigate: navigateMock,
+        });
+        (isPlatformiOS as jest.Mock).mockReturnValue(false);
+        const { getByLabelText } = render(<ShareDiagnosis />, {
+          wrapper: GPSWrapper,
+        });
+
+        const button = getByLabelText('Set up my phone');
+        fireEvent.press(button);
+
+        expect(navigateMock).toHaveBeenCalledWith(
+          Screens.OnboardingLocationPermissions,
+        );
+      });
+    });
+
+    describe('and platform is iOS', () => {
+      it('navigates next to Notification Permissions ', () => {
+        const navigateMock = jest.fn();
+
+        (useNavigation as jest.Mock).mockReturnValue({
+          navigate: navigateMock,
+        });
+        (isPlatformiOS as jest.Mock).mockReturnValue(true);
+        const { getByLabelText } = render(<ShareDiagnosis />, {
+          wrapper: GPSWrapper,
+        });
+
+        const button = getByLabelText('Set up my phone');
+        fireEvent.press(button);
+
+        expect(navigateMock).toHaveBeenCalledWith(
+          Screens.OnboardingNotificationPermissions,
+        );
+      });
+    });
+  });
+});
+
+const GPSWrapper: FunctionComponent = ({ children }) => {
+  return (
+    <TracingStrategyProvider strategy={gpsStrategy}>
+      {children}
+    </TracingStrategyProvider>
+  );
+};

--- a/app/views/onboarding/ShareDiagnosis.tsx
+++ b/app/views/onboarding/ShareDiagnosis.tsx
@@ -13,16 +13,22 @@ const ShareDiagnosis: FunctionComponent = () => {
   const { t } = useTranslation();
   const { StrategyCopy, StrategyAssets } = useStrategyContent();
 
-  const gpsNext = () =>
-    navigation.navigate(
+  const gpsNext = () => {
+    return navigation.navigate(
       // Skip notification permissions on android
       isPlatformiOS()
         ? Screens.OnboardingNotificationPermissions
         : Screens.OnboardingLocationPermissions,
     );
+  };
 
-  const btNext = () => navigation.navigate(Screens.NotificationPermissionsBT);
-
+  const btNext = () => {
+    navigation.navigate(
+      isPlatformiOS()
+        ? Screens.NotificationPermissionsBT
+        : Screens.EnableExposureNotifications,
+    );
+  };
   const handleOnPressNext = isGPS ? gpsNext : btNext;
 
   const explanationScreenContent = {

--- a/jest/setupFile.js
+++ b/jest/setupFile.js
@@ -75,33 +75,3 @@ jest.mock('@react-navigation/stack', () => {
     },
   };
 });
-
-jest.mock('@react-navigation/native', () => {
-  return {
-    createAppContainer: jest
-      .fn()
-      .mockReturnValue(function NavigationContainer() {
-        return null;
-      }),
-    createDrawerNavigator: jest.fn(),
-    createMaterialTopTabNavigator: jest.fn(),
-    StackActions: {
-      push: jest
-        .fn()
-        .mockImplementation((x) => ({ ...x, type: 'Navigation/PUSH' })),
-      replace: jest
-        .fn()
-        .mockImplementation((x) => ({ ...x, type: 'Navigation/REPLACE' })),
-    },
-    NavigationActions: {
-      navigate: jest.fn().mockImplementation((x) => x),
-    },
-    useNavigation: () => {
-      return { navigate: jest.fn() };
-    },
-    useRoute: () => {
-      return {};
-    },
-    useFocusEffect: jest.fn(),
-  };
-});


### PR DESCRIPTION
Why:
----
We have some regression on the onboarding flow that needs to be corrected. Some patterns to test the different flavors
of the application(bt or gps) are not present in the test suite.

This Commit:
----
- Add tests for the ShareDiagnosis screen
- Separate test files dependant of the flavor config(gps or bt) into files with bt or gps extension
- Don't show notification permission for android bluetooth
- Delete global navigation mock

Co-Authored-By: Thomas G Paresi <tparesi@gmail.com>
Co-Authored-By: amandabeiner <aebeiner@gmail.com>
