### PR TITLE
Fetch verification certificate

### DIFF
--- a/__mocks__/react-native-simple-crypto.ts
+++ b/__mocks__/react-native-simple-crypto.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/app/bt/AffectedUserFlow/CodeInput.spec.tsx
+++ b/app/bt/AffectedUserFlow/CodeInput.spec.tsx
@@ -11,6 +11,8 @@ import { useNavigation } from '@react-navigation/native';
 import CodeInputScreen from './CodeInput';
 import { AffectedUserProvider } from './AffectedUserContext';
 import * as API from './verificationAPI';
+import * as NativeModule from '../nativeModule';
+import * as Hmac from './hmac';
 import { Screens } from '../../navigation';
 
 afterEach(cleanup);
@@ -33,18 +35,35 @@ describe('CodeInputScreen', () => {
     it('navigates to the affected user publish consent', async () => {
       const navigateSpy = jest.fn();
       (useNavigation as jest.Mock).mockReturnValue({ navigate: navigateSpy });
+      const verificationToken = 'verificationToken';
       const successTokenResponse = {
         kind: 'success' as const,
         body: {
-          token: 'token',
+          token: verificationToken,
           error: '',
           testDate: 'testDate',
-          testType: 'testType',
+          testType: 'confirmed' as const,
         },
       };
       const apiSpy = jest
-        .spyOn(API, 'postVerificationCode')
+        .spyOn(API, 'postCode')
         .mockResolvedValue(successTokenResponse);
+      jest.spyOn(NativeModule, 'getExposureKeys').mockResolvedValue([]);
+      jest.spyOn(Hmac, 'generateKey').mockResolvedValueOnce('key');
+      jest.spyOn(NativeModule, 'storeHMACKey').mockResolvedValueOnce();
+      const hmacDigest = 'hmacDigest';
+      jest.spyOn(Hmac, 'calculateHmac').mockResolvedValueOnce(hmacDigest);
+      const certificateReponse = {
+        kind: 'success' as const,
+        body: {
+          certificate: '',
+          error: '',
+        },
+      };
+      const postTokenSpy = jest
+        .spyOn(API, 'postTokenAndHmac')
+        .mockResolvedValueOnce(certificateReponse);
+
       const code = '12345678';
 
       const { getByTestId, getByLabelText } = render(
@@ -57,6 +76,10 @@ describe('CodeInputScreen', () => {
 
       await wait(() => {
         expect(apiSpy).toHaveBeenCalledWith(code);
+        expect(postTokenSpy).toHaveBeenCalledWith(
+          verificationToken,
+          hmacDigest,
+        );
         expect(navigateSpy).toHaveBeenCalledWith(
           Screens.AffectedUserPublishConsent,
         );
@@ -71,9 +94,7 @@ describe('CodeInputScreen', () => {
         kind: 'failure' as const,
         error,
       };
-      jest
-        .spyOn(API, 'postVerificationCode')
-        .mockResolvedValueOnce(wrongTokenResponse);
+      jest.spyOn(API, 'postCode').mockResolvedValueOnce(wrongTokenResponse);
 
       const { getByTestId, getByLabelText, getByText } = render(
         <AffectedUserProvider>
@@ -94,9 +115,7 @@ describe('CodeInputScreen', () => {
         kind: 'failure' as const,
         error,
       };
-      jest
-        .spyOn(API, 'postVerificationCode')
-        .mockResolvedValueOnce(wrongTokenResponse);
+      jest.spyOn(API, 'postCode').mockResolvedValueOnce(wrongTokenResponse);
 
       const { getByTestId, getByLabelText, getByText } = render(
         <AffectedUserProvider>
@@ -119,9 +138,7 @@ describe('CodeInputScreen', () => {
         kind: 'failure' as const,
         error,
       };
-      jest
-        .spyOn(API, 'postVerificationCode')
-        .mockResolvedValueOnce(wrongTokenResponse);
+      jest.spyOn(API, 'postCode').mockResolvedValueOnce(wrongTokenResponse);
 
       const { getByTestId, getByLabelText, getByText } = render(
         <AffectedUserProvider>

--- a/app/bt/AffectedUserFlow/exposureKey.ts
+++ b/app/bt/AffectedUserFlow/exposureKey.ts
@@ -1,0 +1,6 @@
+export interface ExposureKey {
+  key: string;
+  rollingPeriod: number;
+  rollingStartNumber: number;
+  transmissionRisk: number;
+}

--- a/app/bt/AffectedUserFlow/hmac.ts
+++ b/app/bt/AffectedUserFlow/hmac.ts
@@ -1,0 +1,45 @@
+import RNSimpleCrypto from 'react-native-simple-crypto';
+
+import { ExposureKey } from './exposureKey';
+
+export const generateKey = async (): Promise<string> => {
+  const arrayBuffer = await RNSimpleCrypto.utils.randomBytes(32);
+  return arrayBufferToString(arrayBuffer);
+};
+
+export const arrayBufferToString = (arrayBuffer: ArrayBuffer): string => {
+  return RNSimpleCrypto.utils.convertArrayBufferToUtf8(arrayBuffer);
+};
+
+export const calculateHmac = async (
+  exposureKeys: ExposureKey[],
+  keyHmac: string,
+): Promise<string> => {
+  const exposureKeyMessage = serializeKeys(exposureKeys);
+
+  const messageArrayBuffer = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(
+    exposureKeyMessage,
+  );
+
+  const keyArrayBuffer = RNSimpleCrypto.utils.convertUtf8ToArrayBuffer(keyHmac);
+
+  const signatureArrayBuffer = await RNSimpleCrypto.HMAC.hmac256(
+    messageArrayBuffer,
+    keyArrayBuffer,
+  );
+
+  return RNSimpleCrypto.utils.convertArrayBufferToBase64(signatureArrayBuffer);
+};
+
+const serializeKeys = (exposureKeys: ExposureKey[]) => {
+  return exposureKeys.map(serializeExposureKey).join(',');
+};
+
+const serializeExposureKey = ({
+  key,
+  rollingPeriod,
+  rollingStartNumber,
+  transmissionRisk,
+}: ExposureKey): string => {
+  return [key, rollingPeriod, rollingStartNumber, transmissionRisk].join('.');
+};

--- a/app/bt/AffectedUserFlow/verificationAPI.ts
+++ b/app/bt/AffectedUserFlow/verificationAPI.ts
@@ -30,16 +30,19 @@ type CodeVerificationSuccess = VerifiedCodeResponse;
 export type CodeVerificationError =
   | 'InvalidCode'
   | 'VerificationCodeUsed'
+  | 'InvalidVerificationUrl'
   | 'Unknown';
+
+type TestType = 'confirmed' | 'likely';
 
 interface VerifiedCodeResponse {
   error: string;
   testDate: string;
-  testType: string;
+  testType: TestType;
   token: Token;
 }
 
-export const postVerificationCode = async (
+export const postCode = async (
   code: string,
 ): Promise<NetworkResponse<CodeVerificationSuccess, CodeVerificationError>> => {
   const data = {
@@ -64,7 +67,7 @@ export const postVerificationCode = async (
       return { kind: 'success', body };
     } else {
       switch (json.error) {
-        case 'internal serer error':
+        case 'internal server error':
           return { kind: 'failure', error: 'InvalidCode' };
         case 'verification code used':
           return { kind: 'failure', error: 'VerificationCodeUsed' };
@@ -77,19 +80,24 @@ export const postVerificationCode = async (
   }
 };
 
-type VerificationTokenSuccess = 'Success';
+interface TokenVerificationResponse {
+  certificate: Token;
+  error: string;
+}
 
-type VerificationTokenFailure = 'InvalidToken' | 'Unknown';
+type TokenVerificationSuccess = TokenVerificationResponse;
 
-export const postVerificationToken = async (
+export type TokenVerificationError = 'TokenMetaDataMismatch' | 'Unknown';
+
+export const postTokenAndHmac = async (
   token: Token,
-  hmac: string,
+  hmacDigest: string,
 ): Promise<
-  NetworkResponse<VerificationTokenSuccess, VerificationTokenFailure>
+  NetworkResponse<TokenVerificationSuccess, TokenVerificationError>
 > => {
   const data = {
     token,
-    ekeyhmac: hmac,
+    ekeyhmac: hmacDigest,
   };
 
   try {
@@ -101,11 +109,15 @@ export const postVerificationToken = async (
 
     const json = await response.json();
     if (response.ok) {
-      return { kind: 'success', body: 'Success' };
+      const body = {
+        certificate: json.certificate,
+        error: json.error,
+      };
+      return { kind: 'success', body };
     } else {
       switch (json.error) {
-        case 'invalid_token': {
-          return { kind: 'failure', error: 'InvalidToken' };
+        case 'token metadata mismatch': {
+          return { kind: 'failure', error: 'TokenMetaDataMismatch' };
         }
         default: {
           return { kind: 'failure', error: 'Unknown' };

--- a/app/bt/nativeModule.ts
+++ b/app/bt/nativeModule.ts
@@ -8,7 +8,9 @@ import { ENPermissionStatus } from './PermissionsContext';
 import { ExposureInfo } from '../exposureHistory';
 import { ENDiagnosisKey } from '../views/Settings/ENLocalDiagnosisKeyScreen';
 import { RawExposure, toExposureInfo } from './exposureNotifications';
+import { ExposureKey } from './AffectedUserFlow/exposureKey';
 
+// Event Subscriptions
 export const subscribeToExposureEvents = (
   cb: (exposureInfo: ExposureInfo) => void,
 ): EventSubscription => {
@@ -52,10 +54,9 @@ const toStatus = (data: string[]): ENPermissionStatus => {
   return result;
 };
 
-const permissionsModule = NativeModules.ENPermissionsModule;
-const keySubmissionModule = NativeModules.KeySubmissionModule;
-
 // Permissions Module
+const permissionsModule = NativeModules.ENPermissionsModule;
+
 export const requestAuthorization = async (
   cb: (data: string) => void,
 ): Promise<void> => {
@@ -72,10 +73,41 @@ export const getCurrentENPermissionsStatus = async (
 };
 
 // Key Submission Module
+const keySubmissionModule = NativeModules.KeySubmissionModule;
+
 export const submitDiagnosisKeys = async (
   cb: (errorMessage: string, successMessage: string) => void,
 ): Promise<void> => {
   keySubmissionModule.postDiagnosisKeys(cb);
+};
+
+// Exposure Key Module
+const exposureKeyModule = NativeModules.ExposureKeyModule;
+
+export const getExposureKeys = async (): Promise<ExposureKey[]> => {
+  const keys: RawExposureKey[] = await exposureKeyModule.fetchExposureKeys();
+  return keys.map(toExposureKey);
+};
+
+interface RawExposureKey {
+  key: null | string;
+  rollingPeriod: number;
+  rollingStartNumber: number;
+  transmissionRisk: number;
+}
+
+const toExposureKey = (rawExposureKey: RawExposureKey): ExposureKey => {
+  return {
+    key: rawExposureKey.key || '',
+    rollingPeriod: rawExposureKey.rollingPeriod,
+    rollingStartNumber: rawExposureKey.rollingStartNumber,
+    transmissionRisk: rawExposureKey.transmissionRisk,
+  };
+};
+
+export const storeHMACKey = async (hmacKey: string): Promise<void> => {
+  // exposureKeyModule.storeHMACKey(hmacKey);
+  console.log('storing hmacKey', hmacKey);
 };
 
 // Debug Module

--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -306,6 +306,26 @@ final class ExposureManager: NSObject {
     }
   }
   
+  @objc func fetchExposureKeys(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    manager.getDiagnosisKeys { (keys, error) in
+      if let error = error {
+        print(error)
+        reject("no_exposure_keys", "There was an error fetching the exposure keys \(error)", error);
+      } else {
+        resolve((keys ?? []).map { $0.asDictionary })
+      }
+    }
+  }
+
+  @objc func storeHMACKey(HMACKey: String, callback: @escaping RCTResponseSenderBlock) {
+    BTSecureStorage.shared.HMACKey = HMACKey
+    if BTSecureStorage.shared.HMACKey == HMACKey {
+      callback([BTSecureStorage.shared.HMACKey])
+      callback([NSNull(), String.genericSuccess])
+    } else {
+      callback([GenericError.unknown, NSNull()])
+    }
+  }
 }
 
 private extension ExposureManager {

--- a/ios/BT/Extensions/Foundation/Notification+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Notification+Extensions.swift
@@ -1,7 +1,8 @@
 extension Notification.Name {
   public static let StorageTestResultsDidChange = Notification.Name(rawValue: "BTSecureStorageTestResultsDidChange")
   public static let StorageExposureDetectionErrorLocalizedDescriptionDidChange = Notification.Name(rawValue: "BTSecureStorageExposureDetectionErrorLocalizedDescriptionDidChange")
-  public static let dateLastPerformedFileCapacityResetDidChange = Notification.Name(rawValue: "BTSecureStoragedateLastPerformedFileCapacityResetDidChange")
+  public static let dateLastPerformedFileCapacityResetDidChange = Notification.Name(rawValue: "BTSecureStorageDateLastPerformedExposureDetectionDidChange")
+  public static let HMACKeyDidChange = Notification.Name(rawValue: "BTSecureStorageHMACKeyDidChange")
   public static let ExposuresDidChange = Notification.Name(rawValue: "onExposureRecordUpdated")
   public static let AuthorizationStatusDidChange = Notification.Name(rawValue: "onEnabledStatusUpdated")
   public static let remainingDailyFileProcessingCapacityDidChange = Notification.Name(rawValue: "remainingDailyFileProcessingCapacityDidChange")

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -10,6 +10,7 @@ extension String {
   static let keyPathExposureDetectionErrorLocalizedDescription = "exposureDetectionErrorLocalizedDescription"
   static let keyPathdateLastPerformedFileCapacityReset = "dateLastPerformedFileCapacityReset"
   static let keyPathExposures = "exposures"
+  static let keyPathHMACKey = "HMACKey"
   static let postKeysUrl = "POST_DIAGNOSIS_KEYS_URL"
   static let downloadBaseUrl = "DOWNLOAD_BASE_URL"
   static let downloadPath = "DOWNLOAD_PATH"

--- a/ios/BT/Storage/BTSecureStorage.swift
+++ b/ios/BT/Storage/BTSecureStorage.swift
@@ -71,6 +71,10 @@ final class BTSecureStorage: SafePathsSecureStorage {
              notificationName: .dateLastPerformedFileCapacityResetDidChange, defaultValue: nil)
   var dateLastPerformedFileCapacityReset: Date?
 
+  @Persisted(keyPath: .keyPathHMACKey,
+             notificationName: .HMACKeyDidChange, defaultValue: "")
+  var HMACKey: String
+
   @Persisted(keyPath: .keyPathExposureDetectionErrorLocalizedDescription, notificationName:
     .StorageExposureDetectionErrorLocalizedDescriptionDidChange, defaultValue: .default)
   var exposureDetectionErrorLocalizedDescription: String

--- a/ios/BT/bridge/ExposureKeyModule.m
+++ b/ios/BT/bridge/ExposureKeyModule.m
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTLog.h>
+#import <React/RCTBridgeModule.h>
+#import "BT-Swift.h"
+
+@interface ExposureKeyModule: NSObject <RCTBridgeModule>
+@end
+
+@implementation ExposureKeyModule
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(storeHMACKey: (NSString *)HMACKey withCallback:(RCTResponseSenderBlock)callback) {
+  [[ExposureManager shared] storeHMACKeyWithHMACKey:HMACKey callback:callback];
+}
+
+RCT_REMAP_METHOD(fetchExposureKeys,
+                fetchExposureKeysWithResolver:(RCTPromiseResolveBlock)resolve
+                rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [[ExposureManager shared] fetchExposureKeysWithResolve:resolve reject:reject];
+}
+
+@end

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		C53FD0B824719AD1006D3268 /* IBMPlexSans-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1423A22FF9E04F88BEEE42D6 /* IBMPlexSans-Thin.ttf */; };
 		C53FD0B924719AD1006D3268 /* IBMPlexSans-ThinItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FF7D8132928346A2904ED363 /* IBMPlexSans-ThinItalic.ttf */; };
 		C53FD0BA24719AD1006D3268 /* IBMPlexSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 89D241005D9647C4B0586127 /* IBMPlexSans.ttf */; };
+		C550A66624B7906F002CA7F2 /* ExposureKeyModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C550A66524B7906F002CA7F2 /* ExposureKeyModule.m */; };
 		C58463E42486C51100BCB842 /* ExposureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58463E32486C51100BCB842 /* ExposureManager.swift */; };
 		C5850A64247D5A41007A596B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C5850A63247D5A41007A596B /* Images.xcassets */; };
 		C5AA24D824768FFF00BA0A99 /* COVIDSafePathsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* COVIDSafePathsTests.m */; };
@@ -360,6 +361,7 @@
 		C504FDC5249D15990024219C /* GPS-Production.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "GPS-Production.entitlements"; sourceTree = "<group>"; };
 		C53FD0C124719AD1006D3268 /* BT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C53FD0C224719AD2006D3268 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C550A66524B7906F002CA7F2 /* ExposureKeyModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExposureKeyModule.m; sourceTree = "<group>"; };
 		C56190A12485332E009A6756 /* BT-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BT-Bridging-Header.h"; sourceTree = "<group>"; };
 		C58463E32486C51100BCB842 /* ExposureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureManager.swift; sourceTree = "<group>"; };
 		C5850A63247D5A41007A596B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -872,6 +874,7 @@
 			isa = PBXGroup;
 			children = (
 				B596C0712488127D00943B79 /* ENPermissionsModule.m */,
+				C550A66524B7906F002CA7F2 /* ExposureKeyModule.m */,
 				B57BA02624A3CD3F00FBAA05 /* KeySubmissionModule.m */,
 				B5FB3B42248BD61A001DB1D5 /* DebugMenuModule.m */,
 				B5582D43249943DE001458A9 /* ExposureEventEmitter.m */,
@@ -1374,6 +1377,7 @@
 				B5FBB0D724916DE100433980 /* Notification+Extensions.swift in Sources */,
 				B57BA02724A3CD3F00FBAA05 /* KeySubmissionModule.m in Sources */,
 				B54CBF26249A72E700218477 /* Region.swift in Sources */,
+				C550A66624B7906F002CA7F2 /* ExposureKeyModule.m in Sources */,
 				B54CBF32249A738500218477 /* IndexFileRequests.swift in Sources */,
 				B52D88C4248F10FD0071ED51 /* BTSecureStorage.swift in Sources */,
 				B5FC37CC2489B251006474EB /* Result.swift in Sources */,
@@ -1821,7 +1825,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEAD_CODE_STRIPPING = NO;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 79Z8HUPGC3;
+				DEVELOPMENT_TEAM = 6R7GW6VJ2A;
 				INFOPLIST_FILE = BT/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1834,8 +1838,9 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.modulemap\" -Xcc -fmodule-map-file=\"${PODS_CONFIGURATION_BUILD_DIR}/RealmSwift/RealmSwift.modulemap\" -Xcc -fmodule-map-file=\"${PODS_CONFIGURATION_BUILD_DIR}/ZIPFoundation/ZIPFoundation.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Private/Realm/Realm.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/SSZipArchive/SSZipArchive.modulemap\" -D DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = org.pathcheck.mn.bt;
 				PRODUCT_NAME = BT;
-				PROVISIONING_PROFILE_SPECIFIER = "match Development org.pathcheck.bt";
+				PROVISIONING_PROFILE_SPECIFIER = "pathcheck-dev-john";
 				SWIFT_OBJC_BRIDGING_HEADER = "BT/BT-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1848,11 +1853,11 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "BT/BT-Production.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 79Z8HUPGC3;
+				DEVELOPMENT_TEAM = 6R7GW6VJ2A;
 				INFOPLIST_FILE = BT/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1865,8 +1870,9 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.modulemap\" -Xcc -fmodule-map-file=\"${PODS_CONFIGURATION_BUILD_DIR}/RealmSwift/RealmSwift.modulemap\" -Xcc -fmodule-map-file=\"${PODS_CONFIGURATION_BUILD_DIR}/ZIPFoundation/ZIPFoundation.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Private/Realm/Realm.modulemap\" -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/SSZipArchive/SSZipArchive.modulemap\"";
+				PRODUCT_BUNDLE_IDENTIFIER = org.pathcheck.mn.bt;
 				PRODUCT_NAME = BT;
-				PROVISIONING_PROFILE_SPECIFIER = "match Development org.pathcheck.bt";
+				PROVISIONING_PROFILE_SPECIFIER = "pathcheck-mn-bt-appstore";
 				SWIFT_OBJC_BRIDGING_HEADER = "BT/BT-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -203,6 +203,8 @@ PODS:
     - React
   - react-native-safe-area-context (3.0.5):
     - React
+  - react-native-simple-crypto (0.2.12):
+    - React
   - react-native-splash-screen (3.2.0):
     - React
   - react-native-uuid-generator (6.1.1):
@@ -316,6 +318,7 @@ DEPENDENCIES:
   - "react-native-geolocation (from `../node_modules/@react-native-community/geolocation`)"
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-simple-crypto (from `../node_modules/react-native-simple-crypto`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
   - react-native-uuid-generator (from `../node_modules/react-native-uuid-generator`)
   - "react-native-viewpager (from `../node_modules/@react-native-community/viewpager`)"
@@ -408,6 +411,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-simple-crypto:
+    :path: "../node_modules/react-native-simple-crypto"
   react-native-splash-screen:
     :path: "../node_modules/react-native-splash-screen"
   react-native-uuid-generator:
@@ -494,6 +499,7 @@ SPEC CHECKSUMS:
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-netinfo: cd479ab1b67cdd1cb1403a99ecdb24190a6dd7ef
   react-native-safe-area-context: e768fca90207ee68924b3d0877633f2ce9cc9d68
+  react-native-simple-crypto: f37bae3fba012c1b389f1c68a3e4f68fe4d9b523
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-uuid-generator: 82ffa2a1cac94242ebed52c4dedc5044d3412717
   react-native-viewpager: a7b438ca32c57b2614ece2a123e7fe116f743131
@@ -530,4 +536,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d641f53b267b5fdc2398388c8211cf0739401d29
 
-COCOAPODS: 1.9.2
+COCOAPODS: 1.9.3

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-native-safe-area-context": "^3.0.5",
     "react-native-screens": "^2.8.0",
     "react-native-share": "^3.1.0",
+    "react-native-simple-crypto": "^0.2.12",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.0.3",
     "react-native-uuid-generator": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,7 +2051,7 @@ base-64@0.1.0, base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
 
-base64-js@^1.1.2, base64-js@^1.2.3:
+base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
 
@@ -4363,6 +4363,11 @@ he@^1.1.0:
 hermes-engine@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
+
+hex-lite@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/hex-lite/-/hex-lite-1.5.0.tgz#482db64f673dcacdb8be93c629a799ce5a76b24d"
+  integrity sha512-bXFMCFoKcksmJ1kDRq6B0+Go5Wgq84Dq/3rX99+0OzBQZKUBEMLguPd1lZSpvmzJACb516n07eyswF4KHAF9cg==
 
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
@@ -7279,6 +7284,14 @@ react-native-share@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-3.3.2.tgz#06d1d3f14ba8eeb95e7e94e4db6a286e9902bd29"
 
+react-native-simple-crypto@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/react-native-simple-crypto/-/react-native-simple-crypto-0.2.12.tgz#942d050950fa60b0191fd69ddd6807fe6de958aa"
+  integrity sha512-zjeYa7eJ4agPyj1UZhABjfPzmT6nwckzVwfN1XuPAylo98OImfspDMtBSeeGp0qh6GUF8Kd/q5WwJGKbKUB/3Q==
+  dependencies:
+    base64-js "^1.3.0"
+    hex-lite "^1.5.0"
+
 react-native-splash-screen@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
@@ -7485,6 +7498,7 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable
 readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"


### PR DESCRIPTION
Why:
After verifying the users provided code to the verification server and receiving a token, we need to generated a hashed version of the users keys (and potentially metadata) and post this to verification server to receive a certificate which we can use to post exposure keys to the key server.

This commit:
Introduces the logic for generating and HMAC of the current exposure keys and posting this data along with the previously received token to api/certificate.

We introduced react-native-simple-crypto for calculating the HMAC hashing on the JS side as this will reduce the amount of code that the native layer will need to implement. In a future iteration, it might make sense to do all of the cryptographic logic in the native layer as this will allow us to remove the dependency react-native-simple-crypto

A native module promise, `ExposureKeyModule.fetchExposureKeys`, was added to fetch the exposure keys and serialize them to send the encrypted payload to the verification server.

Next Steps:
- Save the hmacKey to `realm`
- Save the certificate generated on the verification server to `realm`
- Post the exposure keys to the `GAEN` with the certificate and the HMAC key
- Handle errors on the exposure keys, post exposure data flow
- Add in user metadata to the request that goes to the Verification Server

Co-Authored-By: Alejandro Dustet<aledustet@gmail.com>