### PR TITLE
GPS 10 -> 100 feet in Exposure Notification Copy

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -118,7 +118,10 @@
   "exposure_datum": {
     "possible": {
       "duration": "Possible Exposure Time: {{duration}}",
-      "explanation": "For {{duration}}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.",
+      "explanation": {
+        "gps": "For {{duration}} throughout this day, your phone was within 100 feet of someone who was later diagnosed with COVID-19.",
+        "bt": "For {{duration}}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis."
+      },
       "what_next": "What should I do next?"
     },
     "no_known": {

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -21,6 +21,7 @@ import {
   Buttons,
   Spacing,
 } from '../../styles';
+import { isGPS } from '../../COVIDSafePathsConfig';
 
 interface ExposureDatumDetailsProps {
   exposureDatum: ExposureDatum;
@@ -56,9 +57,14 @@ const PossibleExposureDetail = ({
   const exposureTime = t('exposure_datum.possible.duration', {
     duration: exposureDurationText,
   });
-  const explanationContent = t('exposure_datum.possible.explanation', {
-    duration: exposureDurationText,
-  });
+  const explanationContent = t(
+    isGPS
+      ? 'exposure_datum.possible.explanation.gps'
+      : 'exposure_datum.possible.explanation.bt',
+    {
+      duration: exposureDurationText,
+    },
+  );
   const nextStepsButtonText = t('exposure_datum.possible.what_next');
 
   const handleOnPressNextSteps = () => {


### PR DESCRIPTION
Makes "100" feet copy used in gps flavor of app for Exposure Notification body.
Aligns GPS copy with figma.


Before             |  After
:-------------------------:|:-------------------------:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/87345677-673d9000-c51e-11ea-8ac3-dfcf7a356f44.png"> |<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/87345782-8a683f80-c51e-11ea-8cb1-a7930e8ada1b.png">




