### PR TITLE
Fix screen background color on onboarding etc

### DIFF
--- a/app/styles/layout.ts
+++ b/app/styles/layout.ts
@@ -5,9 +5,6 @@ import * as Spacing from './spacing';
 export const screenWidth = Dimensions.get('window').width;
 export const screenHeight = Dimensions.get('window').height;
 
-// iphone 8
-export const smallScreenWidth = 375;
-
 export const baseScreenPadding = Spacing.xSmall;
 
 export const xxSmallWidth = 0.05 * screenWidth;

--- a/app/views/common/ExplanationScreen.tsx
+++ b/app/views/common/ExplanationScreen.tsx
@@ -17,7 +17,6 @@ import { Typography } from '../../components/Typography';
 import {
   Buttons,
   Colors,
-  Layout,
   Spacing,
   Iconography,
   Typography as TypographyStyles,
@@ -105,16 +104,12 @@ const ExplanationScreen = ({
     ...explanationScreenStyles.secondaryButtonContainerStyle,
   };
 
-  const smallScreenWidth = Layout.screenWidth <= Layout.smallScreenWidth;
-
   return (
     <View style={styles.outerContainer}>
-      {smallScreenWidth ? null : (
-        <ImageBackground
-          source={explanationScreenContent.backgroundImage}
-          style={[styles.background, explanationScreenStyles.backgroundStyle]}
-        />
-      )}
+      <ImageBackground
+        source={explanationScreenContent.backgroundImage}
+        style={[styles.background, explanationScreenStyles.backgroundStyle]}
+      />
       <View style={styles.content}>
         <ScrollView
           alwaysBounceVertical={false}


### PR DESCRIPTION
 ### Testing Notes ###
- Run a fresh install of the app, and navigate through the onboarding
screens.
- Expect all screens to have legible copy
- Navigate through the affected user flow intro screens
- Expect all screens to have legible copy

 ### Fixed Issues ###
Fixes issue where text was not visible on some devices because it was a
white background with nearly white text.

#### Linked issues:
[Trello](https://trello.com/c/ms89BJfQ/180-as-a-user-i-want-to-be-able-to-see-all-text-on-the-screen-during-onboarding-process-so-i-know-what-i-am-agreeing-to)

Note that we may want to do another pass to make sure that the text
does not interact with background images on small devices with enlarged
accessibility text.


#### Screenshots:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-13 at 17 46 17](https://user-images.githubusercontent.com/21161427/87357878-c86f5e80-c532-11ea-8e38-fc6283f100ef.png)


Co-Authored-By: jeffstolz <jstolz123@gmail.com>
Co-Authored-By: tparesi <tparesi@gmail.com>