### PR TITLE
Make exposure flow next steps button more obvious

### DIFF
--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -73,8 +73,6 @@ const PossibleExposureDetail = ({
         <View style={styles.contentContainer}>
           <Typography style={styles.content}>{explanationContent}</Typography>
         </View>
-      </View>
-      <View style={styles.ctaContainer}>
         <TouchableOpacity
           testID={'exposure-history-next-steps-button'}
           style={styles.nextStepsButton}
@@ -148,15 +146,12 @@ const styles = StyleSheet.create({
   content: {
     ...TypographyStyles.secondaryContent,
   },
-  ctaContainer: {
-    marginBottom: Spacing.medium,
-  },
   nextStepsButton: {
-    ...Buttons.largeBlueOutline,
+    ...Buttons.largeBlue,
     marginTop: Spacing.xLarge,
   },
   nextStepsButtonText: {
-    ...TypographyStyles.buttonTextDark,
+    ...TypographyStyles.buttonTextLight,
   },
 });
 


### PR DESCRIPTION
 ### Description ###
Fixes issue where the "What should I do next?" button was not obvious when positioned below the fold. This change moves the button to inside the exposure details section and changes its color to be blue.

 ### Testing Notes ###
- Simulate an exposure on an iPhone SE (or another small format phone)
- Select the date of the exposure
- Expect the screen to match the attached screenshot

 ### Fixed Issues ###
[Trello Card](https://trello.com/c/H5xikSy3/59-as-a-user-i-need-to-see-the-what-should-i-do-next-button-on-the-screen-when-i-am-looking-at-a-day-with-an-exposure-event
)
Co-Authored-By: jeffstolz <jeffstolz@gmail.com>

#### Screenshots:

<img width="559" alt="Screen Shot 2020-07-14 at 10 40 24 AM" src="https://user-images.githubusercontent.com/21161427/87439324-a3c0c880-c5be-11ea-9eca-482bec44debf.png">

