### PR TITLE
Move the constants/authorities file to .env

### DIFF
--- a/.env.gps
+++ b/.env.gps
@@ -9,6 +9,7 @@
 
 TRACING_STRATEGY=gps
 AUTHORITIES_YAML_ROUTE=https://raw.githubusercontent.com/Path-Check/trusted-authorities/master/staging/authorities.1.0.1.yaml
+AUTHORITIES_LIST_URL=https://raw.githubusercontent.com/Path-Check/safeplaces-frontend/develop/healthcare-authorities.yaml
 
 flag_google_import=true
 flag_custom_url=true

--- a/.env.gps.release
+++ b/.env.gps.release
@@ -6,3 +6,4 @@
 
 TRACING_STRATEGY=gps
 AUTHORITIES_YAML_ROUTE=https://raw.githubusercontent.com/Path-Check/trusted-authorities/master/production/authorities.1.0.1.yaml
+AUTHORITIES_LIST_URL=https://raw.githubusercontent.com/Path-Check/safeplaces-frontend/develop/healthcare-authorities.yaml

--- a/.env.gps.staging
+++ b/.env.gps.staging
@@ -10,6 +10,7 @@
 
 TRACING_STRATEGY=gps
 AUTHORITIES_YAML_ROUTE=https://raw.githubusercontent.com/Path-Check/trusted-authorities/master/staging/authorities.1.0.1.yaml
+AUTHORITIES_LIST_URL=https://raw.githubusercontent.com/Path-Check/safeplaces-frontend/develop/healthcare-authorities.yaml
 
 # flag_google_import=true
 flag_custom_url=true

--- a/App.js
+++ b/App.js
@@ -3,7 +3,7 @@ import { MenuProvider } from 'react-native-popup-menu';
 import SplashScreen from 'react-native-splash-screen';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
-import Config from 'react-native-config';
+import env from 'react-native-config';
 import 'array-flat-polyfill';
 
 import { Entry } from './app/Entry';
@@ -16,7 +16,7 @@ import BackgroundTaskService from './app/services/BackgroundTaskService';
 import { isGPS } from './app/COVIDSafePathsConfig';
 
 const determineTracingStrategy = () => {
-  switch (Config.TRACING_STRATEGY) {
+  switch (env.TRACING_STRATEGY) {
     case 'gps': {
       return gpsStrategy;
     }

--- a/app/COVIDSafePathsConfig.ts
+++ b/app/COVIDSafePathsConfig.ts
@@ -1,3 +1,3 @@
-import Config from 'react-native-config';
+import env from 'react-native-config';
 
-export const isGPS = Config.TRACING_STRATEGY === 'gps';
+export const isGPS = env.TRACING_STRATEGY === 'gps';

--- a/app/bt/AffectedUserFlow/verificationAPI.ts
+++ b/app/bt/AffectedUserFlow/verificationAPI.ts
@@ -1,13 +1,13 @@
-import Config from 'react-native-config';
+import env from 'react-native-config';
 
-const baseUrl = Config.GAEN_VERIFY_URL;
+const baseUrl = env.GAEN_VERIFY_URL;
 const verifyUrl = `${baseUrl}/api/verify`;
 const certificateUrl = `${baseUrl}/api/certificate`;
 
 const defaultHeaders = {
   'content-type': 'application/json',
   accept: 'application/json',
-  'X-API-Key': Config.GAEN_VERIFY_API_TOKEN,
+  'X-API-Key': env.GAEN_VERIFY_API_TOKEN,
 };
 
 export type Token = string;

--- a/app/constants/authorities.ts
+++ b/app/constants/authorities.ts
@@ -4,7 +4,5 @@ export const PUBLIC_DATA_URL =
 export const AUTHORITIES_LIST_URL =
   'https://raw.githubusercontent.com/Path-Check/safeplaces-frontend/develop/healthcare-authorities.yaml';
 
-export const AUTHORITY_NAME = 'Boston Public Health Commission';
-
 export const AUTHORITY_ADVICE_URL =
   'https://mn.gov/covid19/for-minnesotans/if-sick/index.jsp';

--- a/app/constants/authorities.ts
+++ b/app/constants/authorities.ts
@@ -1,8 +1,0 @@
-export const PUBLIC_DATA_URL =
-  'https://raw.githubusercontent.com/beoutbreakprepared/nCoV2019/master/latest_data/latestdata.csv';
-
-export const AUTHORITIES_LIST_URL =
-  'https://raw.githubusercontent.com/Path-Check/safeplaces-frontend/develop/healthcare-authorities.yaml';
-
-export const AUTHORITY_ADVICE_URL =
-  'https://mn.gov/covid19/for-minnesotans/if-sick/index.jsp';

--- a/app/services/HCAService.js
+++ b/app/services/HCAService.js
@@ -2,8 +2,8 @@ import { isValidCoordinate } from 'geolib';
 import Yaml from 'js-yaml';
 import PushNotification from 'react-native-push-notification';
 import RNFetchBlob from 'rn-fetch-blob';
+import env from 'react-native-config';
 
-import { AUTHORITIES_LIST_URL } from '../constants/authorities';
 import {
   AUTHORITY_SOURCE_SETTINGS,
   ENABLE_HCA_AUTO_SUBSCRIPTION,
@@ -11,6 +11,8 @@ import {
 import { GetStoreData, SetStoreData } from '../helpers/General';
 import languages from '../locales/languages';
 import LocationService from './LocationService';
+
+const { AUTHORITIES_LIST_URL } = env;
 
 /**
  * Singleton class to interact with health care authority data

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -12,10 +12,9 @@ import { Screens, useStatusBarEffect } from '../../navigation';
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 import { Icons } from '../../assets';
 
-import { AUTHORITY_ADVICE_URL } from '../../constants/authorities';
 import { Colors } from '../../styles';
 
-const { GAEN_AUTHORITY_NAME: healthAuthorityName } = env;
+const { GAEN_AUTHORITY_NAME: healthAuthorityName, AUTHORITY_ADVICE_URL } = env;
 
 const NextSteps = (): JSX.Element => {
   const navigation = useNavigation();

--- a/app/views/ExposureHistory/NextSteps.tsx
+++ b/app/views/ExposureHistory/NextSteps.tsx
@@ -3,6 +3,7 @@ import { TouchableOpacity, View, StyleSheet, Linking } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { SvgXml } from 'react-native-svg';
+import env from 'react-native-config';
 
 import { Typography } from '../../components/Typography';
 import { NavigationBarWrapper } from '../../components/NavigationBarWrapper';
@@ -11,11 +12,10 @@ import { Screens, useStatusBarEffect } from '../../navigation';
 import { Buttons, Spacing, Typography as TypographyStyles } from '../../styles';
 import { Icons } from '../../assets';
 
-import {
-  AUTHORITY_NAME as healthAuthorityName,
-  AUTHORITY_ADVICE_URL,
-} from '../../constants/authorities';
+import { AUTHORITY_ADVICE_URL } from '../../constants/authorities';
 import { Colors } from '../../styles';
+
+const { GAEN_AUTHORITY_NAME: healthAuthorityName } = env;
 
 const NextSteps = (): JSX.Element => {
   const navigation = useNavigation();

--- a/app/views/assessment/__tests__/endScreens/Share.spec.js
+++ b/app/views/assessment/__tests__/endScreens/Share.spec.js
@@ -6,6 +6,10 @@ import i18n from '../../../../locales/languages';
 import { AssessmentNavigationContext } from '../../Context';
 import { Share } from '../../endScreens/Share';
 
+jest.mock('react-native-config', () => ({
+  GAEN_AUTHORITY_NAME: 'Boston Public Health Commission',
+}));
+
 test('base', () => {
   const { asJSON } = render(<Share />, { wrapper: Wrapper });
   expect(asJSON()).toMatchSnapshot();

--- a/app/views/assessment/endScreens/Share.js
+++ b/app/views/assessment/endScreens/Share.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import env from 'react-native-config';
 
 import { Icons } from '../../../assets';
 import { Info } from '../Info';
@@ -8,7 +9,7 @@ import { Button } from '../components/Button';
 
 import { Colors } from '../../../styles';
 
-import { AUTHORITY_NAME as authority } from '../../../constants/authorities';
+const { GAEN_AUTHORITY_NAME: authority } = env;
 
 /** @type {React.FunctionComponent<{}>} */
 export const Share = ({ navigation }) => {


### PR DESCRIPTION
#### Description:

WHY: 
The contents of the authorities.ts file were following a similar pattern as the .env files. Also, some of the contents were being used for the GPS strategy and some for the BT strategy. 

We moved the contents of the constants/authorities.ts into the appropriate .env file (GPS or BT).

#### Linked issues:

[Trello](https://trello.com/c/L4pNhsN4/71-as-a-dev-team-we-have-a-way-to-customize-the-health-authority-name-in-the-app)
[Pathcheck Mobile Resources PR](https://github.com/Path-Check/pathcheck-mobile-resources/pull/1)
