### PR TITLE
Exposure History Datum Title & Design Parity

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -125,9 +125,11 @@
       "what_next": "What should I do next?"
     },
     "no_known": {
+      "title": "No reports received at this time",
       "explanation": "Your exposure history will be updated if this changes in the future."
     },
     "no_data": {
+      "title": "No information available for this days",
       "explanation": "This happens when location access is disabled for your PathCheck app or the date selected was more than 14 days ago. No exposure notifications will be available for this day."
     }
   },

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -129,7 +129,7 @@
       "explanation": "Your exposure history will be updated if this changes in the future."
     },
     "no_data": {
-      "title": "No information available for this days",
+      "title": "No information available for this day",
       "explanation": "This happens when location access is disabled for your PathCheck app or the date selected was more than 14 days ago. No exposure notifications will be available for this day."
     }
   },

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -104,10 +104,12 @@ const NoKnownExposureDetail = ({
   const { t } = useTranslation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
   const explanationContent = t('exposure_datum.no_known.explanation');
+  const explanationTitle = t('exposure_datum.no_known.title');
   return (
     <View style={styles.container}>
       <Typography style={styles.date}>{exposureDate}</Typography>
       <View style={styles.contentContainer}>
+        <Typography style={styles.info}>{explanationTitle}</Typography>
         <Typography style={styles.content}>{explanationContent}</Typography>
       </View>
     </View>
@@ -124,10 +126,12 @@ const NoDataExposureDetail = ({
   const { t } = useTranslation();
   const exposureDate = dayjs(date).format('dddd, MMM DD');
   const explanationContent = t('exposure_datum.no_data.explanation');
+  const explanationTitle = t('exposure_datum.no_data.title');
   return (
     <View style={styles.container}>
       <Typography style={styles.date}>{exposureDate}</Typography>
       <View style={styles.contentContainer}>
+        <Typography style={styles.info}>{explanationTitle}</Typography>
         <Typography style={styles.content}>{explanationContent}</Typography>
       </View>
     </View>
@@ -146,7 +150,8 @@ const styles = StyleSheet.create({
     ...TypographyStyles.header6,
   },
   info: {
-    lineHeight: TypographyStyles.largeLineHeight,
+    ...TypographyStyles.mainContentViolet,
+    paddingBottom: Spacing.xxSmall,
   },
   contentContainer: {
     paddingTop: Spacing.xxSmall,

--- a/app/views/ExposureHistory/ExposureDatumIndicator.tsx
+++ b/app/views/ExposureHistory/ExposureDatumIndicator.tsx
@@ -30,7 +30,7 @@ const ExposureDatumIndicator = ({
     return (
       <>
         {indicator}
-        <View style={styles.selectedBadge} />
+        <View style={styles.todayBadge} />
       </>
     );
   };
@@ -135,8 +135,8 @@ const styles = StyleSheet.create({
     color: Colors.primaryText,
     fontWeight: Typography.heavyWeight,
   },
-  selectedBadge: {
-    ...Affordances.bottomDotBadge(Colors.primaryText),
+  todayBadge: {
+    ...Affordances.bottomDotBadge(Colors.primaryBlue),
   },
 });
 

--- a/app/views/ExposureHistory/History.tsx
+++ b/app/views/ExposureHistory/History.tsx
@@ -63,7 +63,9 @@ const History = ({ exposureHistory }: HistoryProps): JSX.Element => {
       <ScrollView style={styles.container} alwaysBounceVertical={false}>
         <View>
           <View style={styles.headerRow}>
-            <Typography style={styles.headerText}>{titleText}</Typography>
+            <View style={{ flex: 1 }}>
+              <Typography style={styles.headerText}>{titleText}</Typography>
+            </View>
             <TouchableOpacity
               onPress={handleOnPressMoreInfo}
               style={styles.moreInfoButton}>

--- a/app/views/ExposureHistory/History.tsx
+++ b/app/views/ExposureHistory/History.tsx
@@ -63,7 +63,7 @@ const History = ({ exposureHistory }: HistoryProps): JSX.Element => {
       <ScrollView style={styles.container} alwaysBounceVertical={false}>
         <View>
           <View style={styles.headerRow}>
-            <View style={{ flex: 1 }}>
+            <View style={{ flexShrink: 1 }}>
               <Typography style={styles.headerText}>{titleText}</Typography>
             </View>
             <TouchableOpacity
@@ -108,7 +108,6 @@ const styles = StyleSheet.create({
   headerRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    flexWrap: 'wrap',
     marginTop: Spacing.xSmall,
   },
   headerText: {

--- a/app/views/ExposureHistory/History.tsx
+++ b/app/views/ExposureHistory/History.tsx
@@ -104,6 +104,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.primaryBackground,
   },
   headerRow: {
+    alignItems: 'center',
     flexDirection: 'row',
     flexWrap: 'wrap',
     marginTop: Spacing.xSmall,

--- a/app/views/ExposureHistory/index.tsx
+++ b/app/views/ExposureHistory/index.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native';
 import ExposureHistoryContext from '../../ExposureHistoryContext';
 import { useStatusBarEffect } from '../../navigation';
 import History from './History';
+import { Colors } from '../../styles';
 
 const ExposureHistoryScreen = (): JSX.Element => {
   const { exposureHistory } = useContext(ExposureHistoryContext);
@@ -11,7 +12,8 @@ const ExposureHistoryScreen = (): JSX.Element => {
   useStatusBarEffect('dark-content');
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView
+      style={{ flex: 1, backgroundColor: Colors.primaryBackground }}>
       <History exposureHistory={exposureHistory} />
     </SafeAreaView>
   );


### PR DESCRIPTION
Some design parity changes for exposure history datum. 
- adds the titles per card
- centers question mark icon & title
- makes "today" badge same color as the legend badge + the designs
- make safe area view of the calendar screen the same background color 

Before           |  After
:-------------------------:|:-------------------------:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/87492303-3e012a80-c618-11ea-9628-1a5106190a65.png"> | <img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/87492602-e616f380-c618-11ea-97e8-4d5c5668f7fc.png">
