### PR TITLE
Await Location Permissions Before Completing Onboarding

### DIFF
--- a/app/views/onboarding/LocationsPermissions.tsx
+++ b/app/views/onboarding/LocationsPermissions.tsx
@@ -35,6 +35,7 @@ const LocationsPermissions = (): JSX.Element => {
   useStatusBarEffect('dark-content');
 
   const requestLocationAccess = async () => {
+    console.log('----------- request Location Access ----------------')
     await location.request();
     authSubscription.request();
     completeOnboarding();
@@ -46,8 +47,8 @@ const LocationsPermissions = (): JSX.Element => {
     dispatch(onboardingCompleteAction());
   };
 
-  const handleOnPressEnable = () => {
-    requestLocationAccess();
+  const handleOnPressEnable = async () => {
+    await requestLocationAccess();
     completeOnboarding();
   };
 

--- a/app/views/onboarding/LocationsPermissions.tsx
+++ b/app/views/onboarding/LocationsPermissions.tsx
@@ -35,7 +35,6 @@ const LocationsPermissions = (): JSX.Element => {
   useStatusBarEffect('dark-content');
 
   const requestLocationAccess = async () => {
-    console.log('----------- request Location Access ----------------')
     await location.request();
     authSubscription.request();
     completeOnboarding();


### PR DESCRIPTION
#### Description:
Currently the app progresses to the main screen from Onboarding when the user presses the Enable Location button. The app should progress after the user makes a selection in the Enable Location Popup that appears after pressing the Enable Location button.

#### How to test:
Go through onboarding and enable location. The app should wait for you to enable/disabled location permissions before navigating to the main screen.
