### PR TITLE
MB iOS EN Updates

### DIFF
--- a/app/bt/nativeModule.ts
+++ b/app/bt/nativeModule.ts
@@ -110,7 +110,7 @@ const toExposureKey = (rawExposureKey: RawExposureKey): ExposureKey => {
 export const submitDiagnosisKeys = async (
   certificate: string,
   hmacKey: string,
-): Promise<'success'> => {
+): Promise<string> => {
   return exposureKeyModule.postDiagnosisKeys(certificate, hmacKey);
 };
 
@@ -124,7 +124,7 @@ export const fetchDiagnosisKeys = async (): Promise<ENDiagnosisKey[]> => {
 export type ENModuleErrorMessage = string | null;
 export type ENModuleSuccessMessage = string | null;
 
-export const detectExposuresNow = async (): Promise<'success'> => {
+export const detectExposuresNow = async (): Promise<string> => {
   return debugModule.detectExposuresNow();
 };
 

--- a/ios/BT/API/Result.swift
+++ b/ios/BT/API/Result.swift
@@ -7,6 +7,13 @@ public enum Result<T> {
 
 }
 
+public enum ExposureResult {
+
+  case success(Int)
+  case failure(ExposureError)
+
+}
+
 public enum GenericError: Error {
 
   case unknown
@@ -15,6 +22,28 @@ public enum GenericError: Error {
   case notFound
   case notImplemented
   case unauthorized
+
+}
+
+public enum ExposureError: LocalizedError {
+
+  case `default`(String?)
+  case dailyFileProcessingLimitExceeded
+  case cancelled
+
+  public var errorDescription: String? {
+    switch self {
+    case .default(message: let message):
+      guard let unwrappedMessage = message else {
+        return localizedDescription
+      }
+      return unwrappedMessage
+    case .dailyFileProcessingLimitExceeded:
+      return "Daily exposure detection file processing limit exceeded"
+    case .cancelled:
+      return "Exposure Detection Cancelled"
+    }
+  }
 
 }
 

--- a/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
+++ b/ios/BT/Extensions/Exposure Notifications/ENTemporaryExposureKey+Extensions.swift
@@ -19,4 +19,8 @@ extension ENTemporaryExposureKey {
     ]
   }
 
+  static func rollingStartNumber(_ date: Date) -> UInt32 {
+    UInt32(Int(date.timeIntervalSince1970 / (24 * 60 * 60)) * Constants.intervalsPerRollingPeriod)
+  }
+
 }

--- a/ios/BT/Extensions/Foundation/Array+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/Array+Extensions.swift
@@ -1,3 +1,4 @@
+import ExposureNotification
 import Foundation
 
 extension Array where Element == DownloadedPackage {
@@ -23,6 +24,19 @@ extension Array where Element == DownloadedPackage {
       throw GenericError.unknown
     }
 
+  }
+
+}
+
+extension Array where Element == ENTemporaryExposureKey {
+
+  func minRollingStartNumber() -> UInt32 {
+    let date = Calendar.current.date(byAdding: .hour, value: -Constants.exposureLifetimeHours, to: Date())!
+    return ENTemporaryExposureKey.rollingStartNumber(date)
+  }
+
+  func current() -> [ENTemporaryExposureKey] {
+    filter { $0.rollingStartNumber > self.minRollingStartNumber() }
   }
 
 }

--- a/ios/BT/Extensions/Foundation/String+Extensions.swift
+++ b/ios/BT/Extensions/Foundation/String+Extensions.swift
@@ -31,7 +31,6 @@ extension String {
   static let bluetoothNotificationIdentifier = "bluetooth-off"
   static let exposureDetectionErrorNotificationTitle = "Error Detecting Exposures"
   static let exposureDetectionErrorNotificationBody = "An error occurred while attempting to detect exposures."
-  static let newExposureNotificationTitle = "New Exposure"
   static let newExposureNotificationBody = "Someone you were near recently has been diagnosed with COVID-19. Tap for more details."
   static let exposureDetectionErrorNotificationIdentifier = "expososure-notification-error"
 

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -19,15 +19,16 @@ extension ExposureManager {
     case .detectExposuresNow:
       guard BTSecureStorage.shared.userState.remainingDailyFileProcessingCapacity > 0 else {
         let hoursRemaining = 24 - Date.hourDifference(from: BTSecureStorage.shared.userState.dateLastPerformedFileCapacityReset ?? Date(), to: Date())
-        reject("You have reached the exposure file submission limit. Please wait \(hoursRemaining) hours before detecting exposures again.", "Failed to detect Exposures", GenericError.unknown)
+        reject("Time window Error.", "You have reached the exposure file submission limit. Please wait \(hoursRemaining) hours before detecting exposures again.", GenericError.unknown)
         return
       }
       
-      detectExposures { error in
-        if let error = error {
-          reject(error.localizedDescription, "Failed to detect Exposures", error)
-        } else {
-          resolve("Exposure detection successfully executed.")
+      detectExposures { result in
+        switch result {
+        case .success(let numberOfFilesProcessed):
+          resolve("Exposure detection successfully executed. Processed \(numberOfFilesProcessed) files.")
+        case .failure(let exposureError):
+          reject(exposureError.localizedDescription, exposureError.errorDescription, exposureError)
         }
       }
     case .simulateExposureDetectionError:

--- a/ios/COVIDSafePathsTests/ExposureManagerTests.swift
+++ b/ios/COVIDSafePathsTests/ExposureManagerTests.swift
@@ -1,7 +1,8 @@
 import Foundation
-
+import  ExposureNotification
 import RealmSwift
 import XCTest
+
 @testable import BT
 
 class ExposureManagerTests: XCTestCase {
@@ -242,6 +243,29 @@ mn/1593460800-1593475200-00022.zip
     // Setup
     BTSecureStorage.shared.resetUserState() { _ in }
     XCTAssertEqual(BTSecureStorage.shared.userState.remainingDailyFileProcessingCapacity, Constants.dailyFileProcessingCapacity)
+  }
+
+  func testFilterOldKeysForSubmission() {
+    // Keys older than 350 hours should not be submitted
+    
+    let oneMonthAgo: Date = Calendar.current.date(byAdding: .month, value: -1, to: Date())!
+    let oneWeekAgo: Date = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
+    let today: Date = Date()
+
+    let keyA = ENTemporaryExposureKey()
+    keyA.rollingStartNumber = ENTemporaryExposureKey.rollingStartNumber(oneMonthAgo)
+
+    let keyB = ENTemporaryExposureKey()
+    keyB.rollingStartNumber = ENTemporaryExposureKey.rollingStartNumber(oneWeekAgo)
+
+    let keyC = ENTemporaryExposureKey()
+    keyC.rollingStartNumber = ENTemporaryExposureKey.rollingStartNumber(today)
+
+    let currentKeys = [keyA, keyB, keyC].current()
+
+    XCTAssertFalse(currentKeys.contains(keyA))
+    XCTAssertTrue(currentKeys.contains(keyB))
+    XCTAssertTrue(currentKeys.contains(keyC))
   }
 
 }


### PR DESCRIPTION
### Why
We'd like testers to be able to read information that is helpful during debugging rather than opaque errors. We'd also like more of the iOS exposure detection logic to have unit test coverage.

### This Commit
This commit changes error handling such that relevant information (the number of files processed during exposure detection, the number of keys sent during key submission) are bubbled up to the JS layer and ultimately made visible to the user. This commit also adds test coverage for the logic that filters out keys older than 350 hours during key submission.

![Screenshot 2020-07-15 at 3 47 01 PM](https://user-images.githubusercontent.com/2637355/87592023-2e84ee80-c6b7-11ea-8b37-598dd634c9a1.jpeg)
![IMG_526E3C3A5899-1](https://user-images.githubusercontent.com/2637355/87592069-3d6ba100-c6b7-11ea-8645-acca0927b39e.jpeg)
![Screenshot 2020-07-15 at 3 47 01 PM](https://user-images.githubusercontent.com/2637355/87592178-6ee46c80-c6b7-11ea-8b68-750cccd5fb13.jpeg)
