### PR TITLE
Include hmac and certificate in post key payload

### DIFF
--- a/ios/BT/API/Requests/DiagnosisKeyRequests.swift
+++ b/ios/BT/API/Requests/DiagnosisKeyRequests.swift
@@ -58,8 +58,8 @@ enum DiagnosisKeyListRequest: APIRequest {
         "temporaryExposureKeys": keys,
         "regions": regions.map { $0.rawValue },
         "appPackageName": Bundle.main.bundleIdentifier!,
-        "verificationPayload": String.default,
-        "hmackey": String.default,
+        "verificationPayload": certificate,
+        "hmackey": hmacKey,
         "padding": String(decoding: Data(), as: UTF8.self)
       ]
     }


### PR DESCRIPTION
Why:
We would like to include the hmac key and jwt certificate in the post
diagnosis keys call to the verification server. Previously we were not
including these due to an error in the verification server, which has
recently been resolved.