### PR TITLE
iOS Descriptive Error for Background Failures 

### DIFF
--- a/ios/BT/ExposureManager.swift
+++ b/ios/BT/ExposureManager.swift
@@ -226,7 +226,7 @@ final class ExposureManager: NSObject {
       case let .failure(error):
         let exposureError = ExposureError.default(error.localizedDescription)
         BTSecureStorage.shared.exposureDetectionErrorLocalizedDescription = error.localizedDescription
-        postExposureDetectionErrorNotification()
+        postExposureDetectionErrorNotification(exposureError.errorDescription)
         completionHandler(.failure(exposureError))
       }
     }
@@ -298,13 +298,13 @@ final class ExposureManager: NSObject {
     }
   }
   
-  func postExposureDetectionErrorNotification() {
+  func postExposureDetectionErrorNotification(_ errorString: String?) {
     #if DEBUG
     let identifier = String.exposureDetectionErrorNotificationIdentifier
     
     let content = UNMutableNotificationContent()
     content.title = String.exposureDetectionErrorNotificationTitle.localized
-    content.body = String.exposureDetectionErrorNotificationBody.localized
+    content.body = errorString ?? String.exposureDetectionErrorNotificationBody.localized
     content.sound = .default
     let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
     UNUserNotificationCenter.current().add(request) { error in

--- a/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
+++ b/ios/BT/Extensions/Other/ExposureManager+Extensions.swift
@@ -33,7 +33,7 @@ extension ExposureManager {
       }
     case .simulateExposureDetectionError:
       BTSecureStorage.shared.exposureDetectionErrorLocalizedDescription = "Unable to connect to server."
-      ExposureManager.shared.postExposureDetectionErrorNotification()
+      ExposureManager.shared.postExposureDetectionErrorNotification("Simulated Error")
       resolve(String.genericSuccess)
     case .simulateExposure:
       let exposure = Exposure(id: UUID().uuidString,


### PR DESCRIPTION
### Why
We'd like to know specific information about errors when they occur in the background

### This Commit
This commit surfaces more detailed error information in the push notification that appears in debug when an error occurs in the background during exposure detection on iOS