### PR TITLE
Script to update display name based on environment

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,4 +1,11 @@
-#!/bin/bash                                                                                                         
+#!/bin/bash
+
+# USAGE
+# First argument is the name of the health authority to build
+# Flags:
+# --renaming: Puts the display name provided on the .env.bt files on the android
+# app for ios and android bt builds
+# THIS REQUIRES THE xmllint and the PlistBuddy utilities to be present
 
 HA=$1
 
@@ -25,3 +32,34 @@ if [ ! -f pathcheck-mobile-resources/environment/$HA/.env.bt.release ]; then
 fi
 
 cp -r pathcheck-mobile-resources/environment/$HA/. ./
+
+# In order to read properly spaces on environment variables
+IFS='
+'
+
+if [ "$2" = "--renaming" ]; then
+# Loading the .env.bt
+export $(cat .env.bt.release | xargs)
+
+# Check for a display name on the environment variables
+if [ -z "$DISPLAY_NAME" ]; then echo ERROR: No display name provided; exit 0; fi
+
+PLIST_PATH="./ios/BT/Info.plist"
+echo "read BT Info.plist file" $PLIST_PATH
+
+IOS_CURRENT_NAME=`/usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$PLIST_PATH"`
+echo "Changing ios display name from $IOS_CURRENT_NAME to" $DISPLAY_NAME
+`/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $DISPLAY_NAME" "$PLIST_PATH"`
+
+ANDROID_STRINGS_PATH="./android/app/src/bt/res/values/strings.xml"
+
+ANDROID_CURRENT_NAME=`xmllint --xpath "/resources/string[@name='app_name']/text()" $ANDROID_STRINGS_PATH`
+echo "Changing android display name from $ANDROID_CURRENT_NAME to" $DISPLAY_NAME
+
+xmllint --shell $ANDROID_STRINGS_PATH << EOF
+cd /resources/string[@name='app_name']
+set $DISPLAY_NAME
+save
+EOF
+
+fi

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -38,8 +38,9 @@ IFS='
 '
 
 if [ "$2" = "--renaming" ]; then
-# Loading the .env.bt
-export $(cat .env.bt.release | xargs)
+
+# Loading the .env.bt.release
+export $(egrep -v '^#' .env.bt.release | xargs -0)
 
 # Check for a display name on the environment variables
 if [ -z "$DISPLAY_NAME" ]; then echo ERROR: No display name provided; exit 0; fi


### PR DESCRIPTION
Why:
----
Each HA will have different settings for our builds, one of those is the
display name. We need a way to update those values for each one of the
builds.

This Commit:
----
- Extend setup env script to update the display name of the android and
the ios app for the bt builds

Reviewers:
----
This script is counting on having `xmllint` and `PlistBuddy` in the
executing environment. Given that builds need to happen on `MacOS` those
two libraries are part of the system. The solution is very rigid but it
is a start on how we might tackle the configurations per HA.