### PR TITLE
en.json 1.2.0 update

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -119,13 +119,18 @@
   "exposure_datum": {
     "possible": {
       "duration": "Possible Exposure Time: {{duration}}",
-      "explanation": "For {{duration}}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis.",
+      "explanation": {
+        "gps": "For {{duration}} throughout this day, your phone was within 100 feet of someone who was later diagnosed with COVID-19.",
+        "bt": "For {{duration}}, your phone was within 10 feet of someone who later received a confirmed positive COVID-19 diagnosis."
+      },
       "what_next": "What should I do next?"
     },
     "no_known": {
+      "title": "No reports received at this time",
       "explanation": "Your exposure history will be updated if this changes in the future."
     },
     "no_data": {
+      "title": "No information available for this day",
       "explanation": "This happens when location access is disabled for your PathCheck app or the date selected was more than 14 days ago. No exposure notifications will be available for this day."
     }
   },
@@ -135,8 +140,9 @@
     "why_did_i_get_an_en": "Why did I get an exposure notification?",
     "how_does_this_work": "How does this work?",
     "legend": {
+      "exposure_likely": "Exposure very likely",
+      "exposure_possible": "Exposure possible",
       "new_exposure": "New possible exposure",
-      "exposure_possible": "Possible exposure",
       "no_exposure_detected": "No exposure detected",
       "today": "Today"
     },

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -141,8 +141,8 @@
     "how_does_this_work": "How does this work?",
     "legend": {
       "exposure_likely": "Exposure very likely",
-      "exposure_possible": "Exposure possible",
       "new_exposure": "New possible exposure",
+      "exposure_possible": "Possible exposure",
       "no_exposure_detected": "No exposure detected",
       "today": "Today"
     },

--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -21,6 +21,7 @@ import {
   Buttons,
   Spacing,
 } from '../../styles';
+import { isGPS } from '../../COVIDSafePathsConfig';
 
 interface ExposureDatumDetailsProps {
   exposureDatum: ExposureDatum;
@@ -56,9 +57,14 @@ const PossibleExposureDetail = ({
   const exposureTime = t('exposure_datum.possible.duration', {
     duration: exposureDurationText,
   });
-  const explanationContent = t('exposure_datum.possible.explanation', {
-    duration: exposureDurationText,
-  });
+  const explanationContent = t(
+    isGPS
+      ? 'exposure_datum.possible.explanation.gps'
+      : 'exposure_datum.possible.explanation.bt',
+    {
+      duration: exposureDurationText,
+    },
+  );
   const nextStepsButtonText = t('exposure_datum.possible.what_next');
 
   const handleOnPressNextSteps = () => {


### PR DESCRIPTION
Merges 1.2.0 Locale changes into develop. @alpita-masurkar for visibility.

We're merging this in so that we can immediately get a localization update from these strings.

Quick hack to be non-breaking with the `isGps`, probably want this to use tracing strategy content long term?  @johnschoeman 