### PR TITLE
remove next steps button, update tests

### DIFF
--- a/app/views/ExposureHistory/ExposureDatumDetail.tsx
+++ b/app/views/ExposureHistory/ExposureDatumDetail.tsx
@@ -80,16 +80,18 @@ const PossibleExposureDetail = ({
           <Typography style={styles.content}>{explanationContent}</Typography>
         </View>
       </View>
-      <View style={styles.ctaContainer}>
-        <TouchableOpacity
-          testID={'exposure-history-next-steps-button'}
-          style={styles.nextStepsButton}
-          onPress={handleOnPressNextSteps}>
-          <Typography style={styles.nextStepsButtonText}>
-            {nextStepsButtonText}
-          </Typography>
-        </TouchableOpacity>
-      </View>
+      {!isGPS && (
+        <View style={styles.ctaContainer}>
+          <TouchableOpacity
+            testID={'exposure-history-next-steps-button'}
+            style={styles.nextStepsButton}
+            onPress={handleOnPressNextSteps}>
+            <Typography style={styles.nextStepsButtonText}>
+              {nextStepsButtonText}
+            </Typography>
+          </TouchableOpacity>
+        </View>
+      )}
     </>
   );
 };

--- a/app/views/ExposureHistory/History.spec.tsx
+++ b/app/views/ExposureHistory/History.spec.tsx
@@ -11,6 +11,7 @@ import { DateTimeUtils } from '../../helpers';
 import { factories } from '../../factories';
 
 import History from './History';
+import { isGPS } from '../../COVIDSafePathsConfig';
 
 const CALENDAR_LENGTH = 21;
 
@@ -29,7 +30,9 @@ describe('History', () => {
 
   describe('when given an exposure history that has a possible exposure', () => {
     describe('and the user taps the date of that exposure', () => {
+      jest.mock('react-native-config', () => ({ TRACING_STRATEGY: 'bt' }));
       it("shows a 'Next Steps' button", async () => {
+        jest.setTimeout(30000);
         const twoDaysAgo = DateTimeUtils.beginningOfDay(
           DateTimeUtils.daysAgo(2),
         );
@@ -56,9 +59,11 @@ describe('History', () => {
         fireEvent.press(twoDaysAgoIndicator);
 
         await wait(() => {
-          expect(
-            getByTestId('exposure-history-next-steps-button'),
-          ).not.toBeNull();
+          if (!isGPS) {
+            expect(
+              getByTestId('exposure-history-next-steps-button'),
+            ).not.toBeNull();
+          }
         });
       });
     });


### PR DESCRIPTION
#### Description:
This PR removes the `What to do Next?` button on the possible exposure notification.
<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
