### PR TITLE
Fix Allow Exposure Notifications Button

### DIFF
--- a/android/app/src/bt/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
+++ b/android/app/src/bt/java/covidsafepaths/bt/exposurenotifications/ExposureNotificationsModule.java
@@ -107,11 +107,7 @@ public class ExposureNotificationsModule extends ReactContextBaseJavaModule {
         ExposureNotificationClientWrapper.get(reactContext.getCurrentActivity())
                 .isEnabled().addOnSuccessListener(
                 enabled -> {
-                    if(enabled) {
-                        callback.invoke(Util.toWritableArray(CallbackMessages.EN_AUTHORIZATION_AUTHORIZED, CallbackMessages.EN_ENABLEMENT_ENABLED));
-                    } else {
-                        callback.invoke(Util.toWritableArray(CallbackMessages.EN_AUTHORIZATION_UNAUTHORIZED, CallbackMessages.EN_ENABLEMENT_DISABLED));
-                    }
+                    callback.invoke(Util.getEnStatusWritableArray(enabled));
                 })
                 .addOnFailureListener(
                         exception -> {

--- a/android/app/src/bt/java/covidsafepaths/bt/exposurenotifications/utils/Util.java
+++ b/android/app/src/bt/java/covidsafepaths/bt/exposurenotifications/utils/Util.java
@@ -19,4 +19,13 @@ public class Util {
 
         return array;
     }
+
+    public static WritableArray getEnStatusWritableArray(boolean enabled) {
+        final String enablement = enabled ?  CallbackMessages.EN_ENABLEMENT_ENABLED : CallbackMessages.EN_ENABLEMENT_DISABLED;
+
+        // Android differs from iOS in that an app can always request to enable Exposure Notifications. No need to have it authorized
+        // in the OS settings prior to enabling it in the app. For this reason, whether this app is enabled or disabled, we can
+        // safely say that it is authorized.
+        return Util.toWritableArray(CallbackMessages.EN_AUTHORIZATION_AUTHORIZED, enablement);
+    }
 }

--- a/android/app/src/bt/java/org/pathcheck/covidsafepaths/MainActivity.java
+++ b/android/app/src/bt/java/org/pathcheck/covidsafepaths/MainActivity.java
@@ -124,13 +124,11 @@ public class MainActivity extends ReactActivity {
 
   private void handleExposureStateChanged(boolean enabled) {
     final ReactContext reactContext = getReactNativeHost().getReactInstanceManager().getCurrentReactContext();
-    WritableArray params = null;
+    WritableArray params = Util.getEnStatusWritableArray(enabled);
 
     if(enabled) {
-      params = Util.toWritableArray(CallbackMessages.EN_AUTHORIZATION_AUTHORIZED, CallbackMessages.EN_ENABLEMENT_ENABLED);
       ProvideDiagnosisKeysWorker.scheduleDailyProvideDiagnosisKeys(this);
     } else {
-     params = Util.toWritableArray(CallbackMessages.EN_AUTHORIZATION_UNAUTHORIZED, CallbackMessages.EN_ENABLEMENT_DISABLED);
      ProvideDiagnosisKeysWorker.cancelDailyProvideDiagnosisKeys(this);
     }
 


### PR DESCRIPTION
#### Description:
Addresses an issue where Exposure Notifications could not be enabled on the home screen, but only through onboarding.

#### How to test:
1. Install BT app.
2. Go through onboarding and do not enable exposure notifications.
3. On the home screen enable exposure notifications.
4. Observe exposure notifications can be enabled from the home screen.
