### PR TITLE
Add badge indicator when user has new exposure

### DIFF
--- a/app/ExposureHistoryContext.tsx
+++ b/app/ExposureHistoryContext.tsx
@@ -23,7 +23,6 @@ interface ExposureHistoryState {
   hasBeenExposed: boolean;
   userHasNewExposure: boolean;
   observeExposures: () => void;
-  resetExposures: () => void;
   getCurrentExposures: () => void;
   lastExposureDetectionDate: Dayjs | null;
 }
@@ -33,7 +32,6 @@ const initialState = {
   hasBeenExposed: false,
   userHasNewExposure: true,
   observeExposures: (): void => {},
-  resetExposures: (): void => {},
   getCurrentExposures: (): void => {},
   lastExposureDetectionDate: null,
 };
@@ -111,7 +109,7 @@ const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
           blankHistoryConfig,
         );
         getLastExposureDetectionDate();
-
+        setUserHasNewExposure(true);
         setExposureHistory(exposureHistory);
       },
     );
@@ -132,10 +130,6 @@ const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
     setUserHasNewExposure(false);
   };
 
-  const resetExposures = () => {
-    setUserHasNewExposure(true);
-  };
-
   const hasBeenExposed = false;
   return (
     <ExposureHistoryContext.Provider
@@ -144,7 +138,6 @@ const ExposureHistoryProvider: FunctionComponent<ExposureHistoryProps> = ({
         hasBeenExposed,
         userHasNewExposure,
         observeExposures,
-        resetExposures,
         getCurrentExposures,
         lastExposureDetectionDate,
       }}>


### PR DESCRIPTION
 ### Testing Notes ###
- Simulate an exposure
- Expect a yellow badge to appear above the calendar icon in the main
tab navigator
- Visit the calendar tab
- Expect the badge to disappear
Include instructions for reviewers to run tests related to this PR.

 ### Fixed Issues ###
Resolves [issue](https://trello.com/c/cfe33Gbb/194-as-a-user-i-want-to-see-a-badge-on-the-calendar-icon-when-i-have-an-en-so-that-i-notice-it-as-soon-as-possible) where user was not receiving a badge on the calendar icon when they had
a new exposure.

 ### Tech Notes ###
When the exposureInfoSubscription is called after the user has a new
exposure, we were not updating the ExposureHistory context with the
information that a new exposure was found. This commit:
- Updates the userHasNewExposure when the subscription is called
- Removes a resetExposures function that is unused

#### Screenshots:

![dot](https://user-images.githubusercontent.com/21161427/87827414-e09ff000-c848-11ea-839f-6527c6d0b636.gif)


Co-Authored-By: Thomas G Paresi <tparesi@gmail.com>