### PR TITLE
SAF-826 Compute hashes using milliseconds on iOS

### DIFF
--- a/ios/COVIDSafePathsTests/MARULocation+ExtensionTests.swift
+++ b/ios/COVIDSafePathsTests/MARULocation+ExtensionTests.swift
@@ -10,7 +10,7 @@ import XCTest
 class MAURLocation_ExtensionTests: XCTestCase {
 
   func testTimeWindow() {
-    let date = Date(timeIntervalSince1970: 1586865792000)
+    let date = Date(timeIntervalSince1970: 1586865792)
     let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: date)
     let windows = backgroundLocation.timeWindows(interval: 60 * 5 * 1000)
     XCTAssertEqual(windows.early, 1586865600000)
@@ -18,7 +18,7 @@ class MAURLocation_ExtensionTests: XCTestCase {
   }
 
   func testScryptHashSpec() {
-    let date = Date(timeIntervalSince1970: 1589117939000)
+    let date = Date(timeIntervalSince1970: 1589117939)
     let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: date)
     let scryptHashes = backgroundLocation.geoHashes
 
@@ -44,7 +44,7 @@ class MAURLocation_ExtensionTests: XCTestCase {
   }
 
   func testValidScrypt() {
-    let date = Date(timeIntervalSince1970: 1589117939000)
+    let date = Date(timeIntervalSince1970: 1589117939)
     let backgroundLocation = TestMAURLocation(latitude: 41.24060321, longitude: 14.91328448, date: date)
     let scryptHashes = backgroundLocation.scryptHashes
     let expectedHashes = [

--- a/ios/GPS/Extension/MAURLocation+Extension.swift
+++ b/ios/GPS/Extension/MAURLocation+Extension.swift
@@ -22,7 +22,7 @@ extension MAURLocation {
     }).reduce(into: Set<String>(), { (hashes, currentLocation) in
       hashes.insert(Geohash.encode(latitude: currentLocation.0, longitude: currentLocation.1, length: 8))
     }).reduce(into: [String](), { (hashes, hash) in
-      let timeWindow = timeWindows(interval: Double(60 * 5 * 1000))
+      let timeWindow = timeWindows(interval: 60 * 5 * 1000)
       hashes.append("\(hash)\(timeWindow.early)")
       hashes.append("\(hash)\(timeWindow.late)")
     })
@@ -55,13 +55,15 @@ extension MAURLocation {
   }
 
   /// Generates rounded time windows for interval before and after timestamp
-  /// https://pathcheck.atlassian.net/wiki/x/CoDXB
   /// - Parameters:
-  ///   - interval: location storage interval in seconds
-  public func timeWindows(interval: TimeInterval) -> (early: Int, late: Int) {
-    let time1 = Int(((time.timeIntervalSince1970 - interval / 2) / interval).rounded(.down) * interval)
-    let time2 = Int(((time.timeIntervalSince1970 + interval / 2) / interval).rounded(.down) * interval)
-    return (time1, time2)
+  ///   - interval: location storage interval in milliseconds
+  public func timeWindows(interval: Int64) -> (early: Int64, late: Int64) {
+    let ms = Int64(time.timeIntervalSince1970 * 1000.0)
+
+    let early = (ms - interval / 2) / interval * interval
+    let late = (ms + interval / 2) / interval * interval
+
+    return (early, late)
   }
 
   /// Apply scrypt hash algorithm on a String


### PR DESCRIPTION
https://pathcheck.atlassian.net/browse/SAF-826

* Standardized parameter and time to milliseconds when computing time windows for hashes
* Converted time to seconds in tests (which is what iOS expects)