### PR TITLE
[SAF-821] Fix feature flag language reset

### DIFF
--- a/app/locales/languages.ts
+++ b/app/locales/languages.ts
@@ -120,14 +120,25 @@ const config = {
 };
 
 export const initProdLanguages = (): void => {
+  const selected = i18next.language;
+
+  if(PROD_RESOURCES.hasOwnProperty(selected)) {
+    i18next.use(initReactI18next).init({
+      ...config,
+        lng: selected,
+    });
+    return;
+  }
   i18next.use(initReactI18next).init(config);
 };
 
 initProdLanguages();
 
-export const initDevLanguages = (): void => {
+export const initDevLanguages = () => {
+  const current = i18next.language;
   i18next.use(initReactI18next).init({
     ...config,
+    lng: current,
     resources: {
       ...PROD_RESOURCES,
       ...DEV_RESOURCES,

--- a/app/locales/languages.ts
+++ b/app/locales/languages.ts
@@ -129,7 +129,7 @@ export const initProdLanguages = (): void => {
   if (available) {
     i18next.use(initReactI18next).init({
       ...config,
-      lng: selected,
+      lng: available ? selected : config.lng,
     });
     return;
   }

--- a/app/locales/languages.ts
+++ b/app/locales/languages.ts
@@ -121,11 +121,15 @@ const config = {
 
 export const initProdLanguages = (): void => {
   const selected = i18next.language;
+  const available = Object.prototype.hasOwnProperty.call(
+    PROD_RESOURCES,
+    selected,
+  );
 
-  if(PROD_RESOURCES.hasOwnProperty(selected)) {
+  if (available) {
     i18next.use(initReactI18next).init({
       ...config,
-        lng: selected,
+      lng: selected,
     });
     return;
   }
@@ -134,7 +138,7 @@ export const initProdLanguages = (): void => {
 
 initProdLanguages();
 
-export const initDevLanguages = () => {
+export const initDevLanguages = (): void => {
   const current = i18next.language;
   i18next.use(initReactI18next).init({
     ...config,

--- a/app/views/FeatureFlagToggles.js
+++ b/app/views/FeatureFlagToggles.js
@@ -62,17 +62,16 @@ export const FeatureFlagsScreen = ({ navigation }) => {
     } else {
       initProdLanguages();
     }
-  },[devLanguagesEnabled])
+  }, [devLanguagesEnabled]);
 
   // Dev languages requires an init step, not just conditional render
   useEffect(() => {
-    if(isLoaded.current) {
+    if (isLoaded.current) {
       isLoaded.current = false;
       return;
     } else {
       toggleLanguages();
     }
-
   }, [toggleLanguages]);
   const dispatch = useDispatch();
 

--- a/app/views/FeatureFlagToggles.js
+++ b/app/views/FeatureFlagToggles.js
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-raw-text */
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import { StyleSheet, View, FlatList } from 'react-native';
 
 import {
@@ -53,15 +53,27 @@ export const FeatureFlagsScreen = ({ navigation }) => {
   const flagMap = useSelector((state) => state.featureFlags.flags);
   const flags = Object.keys(flagMap);
   const devLanguagesEnabled = flagMap[FeatureFlagOption.DEV_LANGUAGES];
+  const isLoaded = useRef(true);
 
-  // Dev languages requires an init step, not just conditional render
-  useEffect(() => {
+  // Only runs when language flag is toggled
+  const toggleLanguages = useCallback(() => {
     if (devLanguagesEnabled) {
       initDevLanguages();
     } else {
       initProdLanguages();
     }
-  }, [devLanguagesEnabled]);
+  },[devLanguagesEnabled])
+
+  // Dev languages requires an init step, not just conditional render
+  useEffect(() => {
+    if(isLoaded.current) {
+      isLoaded.current = false;
+      return;
+    } else {
+      toggleLanguages();
+    }
+
+  }, [toggleLanguages]);
   const dispatch = useDispatch();
 
   const disableFeatureFlags = () => {


### PR DESCRIPTION
#### Description:
This PR addresses an issue where entering feature flags screen would reset selected language to default(en).

#### How to test:

- enable feature flags

- select (if available) language different than English

- toggle 'All Language Options' flag on

- language should stay the same
