### PR TITLE
SAF-799 Android native function to clear Realm locations

### DIFF
--- a/android/app/src/androidTestGps/java/org/pathcheck/covidsafepaths/gps/storage/RealmSecureStorageTest.kt
+++ b/android/app/src/androidTestGps/java/org/pathcheck/covidsafepaths/gps/storage/RealmSecureStorageTest.kt
@@ -383,6 +383,47 @@ class RealmSecureStorageTest {
     assertEquals(0, assumedLocations.size)
   }
 
+  @Test
+  fun removeAllLocations() {
+    // Insert mock data
+    val calendar = Calendar.getInstance()
+    calendar.add(Calendar.DAY_OF_YEAR, -15)
+    val location1Time =calendar.timeInMillis
+    val backgroundLocation1 = BackgroundLocation().apply {
+      latitude = 40.730610
+      longitude = -73.935242
+      time = location1Time
+    }
+    val calendar2 = Calendar.getInstance()
+    calendar2.add(Calendar.DAY_OF_YEAR, -13)
+    val location2Time =calendar2.timeInMillis
+    val backgroundLocation2 = BackgroundLocation().apply {
+      latitude = 40.730610
+      longitude = -73.935242
+      time = location2Time
+    }
+    secureStorage.saveDeviceLocation(backgroundLocation1)
+    secureStorage.saveDeviceLocation(backgroundLocation2)
+
+    assertEquals(2, secureStorage.getRealmInstance().where<Location>().findAll().size)
+
+    // Remove locations
+    val promiseLatch = CountDownLatch(1)
+    val promise = object : TestPromise() {
+      override fun resolve(value: Any?) {
+        super.resolve(value)
+        assertNull(value)
+        promiseLatch.countDown()
+      }
+    }
+
+    secureStorage.removeAllLocations(promise)
+
+    assertEquals(0, secureStorage.getRealmInstance().where<Location>().findAll().size)
+
+    assertTrue(promiseLatch.await(1, SECONDS))
+  }
+
   private fun createWritableMapLocation(latitude: Double, longitude: Double, time: Long): WritableMap {
     return WritableNativeMap().apply {
       putDouble("latitude", latitude)

--- a/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
+++ b/android/app/src/gps/java/covidsafepaths/gps/bridge/SecureStorageManager.kt
@@ -27,7 +27,6 @@ class SecureStorageManager(reactContext: ReactApplicationContext) : ReactContext
 
   @ReactMethod
   fun removeAllLocations(promise: Promise) {
-//    TODO: Implement the following method in SecureStorage
-//    SecureStorage.removeAllLocations(promise)
+    SecureStorage.removeAllLocations(promise)
   }
 }

--- a/android/app/src/gps/java/covidsafepaths/gps/storage/RealmSecureStorage.kt
+++ b/android/app/src/gps/java/covidsafepaths/gps/storage/RealmSecureStorage.kt
@@ -149,6 +149,17 @@ open class RealmSecureStorage(inMemory: Boolean?) {
     realm.close()
   }
 
+  fun removeAllLocations(promise: Promise) {
+    val realm = getRealmInstance()
+
+    realm.executeTransaction {
+      realm.delete(Location::class.java)
+    }
+
+    promise.resolve(null)
+    realm.close()
+  }
+
   fun createAssumedLocations(previousLocation: Location?, newLocation: BackgroundLocation): List<Location> {
     val assumedLocationsToInsert = mutableListOf<Location>()
     previousLocation?.let { previous ->

--- a/android/app/src/gps/java/covidsafepaths/gps/storage/SecureStorage.kt
+++ b/android/app/src/gps/java/covidsafepaths/gps/storage/SecureStorage.kt
@@ -49,4 +49,16 @@ object SecureStorage {
       secureStorage.getLocations(promise)
     }).start()
   }
+
+  fun removeAllLocations(promise: Promise) {
+    Thread(Runnable {
+      val ready = readyCountdown.await(10, SECONDS)
+      if (!ready) {
+        promise.reject(java.lang.Exception("Failed to get Realm instance with encryption"))
+        return@Runnable
+      }
+
+      secureStorage.removeAllLocations(promise)
+    }).start()
+  }
 }


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->
Adds a native method to delete locations stored in Realm database.
It's the only `RealmObject` stored in the database. In the future, if more `RealmObject`s are added, we can call `realm.deleteAll()` to delete everything.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/SAF-799

#### How to test:

<!-- Description of how to validate or test this PR.  If it's a code change, you must describe what and how to test. -->
This method should be called from React Native to be tested
 `await NativeModules.SecureStorageManager.removeAllLocations()`