### PR TITLE
App breaking on code input for HA screen fix

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -18,8 +18,8 @@ import PartnersEditScreen from './views/Partners/PartnersEdit';
 import PartnersCustomUrlScreen from './views/Partners/PartnersCustomUrlScreen';
 
 import { LicensesScreen } from './views/Licenses';
-import { ExportSelectHA, ExportStart, ExportLocally } from './gps/Export';
-import ExportStack from './bt/AffectedUserFlow';
+import { ExportStart, ExportLocally } from './gps/Export';
+import ExportStack from './gps/ExportStack';
 
 import NotificationPermissionsBT from './bt/NotificationPermissionsBT';
 import ExposureHistoryScreen from './views/ExposureHistory';
@@ -114,14 +114,7 @@ const MoreTabStack = () => {
         name={Screens.LanguageSelection}
         component={LanguageSelection}
       />
-      <Stack.Screen
-        name={Screens.ExportFlow}
-        component={ExportStack}
-        options={{
-          ...TransitionPresets.ModalSlideFromBottomIOS,
-          gestureEnabled: false,
-        }}
-      />
+
       <Stack.Screen
         name={Screens.ExposureListDebugScreen}
         component={ExposureListDebugScreen}
@@ -155,12 +148,12 @@ const GPSExportStack = () => {
         }}
       />
       <Stack.Screen
-        name={Screens.ExportSelectHA}
-        component={ExportSelectHA}
+        name={Screens.ExportFlow}
+        component={ExportStack}
         options={{
           ...TransitionPresets.ModalSlideFromBottomIOS,
-          headerShown: false,
           gestureEnabled: false,
+          headerShown: false,
         }}
       />
     </Stack.Navigator>

--- a/app/gps/Export/ExportStart.js
+++ b/app/gps/Export/ExportStart.js
@@ -8,7 +8,7 @@ export const ExportStart = ({ navigation }) => {
   const { t } = useTranslation();
 
   const onNext = () => {
-    navigation.navigate(Screens.ExportSelectHA);
+    navigation.navigate(Screens.ExportFlow);
   };
 
   return (

--- a/app/views/Settings/index.tsx
+++ b/app/views/Settings/index.tsx
@@ -170,7 +170,7 @@ const SettingsScreen = ({ navigation }: SettingsScreenProps): JSX.Element => {
           </View>
         ) : null}
 
-        <FeatureFlag flag={FeatureFlagOption.GOOGLE_IMPORT}>
+        <FeatureFlag flag={FeatureFlagOption.DOWNLOAD_LOCALLY}>
           <View style={styles.section}>
             <SettingsListItem
               label={'Download Locally'}


### PR DESCRIPTION
#### Description:

This PR fixes two things: 

- an issue with app breaking when clicking on next after selecting HA during export flow

- download locally feature missing after enabling FF
