### PR TITLE
HA Selection Intersect Trigger Only On Change

### DIFF
--- a/app/store/middleware/onChangedSelectedHealthAuthorities.ts
+++ b/app/store/middleware/onChangedSelectedHealthAuthorities.ts
@@ -1,22 +1,37 @@
 import { Dispatch, Middleware, AnyAction, MiddlewareAPI } from 'redux';
 import IntersectService from '../../services/IntersectService';
+import toggleSelectedHealthcareAuthorityAction from '../actions/healthcareAuthorities/toggleSelectedHealthcareAuthorityAction';
+import { HealthcareAuthority } from '../../api/healthcareAuthorities/getHealthcareAuthoritiesApi';
+
+const areHaListsEqual = (
+  listA: HealthcareAuthority[],
+  listB: HealthcareAuthority[],
+) => {
+  const haIdSetA = new Set(listA.map((ha) => ha.internal_id));
+  const haIdSetB = new Set(listB.map((ha) => ha.internal_id));
+  if (haIdSetA.size != haIdSetB.size) return false;
+  return haIdSetA.forEach(haIdSetB.has);
+};
 
 const onChangedSelectedHealthAuthorities: Middleware<Dispatch> = (
   store: MiddlewareAPI,
 ) => (next: Dispatch<AnyAction>) => (action: AnyAction): unknown => {
   const {
-    healthcareAuthorities: { selectedAuthorities: stateBefore },
+    healthcareAuthorities: { selectedAuthorities: haListBefore },
   } = store.getState();
 
   const result = next(action);
 
   const {
-    healthcareAuthorities: { selectedAuthorities: stateAfter },
+    healthcareAuthorities: { selectedAuthorities: haListAfter },
   } = store.getState();
 
   try {
-    if (stateBefore !== stateAfter) {
-      IntersectService.checkIntersect(stateAfter);
+    if (
+      action.type === toggleSelectedHealthcareAuthorityAction.type &&
+      !areHaListsEqual(haListBefore, haListAfter)
+    ) {
+      IntersectService.checkIntersect(haListAfter);
     }
   } catch (e) {
     console.log('[intersect] failed ', e);


### PR DESCRIPTION
The middleware for HA Selection has been triggering excessively, due to
1. a shallow comparison check on array equality, vs. a check on the sameness of the array HAs by ids
2. the persist middlelware triggering an intersection on app start always, due to the persist rehydrate action instantiating the store

This improves app launch performance & the toggle performance around toggling HAs. May fix https://pathcheck.atlassian.net/browse/SAF-817, will check that seperately