### PR TITLE
invert button styling for custom url

### DIFF
--- a/app/views/Partners/PartnersCustomUrlScreen.tsx
+++ b/app/views/Partners/PartnersCustomUrlScreen.tsx
@@ -71,7 +71,7 @@ const PartnersScreen = ({
             },
           ]}
         />
-        <Button label={t('common.add')} onPress={searchForUrl} />
+        <Button invert label={t('common.add')} onPress={searchForUrl} />
       </View>
     </NavigationBarWrapper>
   );

--- a/app/views/Partners/PartnersEdit.tsx
+++ b/app/views/Partners/PartnersEdit.tsx
@@ -20,7 +20,7 @@ import NoAuthoritiesMessage from '../../components/NoAuthoritiesMessage';
 import FeatureFlag from '../../components/FeatureFlag';
 
 import { Icons } from '../../assets';
-import { Colors, Buttons, Spacing } from '../../styles';
+import { Colors, Spacing } from '../../styles';
 
 type PartnersEditScreenProps = {
   navigation: NavigationProp;
@@ -122,9 +122,9 @@ const PartnersScreen = ({
       <FeatureFlag flag={FeatureFlagOption.CUSTOM_URL}>
         <View style={{ padding: Spacing.large }}>
           <Button
+            invert
             label={t('authorities.custom_url')}
             onPress={() => navigation.navigate(Screens.PartnersCustomUrl)}
-            style={styles.button}
           />
         </View>
       </FeatureFlag>
@@ -138,9 +138,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: Spacing.xLarge,
-  },
-  button: {
-    ...Buttons.largeBlue,
   },
 });
 export default PartnersScreen;


### PR DESCRIPTION
Fixes button inversion for custom yaml url

Before | After
:-------------------------:|:-------------------------:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/88094456-9f1d8680-cb61-11ea-8b2a-607922742ed1.png">|  <img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/88094435-8f05a700-cb61-11ea-93fa-4abb1566bafe.png">
<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/88094462-a17fe080-cb61-11ea-8571-f3b2ef45448d.png">|<img width="561" alt="image" src="https://user-images.githubusercontent.com/25315679/88094439-92992e00-cb61-11ea-8083-2fdd79a0abf6.png">
