### PR TITLE
Display Correct Exposure Duration On Calendar Screen

### DIFF
--- a/app/views/utils/timeHelpers.ts
+++ b/app/views/utils/timeHelpers.ts
@@ -12,10 +12,11 @@ type DurationRoundedToFiveMinuteIncrement = number;
 export const durationToString = (
   duration: DurationRoundedToFiveMinuteIncrement,
 ): string => {
-  /// Native layer returns length of exposure in
-  /// 5 minute increments with a 30 minute maximum.
-  /// 1 is the smallest possible number of 5 minute increments,
-  /// so if we receive 1 from the native layer, we display "one minute"
-  const durationMinutes = Math.max(duration, 1);
+  // Duration is in milliseconds
+  // Native layer returns length of exposure in
+  // 5 minute increments with a 30 minute maximum.
+  // 1 is the smallest possible number of 5 minute increments,
+  // so if we receive 1 from the native layer, we display "one minute"
+  const durationMinutes = Math.max(duration / 1000 / 60, 1);
   return dayjs.duration({ minutes: durationMinutes }).humanize(false);
 };


### PR DESCRIPTION
#### Description:
The Possible Exposure Time displayed for exposed dates on the calendar screen is currently reporting an impossibly high exposure time. This was caused by the `durationToString` method expecting a duration in units of minutes but actually getting a duration in units of milliseconds.

#### Linked issues:
https://pathcheck.atlassian.net/browse/SAF-845

#### Screenshots:
Before:
![Screen Shot 2020-07-22 at 1 50 06 PM](https://user-images.githubusercontent.com/20758953/88226666-66051500-cc3a-11ea-8711-f238120aceb7.png)

After:
![Screen Shot 2020-07-22 at 4 42 19 PM](https://user-images.githubusercontent.com/20758953/88226683-70bfaa00-cc3a-11ea-8dd5-74e4dc330c8b.png)

#### How to test:
1. Generate an exposure notification
2. Select an exposed date on the exposure calendar screen
The reported exposure duration should be a reasonable number