### PR TITLE
Cause workflows to alway run, but pass when not needed

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   e2e-ios-build:
     runs-on: macos-latest
-    # while this job doesn't depend on the previous job explicitly
-    # this will force them not to run in parallel. If they're run in parallel,
-    # the node_modules caches will conflict
-    needs: unit-test
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - develop
-    paths:
-      - "ios/**"
 
 jobs:
   unit-test-ios:
@@ -17,10 +15,28 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Check if run is needed
+        run: |
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+          FILES=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s -X GET -G $URL |  jq -r '.[] | .filename')
+          echo "Checking Files: $FILES"
+          REGEX="\.js\|\.jsx\|\.ts\|\.tsx"
+          if echo $FILES | grep -q $REGEX; then
+            echo "Detected JavaScript changes. Running tests!"
+            echo "Changed Files:"
+            echo $FILES | grep $REGEX
+            echo "::set-env name=RUN_TESTS::1"
+          else
+            echo "No JavaScript changed detected. Skipping tests."
+            echo "::set-env name=RUN_TESTS::0"
+          fi
+
       - name: Set XCode Version
+        if: env.RUN_TESTS == 1
         run: sudo xcode-select -s /Applications/Xcode_11.5.app
 
       - name: Cache node_modules/
+        if: env.RUN_TESTS == 1
         uses: actions/cache@v1
         id: cache
         with:
@@ -30,10 +46,11 @@ jobs:
             ${{ runner.OS }}-yarn-cache-
 
       - name: Install Node Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: env.RUN_TESTS == 1 && steps.cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile
 
       - name: Cache ruby gems
+        if: env.RUN_TESTS == 1
         uses: actions/cache@v1
         with:
           path: ios/vendor/bundle
@@ -42,15 +59,20 @@ jobs:
             ${{ runner.os }}-gems-
 
       - name: Install ruby gems (including Cocoapods)
+        if: env.RUN_TESTS == 1
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
         working-directory: ./ios
 
-      - run: pod install --repo-update
+      - name: Install Pods
+        if: env.RUN_TESTS == 1
+        run: pod install --repo-update
         working-directory: ./ios
 
-      - run: |
+      - name: Run iOS Tests
+        if: env.RUN_TESTS == 1
+        run: |
           xcodebuild test -workspace COVIDSafePaths.xcworkspace \
             -scheme GPS_Development \
             -destination 'platform=iOS Simulator,name=iPhone 8' \

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -20,14 +20,14 @@ jobs:
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
           FILES=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s -X GET -G $URL |  jq -r '.[] | .filename')
           echo "Checking Files: $FILES"
-          REGEX="\.js\|\.jsx\|\.ts\|\.tsx"
+          REGEX="\ios*"
           if echo $FILES | grep -q $REGEX; then
-            echo "Detected JavaScript changes. Running tests!"
+            echo "Detected iOS changes. Running tests!"
             echo "Changed Files:"
             echo $FILES | grep $REGEX
             echo "::set-env name=RUN_TESTS::1"
           else
-            echo "No JavaScript changed detected. Skipping tests."
+            echo "No iOS changed detected. Skipping tests."
             echo "::set-env name=RUN_TESTS::0"
           fi
 

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - develop
-    paths:
-      - 'app/**'
 
 jobs:
   unit-test-js:
@@ -19,7 +17,24 @@ jobs:
 
       - run: node --version
 
+      - name: Check if run is needed
+        run: |
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+          FILES=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s -X GET -G $URL |  jq -r '.[] | .filename')
+          echo "Checking Files: $FILES"
+          REGEX="\.js\|\.jsx\|\.ts\|\.tsx"
+          if echo $FILES | grep -q $REGEX; then
+            echo "Detected iOS changes. Running tests!"
+            echo "Changed Files:"
+            echo $FILES | grep $REGEX
+            echo "::set-env name=RUN_TESTS::1"
+          else
+            echo "No iOS changed detected. Skipping tests."
+            echo "::set-env name=RUN_TESTS::0"
+          fi
+
       - name: Cache node_modules/
+        if: env.RUN_TESTS == 1
         uses: actions/cache@v1
         with:
           path: node_modules
@@ -28,7 +43,10 @@ jobs:
             ${{ runner.OS }}-yarn-cache-
 
       - run: yarn --frozen-lockfile
+        if: env.RUN_TESTS == 1
 
       - run: yarn test
+        if: env.RUN_TESTS == 1
+
         env:
           CI: true

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -24,12 +24,12 @@ jobs:
           echo "Checking Files: $FILES"
           REGEX="\.js\|\.jsx\|\.ts\|\.tsx"
           if echo $FILES | grep -q $REGEX; then
-            echo "Detected iOS changes. Running tests!"
+            echo "Detected JavaScript changes. Running tests!"
             echo "Changed Files:"
             echo $FILES | grep $REGEX
             echo "::set-env name=RUN_TESTS::1"
           else
-            echo "No iOS changed detected. Skipping tests."
+            echo "No JavaScript changed detected. Skipping tests."
             echo "::set-env name=RUN_TESTS::0"
           fi
 


### PR DESCRIPTION
Improves our workflows so we can require all tests on PRs, but they will auto succeed if no changes detected. We can adjust what "changes detected" means as we see fit.

### How this works:
```sh
URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
FILES=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s -X GET -G $URL |  jq -r '.[] | .filename')
echo "Checking Files: $FILES"
REGEX="\.js\|\.jsx\|\.ts\|\.tsx"
if echo $FILES | grep -q $REGEX; then
  echo "Detected iOS changes. Running tests!"
  echo "Changed Files:"
  echo $FILES | grep $REGEX
  echo "::set-env name=RUN_TESTS::1"
else
  echo "No iOS changed detected. Skipping tests."
  echo "::set-env name=RUN_TESTS::0"
fi
```

1. Fetch JSON of files from current PR. Do this in an authorized request, otherwise we face rate limiting by GitHub.
2. Define a regex for our files we watch for. This is like what we previously did with `--paths`, except this happens _within_ the job.
3. if those files match the changed files, set the `RUN_TESTS` command
4. make each step conditional `RUN_TESTS`

step 4 is a little tedious, but it seems that there is no way to _succeed_ a workflow early, only fail it.

### How to test this:
change files matching the regex, make a PR with this code
