### PR TITLE
100 limit on pull request

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Check if run is needed
         run: |
-          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files?per_page=100"
           FILES=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s -X GET -G $URL |  jq -r '.[] | .filename')
           echo "Checking Files: $FILES"
           REGEX="\ios*"

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check if run is needed
         run: |
-          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files?per_page=100"
           FILES=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s -X GET -G $URL |  jq -r '.[] | .filename')
           echo "Checking Files: $FILES"
           REGEX="\.js\|\.jsx\|\.ts\|\.tsx"


### PR DESCRIPTION

By default, github api returns 30 files in response. We want _all_ files in our workflow to check for needed changes. 


We could paginate, but a quick hack is to increase this to the max, which will give us a lot of runway.