### PR TITLE
Android UI regression fixes

### DIFF
--- a/app/components/NavigationBarWrapper.tsx
+++ b/app/components/NavigationBarWrapper.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { SafeAreaView, TouchableOpacity, View, StyleSheet } from 'react-native';
+import {
+  SafeAreaView,
+  TouchableOpacity,
+  View,
+  StyleSheet,
+  StatusBar,
+} from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
 import { useStatusBarEffect } from '../navigation';
@@ -69,7 +75,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.navBar,
-    paddingTop: isPlatformAndroid() ? Spacing.xSmall : 0,
   },
   headerContainer: {
     flexDirection: 'row',
@@ -78,6 +83,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.navBar,
     paddingVertical: Spacing.xxSmall,
     paddingHorizontal: Spacing.small,
+    paddingTop: isPlatformAndroid() ? StatusBar.currentHeight : undefined,
   },
   leftContent: {
     flex: 1,

--- a/app/gps/Export/ExportSelectHA.js
+++ b/app/gps/Export/ExportSelectHA.js
@@ -1,14 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  StyleSheet,
-  TouchableHighlight,
-  View,
-  FlatList,
-  SafeAreaView,
-} from 'react-native';
+import { StyleSheet, TouchableHighlight, View, FlatList } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 import { useDispatch, useSelector } from 'react-redux';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Button } from '../../components/Button';
 import { IconButton } from '../../components/IconButton';
@@ -89,7 +84,7 @@ export const ExportSelectHA = ({ navigation }) => {
                     flexDirection: 'row',
                   }}>
                   <Typography
-                    style={{ fontWeight: '500', paddingRight: 30 }}
+                    style={{ fontWeight: '500', paddingRight: 30, flex: 1 }}
                     use='body1'>
                     {HA.name}
                   </Typography>
@@ -113,20 +108,18 @@ export const ExportSelectHA = ({ navigation }) => {
           />
         </SafeAreaView>
         <View style={styles.card}>
-          <SafeAreaView style={{ marginVertical: 44 }}>
-            <View style={{ paddingHorizontal: 24 }}>
-              <Button
-                invert
-                label={t('common.next')}
-                onPress={() =>
-                  navigation.navigate(Screens.ExportCodeInput, {
-                    selectedAuthority,
-                  })
-                }
-                disabled={!selectedAuthority}
-              />
-            </View>
-          </SafeAreaView>
+          <View style={{ paddingHorizontal: 24, marginVertical: 44 }}>
+            <Button
+              invert
+              label={t('common.next')}
+              onPress={() =>
+                navigation.navigate(Screens.ExportCodeInput, {
+                  selectedAuthority,
+                })
+              }
+              disabled={!selectedAuthority}
+            />
+          </View>
         </View>
       </View>
     </View>

--- a/app/gps/Export/ExportTemplate.tsx
+++ b/app/gps/Export/ExportTemplate.tsx
@@ -5,11 +5,12 @@ import {
   View,
   TextStyle,
   TouchableOpacity,
-  SafeAreaView,
+  StatusBar,
 } from 'react-native';
 import { BackHandler } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { SvgXml } from 'react-native-svg';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Button } from '../../components/Button';
 import { IconButton } from '../../components/IconButton';
@@ -19,6 +20,7 @@ import { Icons } from '../../assets';
 import { Colors, Typography as TypographyStyles } from '../../styles';
 import { useStatusBarEffect } from '../../navigation';
 import { useFocusEffect } from '@react-navigation/native';
+import { isPlatformAndroid } from '../../Util';
 
 interface BackgroundContainerProps {
   lightTheme?: string;
@@ -94,6 +96,13 @@ export const ExportTemplate = ({
 
   return (
     <View style={{ flex: 1 }}>
+      {!ignoreModalStyling && isPlatformAndroid() && (
+        <StatusBar
+          backgroundColor={
+            lightTheme ? Colors.primaryBackground : Colors.primaryBlue
+          }
+        />
+      )}
       <BackgroundContainer lightTheme={lightTheme}>
         <SafeAreaView style={{ flex: 1, marginBottom: 24 }}>
           {onClose && (

--- a/app/navigation/index.ts
+++ b/app/navigation/index.ts
@@ -114,11 +114,17 @@ export const Stacks: { [key in Stack]: Stack } = {
 
 type BarStyle = 'dark-content' | 'light-content';
 
-export const useStatusBarEffect = (barStyle: BarStyle): void => {
+export const useStatusBarEffect = (
+  barStyle: BarStyle,
+  backgroundColor?: string,
+): void => {
   useFocusEffect(
     useCallback(() => {
       StatusBar.setBarStyle(barStyle);
-      Platform.OS === 'android' && StatusBar.setTranslucent(true);
-    }, [barStyle]),
+      Platform.OS === 'android' &&
+        StatusBar.setTranslucent(true) &&
+        backgroundColor &&
+        StatusBar.setBackgroundColor(backgroundColor);
+    }, [barStyle, backgroundColor]),
   );
 };

--- a/app/views/Partners/PartnersEdit.tsx
+++ b/app/views/Partners/PartnersEdit.tsx
@@ -94,7 +94,7 @@ const PartnersScreen = ({
                 flexDirection: 'row',
               }}>
               <Typography
-                style={{ fontWeight: '500', paddingRight: 30 }}
+                style={{ fontWeight: '500', paddingRight: 30, flex: 1 }}
                 use='body1'>
                 {HA.name}
               </Typography>

--- a/app/views/Partners/PartnersOverview.tsx
+++ b/app/views/Partners/PartnersOverview.tsx
@@ -58,7 +58,7 @@ const PartnersIllustration = (): JSX.Element => {
           position: 'absolute',
           bottom: 0,
         }}
-        resizeMode={'contain'}
+        resizeMode={'cover'}
       />
     </View>
   );

--- a/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -6,7 +6,6 @@ exports[`Import component renders correctly 1`] = `
     Object {
       "backgroundColor": "#1f2c9b",
       "flex": 1,
-      "paddingTop": 0,
     }
   }
 >
@@ -18,6 +17,7 @@ exports[`Import component renders correctly 1`] = `
         "flexDirection": "row",
         "justifyContent": "flex-start",
         "paddingHorizontal": 16,
+        "paddingTop": undefined,
         "paddingVertical": 8,
       }
     }

--- a/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.tsx.snap
@@ -15,7 +15,6 @@ exports[`LicensesScreen renders correctly 1`] = `
       Object {
         "backgroundColor": "#1f2c9b",
         "flex": 1,
-        "paddingTop": 0,
       }
     }
   >
@@ -27,6 +26,7 @@ exports[`LicensesScreen renders correctly 1`] = `
           "flexDirection": "row",
           "justifyContent": "flex-start",
           "paddingHorizontal": 16,
+          "paddingTop": undefined,
           "paddingVertical": 8,
         }
       }


### PR DESCRIPTION
A suite of android nit fixes to fix regressions. 
- Fixes  displacement by translucent status bars, using SafeAreaViews that are aware, and by using the platform status bar height where appropriate
- adds explicit flex to typography components, which on android default without the flex, causing issues on our list selectors on wrapping
- bumps the overlay image on partners screen to cover, rather than contain, so that pixel offsets are covered.
- Adds background color for the status bar in the export flow. This is a weird regression, as this isn't needed outside of this separately hoisted stack, but this is a quick fix.