### PR TITLE
handle failed intersect check

### DIFF
--- a/app/services/IntersectService.ts
+++ b/app/services/IntersectService.ts
@@ -15,17 +15,21 @@ class IntersectService {
     }
     this.isServiceRunning = true;
 
-    intersect(healthcareAuthorities).then((dayBins) => {
-      this.isServiceRunning = false;
+    intersect(healthcareAuthorities)
+      .then((dayBins) => {
+        this.isServiceRunning = false;
 
-      if (this.nextJob) {
-        const job = this.nextJob;
-        this.nextJob = null;
-        this.checkIntersect(job);
-      } else {
-        emitResultDayBins(dayBins);
-      }
-    });
+        if (this.nextJob) {
+          const job = this.nextJob;
+          this.nextJob = null;
+          this.checkIntersect(job);
+        } else {
+          emitResultDayBins(dayBins);
+        }
+      })
+      .catch(() => {
+        this.isServiceRunning = false;
+      });
 
     return 'started';
   };


### PR DESCRIPTION
Previously, a failing intersect would prevent all other intersects from occurring because the job would always remain in progress. 

This adds a catch statement to set the `isServiceRunning` to false on intersect failures