### PR TITLE
gitignore for new android release destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ ios/COVIDSafePaths-stating-bt.app.dSYM.zip
 
 # Local Android build artifacts
 android/app/src/main/assets/index.android.bundle
+android/app/release
 
 # Local Realm Artifact
 safepaths.realm


### PR DESCRIPTION
After GPS / BT split cleanup, builds are now at `android/app/release` for local APKs.