### PR TITLE
Removed react-native-device-info library and replaced with native code 

### DIFF
--- a/android/app/src/main/java/covidsafepaths/gps/bridge/Device.kt
+++ b/android/app/src/main/java/covidsafepaths/gps/bridge/Device.kt
@@ -1,0 +1,37 @@
+package covidsafepaths.gps.bridge
+
+import com.facebook.react.bridge.*
+import covidsafepaths.gps.storage.Location.Companion.SOURCE_GOOGLE
+import covidsafepaths.gps.storage.Location.Companion.SOURCE_MIGRATION
+import covidsafepaths.gps.storage.SecureStorage
+import org.pathcheck.covidsafepaths.BuildConfig;
+import kotlin.Exception 
+
+
+class Device(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String {
+        return "Device"
+    }
+
+    //exports a method getVersion to javascript
+    @ReactMethod
+    fun getVersion(cb:Callback) {
+        try{
+            return cb.invoke(null, BuildConfig.VERSION_NAME)
+        } catch(e:Exception ){
+            return cb.invoke(e,null)
+        }
+       
+    }
+    //exports a method getBuild to javascript
+    @ReactMethod
+    fun getBuildNumber(cb:Callback) {
+        try{
+            return cb.invoke(null, BuildConfig.VERSION_CODE)
+        } catch(e:Exception ){
+            return cb.invoke(e,null)
+        }
+       
+    }
+}

--- a/android/app/src/main/java/covidsafepaths/gps/bridge/RealmPackage.kt
+++ b/android/app/src/main/java/covidsafepaths/gps/bridge/RealmPackage.kt
@@ -9,7 +9,7 @@ import com.facebook.react.uimanager.ViewManager
 
 class RealmPackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
-    return mutableListOf(SecureStorageManager(reactContext))
+    return mutableListOf(SecureStorageManager(reactContext),Device(reactContext))
   }
 
   override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<ViewManager<View, ReactShadowNode<*>>> {

--- a/ios/COVIDSafePaths.xcodeproj/project.pbxproj
+++ b/ios/COVIDSafePaths.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		08445F6824284A52008754AC /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08445F6724284A52008754AC /* UIKit.framework */; };
 		12922BC2C16E4BCCB3F4EA44 /* IBMPlexSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 668BDA050EF549C6B0759425 /* IBMPlexSans-Bold.ttf */; };
 		1360D7CA70F14549967C9912 /* IBMPlexMono-ThinItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3918820E06534ED8B0C3323C /* IBMPlexMono-ThinItalic.ttf */; };
+		1CA81E4F24DBFC99003BCFD4 /* Device.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA81E4E24DBFC99003BCFD4 /* Device.m */; };
+		1CA81E5024DBFC99003BCFD4 /* Device.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA81E4E24DBFC99003BCFD4 /* Device.m */; };
 		25004E4C90704C6B807B88C7 /* IBMPlexMono-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 71F26FBF5BDA423184286546 /* IBMPlexMono-MediumItalic.ttf */; };
 		2606D1B2B11C4D419867361F /* IBMPlexSans-MediumItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A57577D96B89452694B53982 /* IBMPlexSans-MediumItalic.ttf */; };
 		271089B024698720009AC76F /* LocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271089AF24698720009AC76F /* LocationTests.swift */; };
@@ -133,6 +135,8 @@
 		1423A22FF9E04F88BEEE42D6 /* IBMPlexSans-Thin.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexSans-Thin.ttf"; path = "../shared/assets/fonts/IBMPlexSans-Thin.ttf"; sourceTree = "<group>"; };
 		145476A32A7724DCC004C292 /* Pods-GPS.staging-gps.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GPS.staging-gps.xcconfig"; path = "Target Support Files/Pods-GPS/Pods-GPS.staging-gps.xcconfig"; sourceTree = "<group>"; };
 		167DF82F84E242A39CBEB042 /* IBMPlexMono-ExtraLightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexMono-ExtraLightItalic.ttf"; path = "../shared/assets/fonts/IBMPlexMono-ExtraLightItalic.ttf"; sourceTree = "<group>"; };
+		1CA81E4E24DBFC99003BCFD4 /* Device.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Device.m; sourceTree = "<group>"; };
+		1CA81E5324DBFCAC003BCFD4 /* Device.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Device.h; sourceTree = "<group>"; };
 		20E5EE8E6065465F9558DCDB /* IBMPlexMono-SemiBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexMono-SemiBoldItalic.ttf"; path = "../app/assets/fonts/IBMPlexMono-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
 		210E5F50B07048118538B796 /* IBMPlexSans-Italic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "IBMPlexSans-Italic.ttf"; path = "../shared/assets/fonts/IBMPlexSans-Italic.ttf"; sourceTree = "<group>"; };
 		22E0DA6B2DECC1B29A4C7B64 /* Pods-GPS.release-gps.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GPS.release-gps.xcconfig"; path = "Target Support Files/Pods-GPS/Pods-GPS.release-gps.xcconfig"; sourceTree = "<group>"; };
@@ -622,6 +626,8 @@
 				D4B4A89E24C8A1A700E00A99 /* GPS-Bridging-Header.h */,
 				D4B4A89D24C8A1A700E00A99 /* SecureStorageManager.m */,
 				D4B4A89F24C8A1A700E00A99 /* SecureStorageManager.swift */,
+				1CA81E4E24DBFC99003BCFD4 /* Device.m */,
+				1CA81E5324DBFCAC003BCFD4 /* Device.h */,
 			);
 			path = Bridge;
 			sourceTree = "<group>";
@@ -919,6 +925,7 @@
 				271089B024698720009AC76F /* LocationTests.swift in Sources */,
 				68D8971C24809FB50091A254 /* Array+ExtensionTests.swift in Sources */,
 				00E356F31AD99517003FC87E /* COVIDSafePathsTests.m in Sources */,
+				1CA81E5024DBFC99003BCFD4 /* Device.m in Sources */,
 				68D8971824809F5C0091A254 /* MARULocation+ExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -937,6 +944,7 @@
 				D4B4A86124C8A16400E00A99 /* AppDelegate.m in Sources */,
 				B52D88C2248F0FD90071ED51 /* GPSSecureStorage.swift in Sources */,
 				D4B4A8A024C8A1A700E00A99 /* MAURLocation+Extension.swift in Sources */,
+				1CA81E4F24DBFC99003BCFD4 /* Device.m in Sources */,
 				276AB15C245291DE00D39B58 /* Location.swift in Sources */,
 				D4B4A86024C8A16400E00A99 /* main.m in Sources */,
 			);
@@ -1133,7 +1141,7 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-geolocation\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-safe-area-context\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-splash-screen\"",
- 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-viewpager\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-viewpager\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-webview\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/rn-fetch-blob\"",
 				);
@@ -1294,7 +1302,7 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-geolocation\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-safe-area-context\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-splash-screen\"",
- 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-viewpager\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-viewpager\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-webview\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/rn-fetch-blob\"",
 				);
@@ -1450,7 +1458,7 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-geolocation\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-safe-area-context\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-splash-screen\"",
- 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-viewpager\"",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-viewpager\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/react-native-webview\"",
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/rn-fetch-blob\"",
 				);

--- a/ios/COVIDSafePaths/Bridge/Device.h
+++ b/ios/COVIDSafePaths/Bridge/Device.h
@@ -1,0 +1,5 @@
+
+#import <React/RCTBridgeModule.h>
+
+@interface Device : NSObject <RCTBridgeModule>
+@end

--- a/ios/COVIDSafePaths/Bridge/Device.m
+++ b/ios/COVIDSafePaths/Bridge/Device.m
@@ -1,0 +1,31 @@
+#import "Device.h"
+#import <UIKit/UIKit.h>
+
+@implementation Device
+
+//export the name of the native module as 'Device' since no explicit name is mentioned
+RCT_EXPORT_MODULE();
+
+//exports a method getVersion to javascript
+RCT_EXPORT_METHOD(getVersion:(RCTResponseSenderBlock)callback){
+ @try{
+    callback(@[[NSNull null], [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]]);
+ }
+ @catch(NSException *exception){
+   callback(@[exception.reason, [NSNull null]]);
+ }
+}
+
+
+//exports a method getBuild to javascript
+RCT_EXPORT_METHOD(getBuildNumber:(RCTResponseSenderBlock)callback){
+ @try{
+    callback(@[[NSNull null], [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]]);
+ }
+ @catch(NSException *exception){
+   callback(@[exception.reason, [NSNull null]]);
+ }
+}
+
+
+@end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -260,8 +260,6 @@ PODS:
     - React
   - RNDateTimePicker (2.3.2):
     - React
-  - RNDeviceInfo (5.6.2):
-    - React
   - RNFS (2.16.6):
     - React
   - RNGestureHandler (1.6.1):
@@ -335,7 +333,6 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
-  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
@@ -440,8 +437,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNDateTimePicker:
     :path: "../node_modules/@react-native-community/datetimepicker"
-  RNDeviceInfo:
-    :path: "../node_modules/react-native-device-info"
   RNFS:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
@@ -508,7 +503,6 @@ SPEC CHECKSUMS:
   RNCMaskedView: dd13f9f7b146a9ad82f9b7eb6c9b5548fcf6e990
   RNCPushNotificationIOS: 4d9ffd08f00ef6c1029ebbf4d72fc711eca3ff01
   RNDateTimePicker: 4bd49e09f91ca73d69119a9e1173b0d43b82f5e5
-  RNDeviceInfo: ed8557a8bd6443cbc0ab5d375e6808a38a279744
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-native-background-fetch": "^3.0.4",
     "react-native-background-timer": "^2.2.0",
     "react-native-config": "^1.2.1",
-    "react-native-device-info": "^5.6.2",
     "react-native-document-picker": "github:rparet/react-native-document-picker",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7044,11 +7044,6 @@ react-native-config@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.2.1.tgz#f80454fc58ea89b549819ccb4bdab26518a9f0db"
   integrity sha512-u7MDku3fUUKAtxfUFLLwnj4htBYO840EBGdlDB9ry/eX1TY+asHwULaUkAj9x+pJo4vSpIp8GtYxxi8dLzDtJw==
 
-react-native-device-info@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-5.6.2.tgz#194c055355f1dd3121ab682b00598086cf4beb32"
-  integrity sha512-c+bVrvbQIlUlUHpIiggjhCUnqTga7sK0+G1RhRN25ct3kQvDkj3TKv0GGsqTJxIqNBfzg2Hh5ulMkrU0ddeu/Q==
-
 "react-native-document-picker@github:rparet/react-native-document-picker":
   version "3.2.0"
   resolved "https://codeload.github.com/rparet/react-native-document-picker/tar.gz/e71a56183c49c3d967b00abaa9ee7327ef4c376b"


### PR DESCRIPTION


<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

1: Removed react-native-device-info 
2: Added native code to get build number and version number
both in IOS and Android
Added Device.m and Device.h files for IOS and Device.kt for android to get build number and version number with the help of @shilpashendre 

#### Linked issues:

 https://pathcheck.atlassian.net/browse/SAF-858

#### Screenshots:

## IOS:
![Simulator Screen Shot - iPhone Xs Max - 2020-08-06 at 15 38 50](https://user-images.githubusercontent.com/25247251/89520160-0fcbd080-d7fb-11ea-802e-e637635a54ab.png)

## Android:
![1596708556673](https://user-images.githubusercontent.com/25247251/89520207-22dea080-d7fb-11ea-9c31-455ccd090bd6.JPEG)



#### How to test:

1: Install the app 
2: Go to More (last tab)
3: Go to About page
4: Look for Version 
